### PR TITLE
Extract Queue, Take, Offer interfaces, add Queue.take, Stream.fromQueue

### DIFF
--- a/src/Stream.test.ts
+++ b/src/Stream.test.ts
@@ -56,12 +56,13 @@ describe('Stream', () => {
         // Give emits time to start their own tasks
         yield* Async.sleep(1)
       })
-      const producer = Stream.withEmitter<number>(emitter => {
-        eventEmitter.on('event', emitter.event)
+      const producer = Stream.withEmitter<number>(q => {
+        const emit = (e: number) => q.offer(e)
+        eventEmitter.on('event', emit)
         return {
           [Symbol.dispose]() {
-            eventEmitter.off('event', emitter.event)
-            emitter.end()
+            eventEmitter.off('event', emit)
+            q[Symbol.dispose]()
           }
         }
       })

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -41,7 +41,7 @@ export const switchMap = <E, X, E2>(fx: Fx.Fx<E, X>, f: (a: Event<E>) => Fx.Fx<E
     })
   )
 
-export const fromQueue = <A>(queue: Queue.Dequeue<A>): Fx.Fx<Async.Async | Stream<A>, void> => Fx.fx(function* () {
+export const fromDequeue = <A>(queue: Queue.Dequeue<A>): Fx.Fx<Async.Async | Stream<A>, void> => Fx.fx(function* () {
   const take = Queue.dequeue(queue)
 
   while (!queue.disposed) {
@@ -50,14 +50,14 @@ export const fromQueue = <A>(queue: Queue.Dequeue<A>): Fx.Fx<Async.Async | Strea
   }
 })
 
-export const withEmitter = <A>(
+export const withEnqueue = <A>(
   f: (o: Queue.Enqueue<A>) => Disposable,
   q: Queue.Queue<A> = new Queue.UnboundedQueue()
-): Fx.Fx<Async.Async | Stream<A>, void> =>
-  Fx.bracket(
-    Fx.sync(() => f(q)),
-    disposable => Fx.ok(dispose(disposable)),
-    _ => fromQueue(q))
+): Fx.Fx<Async.Async | Stream<A>, void> => Fx.bracket(
+  Fx.sync(() => f(q)),
+  disposable => Fx.ok(dispose(disposable)),
+  _ => fromDequeue(q)
+)
 
 export interface IterableWithReturn<Y, R> {
   [Symbol.iterator](): Iterator<Y, R>

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -5,6 +5,7 @@ import * as Fork from './Fork'
 import * as Fx from './Fx'
 import * as Task from './Task'
 import * as Queue from './internal/Queue'
+import { dispose } from './internal/disposable'
 import { IfAny } from './internal/type'
 
 export class Stream<A> extends Effect('fx/Stream')<A, void> { }
@@ -40,25 +41,23 @@ export const switchMap = <E, X, E2>(fx: Fx.Fx<E, X>, f: (a: Event<E>) => Fx.Fx<E
     })
   )
 
-export const fromQueue = <A>(queue: Queue.Take<A>): Fx.Fx<Async.Async | Stream<A>, void> => Fx.fx(function* () {
-  const take = Queue.take(queue)
+export const fromQueue = <A>(queue: Queue.Dequeue<A>): Fx.Fx<Async.Async | Stream<A>, void> => Fx.fx(function* () {
+  const take = Queue.dequeue(queue)
 
   while (!queue.disposed) {
     const next = yield* take
-    if (next.tag === 'fx/Queue/Taken') yield* event(next.value)
+    if (next.tag === 'fx/Queue/Dequeued') yield* event(next.value)
   }
 })
 
 export const withEmitter = <A>(
-  f: (o: Queue.Offer<A>) => Disposable,
-  q: Queue.Queue<A> = new Queue.UnboundedQueue<A>()
+  f: (o: Queue.Enqueue<A>) => Disposable,
+  q: Queue.Queue<A> = new Queue.UnboundedQueue()
 ): Fx.Fx<Async.Async | Stream<A>, void> =>
-  Fx.fx(function* () {
-    const disposable = f(q)
-    yield* fromQueue(q)
-
-    dispose(disposable)
-  })
+  Fx.bracket(
+    Fx.sync(() => f(q)),
+    disposable => Fx.ok(dispose(disposable)),
+    _ => fromQueue(q))
 
 export interface IterableWithReturn<Y, R> {
   [Symbol.iterator](): Iterator<Y, R>
@@ -148,5 +147,3 @@ class CurrentTask<E> {
     }
   }
 }
-
-const dispose = (d: Disposable) => d[Symbol.dispose]()

--- a/src/internal/Queue.ts
+++ b/src/internal/Queue.ts
@@ -6,24 +6,24 @@ export type Sink<A> = (a: A) => void
 
 export type Dequeued<A> = Variant<'fx/Queue/Dequeued', A>
 
-export type QueueDisposed = Variant<'fx/Queue/Disposed', void>
+export type Disposed = Variant<'fx/Queue/Disposed', void>
 
-const queueDisposed: QueueDisposed = { tag: 'fx/Queue/Disposed', value: undefined }
+const queueDisposed: Disposed = { tag: 'fx/Queue/Disposed', value: undefined }
 
 export interface Queue<A> extends Disposable {
   enqueue(a: A): boolean
-  dequeue(): Promise<Dequeued<A> | QueueDisposed>
+  dequeue(): Promise<Dequeued<A> | Disposed>
   readonly disposed: boolean
 }
 
 export type Enqueue<A> = Pick<Queue<A>, 'enqueue' | 'disposed' | keyof Disposable>
 export type Dequeue<A> = Pick<Queue<A>, 'dequeue' | 'disposed' | keyof Disposable>
 
-export const dequeue = <A>(q: Dequeue<A>): Fx<Async.Async, Dequeued<A> | QueueDisposed> => Async.run(() => q.dequeue())
+export const dequeue = <A>(q: Dequeue<A>): Fx<Async.Async, Dequeued<A> | Disposed> => Async.run(() => q.dequeue())
 
 export class UnboundedQueue<A> implements Queue<A> {
   private readonly items: A[] = []
-  private readonly takers: Sink<Dequeued<A> | QueueDisposed>[] = []
+  private readonly takers: Sink<Dequeued<A> | Disposed>[] = []
   private _disposed = false
 
   enqueue(a: A) {
@@ -34,11 +34,11 @@ export class UnboundedQueue<A> implements Queue<A> {
     return true
   }
 
-  async dequeue(): Promise<Dequeued<A> | QueueDisposed> {
+  async dequeue(): Promise<Dequeued<A> | Disposed> {
     if (this._disposed) return queueDisposed
 
     if (this.items.length > 0) return { tag: 'fx/Queue/Dequeued', value: this.items.shift()! } as const
-    else return new Promise<Dequeued<A> | QueueDisposed>(resolve => this.takers.push(resolve))
+    else return new Promise<Dequeued<A> | Disposed>(resolve => this.takers.push(resolve))
   }
 
   get disposed() {

--- a/src/internal/Queue.ts
+++ b/src/internal/Queue.ts
@@ -1,31 +1,44 @@
+import * as Async from '../Async'
+import { Fx } from '../Fx'
 import { Variant } from './Variant'
 
 export type Sink<A> = (a: A) => void
 
-export type Take<A> = Variant<'fx/Queue/Take', A>
+export type Taken<A> = Variant<'fx/Queue/Taken', A>
 
 export type QueueDisposed = Variant<'fx/Queue/Disposed', void>
 
 const queueDisposed: QueueDisposed = { tag: 'fx/Queue/Disposed', value: undefined }
 
+export interface Queue<A> extends Disposable {
+  offer(a: A): boolean
+  take(): Promise<Taken<A> | QueueDisposed>
+  readonly disposed: boolean
+}
+
+export type Offer<A> = Omit<Queue<A>, 'take'>
+export type Take<A> = Omit<Queue<A>, 'offer'>
+
+export const take = <A>(q: Take<A>): Fx<Async.Async, Taken<A> | QueueDisposed> => Async.run(() => q.take())
+
 export class UnboundedQueue<A> {
   private readonly items: A[] = []
-  private readonly takers: Sink<Take<A> | QueueDisposed>[] = []
+  private readonly takers: Sink<Taken<A> | QueueDisposed>[] = []
   private _disposed = false
 
   offer(a: A) {
     if (this._disposed) return false
 
-    if (this.takers.length > 0) this.takers.shift()!({ tag: 'fx/Queue/Take', value: a })
+    if (this.takers.length > 0) this.takers.shift()!({ tag: 'fx/Queue/Taken', value: a })
     else this.items.push(a)
     return true
   }
 
-  async take(): Promise<Take<A> | QueueDisposed> {
+  async take(): Promise<Taken<A> | QueueDisposed> {
     if (this._disposed) return queueDisposed
 
-    if (this.items.length > 0) return { tag: 'fx/Queue/Take', value: this.items.shift()! } as const
-    else return new Promise<Take<A> | QueueDisposed>(resolve => this.takers.push(resolve))
+    if (this.items.length > 0) return { tag: 'fx/Queue/Taken', value: this.items.shift()! } as const
+    else return new Promise<Taken<A> | QueueDisposed>(resolve => this.takers.push(resolve))
   }
 
   get disposed() {

--- a/src/internal/disposable.ts
+++ b/src/internal/disposable.ts
@@ -1,3 +1,5 @@
+export const dispose = (d: Disposable) => d[Symbol.dispose]()
+
 export class DisposableSet {
   private _disposed = false;
   private readonly disposables = [] as Disposable[]
@@ -9,7 +11,7 @@ export class DisposableSet {
 
   remove(disposable: Disposable) {
     const i = this.disposables.indexOf(disposable)
-    if(i >= 0) this.disposables.splice(i, 1)
+    if (i >= 0) this.disposables.splice(i, 1)
   }
 
   get disposed() { return this._disposed }


### PR DESCRIPTION
Potential refactoring to add a Queue interface, and also "split" it into 2 other interfaces for produces and consumers.  This could pave the way for other Queue implementations, like bounded and back-pressured.