### PR TITLE
Add Handle type

### DIFF
--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -51,17 +51,21 @@ export const bracket = <const IE, const FE, const E, const R, const A>(init: Fx<
   }
 })
 
-export const handle = <T extends EffectType, HandlerEffects>(e: T, f: (e: Arg<T>) => Fx<HandlerEffects, Answer<T>>) =>
-  <const E, const A>(fx: Fx<E, A>): Handler<Exclude<E, InstanceType<T>> | HandlerEffects, A> =>
-    (isHandler(fx)
-      ? new Handler(fx, new Map(fx.handlers).set(e._fxEffectId, f), fx.controls)
-      : new Handler(fx, new Map().set(e._fxEffectId, f), empty)) as Handler<Exclude<E, InstanceType<T>> | HandlerEffects, A>
+// type Exclude<T, U> = T extends U ? never : T;
 
-export const handleIso = <T extends EffectType>(e: T, f: (e: Arg<T>) => Fx<InstanceType<T>, Answer<T>>) =>
-  <const E, const A>(fx: Fx<E, A>): Handler<E, A> =>
+export type Handle<E, A, B = never> = E extends A ? B : E
+
+export const handle = <T extends EffectType, HandlerEffects>(e: T, f: (e: Arg<T>) => Fx<HandlerEffects, Answer<T>>) =>
+  <const E, const A>(fx: Fx<E, A>): Handler<Handle<E, InstanceType<T>, HandlerEffects>, A> =>
     (isHandler(fx)
       ? new Handler(fx, new Map(fx.handlers).set(e._fxEffectId, f), fx.controls)
-      : new Handler(fx, new Map().set(e._fxEffectId, f), empty)) as Handler<E, A>
+      : new Handler(fx, new Map().set(e._fxEffectId, f), empty)) as Handler<Handle<E, InstanceType<T>, HandlerEffects>, A>
+
+// export const handleIso = <T extends EffectType>(e: T, f: (e: Arg<T>) => Fx<InstanceType<T>, Answer<T>>) =>
+//   <const E, const A>(fx: Fx<E, A>): Handler<E, A> =>
+//     (isHandler(fx)
+//       ? new Handler(fx, new Map(fx.handlers).set(e._fxEffectId, f), fx.controls)
+//       : new Handler(fx, new Map().set(e._fxEffectId, f), empty)) as Handler<E, A>
 
 export const control = <T extends EffectType, HandlerEffects, R = never>(e: T, f: <A>(resume: (a: Answer<T>) => A, e: Arg<T>) => Fx<HandlerEffects, R>) =>
   <const E, const A>(fx: Fx<E, A>): Handler<Exclude<E, InstanceType<T>> | HandlerEffects, A> =>

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -51,8 +51,6 @@ export const bracket = <const IE, const FE, const E, const R, const A>(init: Fx<
   }
 })
 
-// type Exclude<T, U> = T extends U ? never : T;
-
 export type Handle<E, A, B = never> = E extends A ? B : E
 
 export const handle = <T extends EffectType, HandlerEffects>(e: T, f: (e: Arg<T>) => Fx<HandlerEffects, Answer<T>>) =>
@@ -60,12 +58,6 @@ export const handle = <T extends EffectType, HandlerEffects>(e: T, f: (e: Arg<T>
     (isHandler(fx)
       ? new Handler(fx, new Map(fx.handlers).set(e._fxEffectId, f), fx.controls)
       : new Handler(fx, new Map().set(e._fxEffectId, f), empty)) as Handler<Handle<E, InstanceType<T>, HandlerEffects>, A>
-
-// export const handleIso = <T extends EffectType>(e: T, f: (e: Arg<T>) => Fx<InstanceType<T>, Answer<T>>) =>
-//   <const E, const A>(fx: Fx<E, A>): Handler<E, A> =>
-//     (isHandler(fx)
-//       ? new Handler(fx, new Map(fx.handlers).set(e._fxEffectId, f), fx.controls)
-//       : new Handler(fx, new Map().set(e._fxEffectId, f), empty)) as Handler<E, A>
 
 export const control = <T extends EffectType, HandlerEffects, R = never>(e: T, f: <A>(resume: (a: Answer<T>) => A, e: Arg<T>) => Fx<HandlerEffects, R>) =>
   <const E, const A>(fx: Fx<E, A>): Handler<Exclude<E, InstanceType<T>> | HandlerEffects, A> =>

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -1,6 +1,5 @@
 import { Effect } from './Effect'
-import { Fx, fx, handle, handleIso, map, ok } from './Fx'
-
+import { Fx, fx, handle, map, ok } from './Fx'
 
 export class Log extends Effect('fx/Log')<LogMessage, void> { }
 
@@ -40,11 +39,11 @@ export const collect = <const E, const A>(f: Fx<E, A>) => fx(function* () {
 })
 
 export const minLevel = (min: Level) =>
-  handleIso(Log, message =>
+  handle(Log, message =>
     message.level >= min ? log(message) : ok(undefined))
 
 export const context = (context: Record<string, unknown>) =>
-  handleIso(Log, message =>
+  handle(Log, message =>
     log({ ...message, context: { ...message.context, ...context } }))
 
 export const debug = (msg: string, data?: Record<string, unknown>) => log({ level: Level.debug, msg, data })

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -43,7 +43,7 @@ export const filter: {
 
 export const switchMap = <E, X, E2>(fx: Fx.Fx<E, X>, f: (a: Event<E>) => Fx.Fx<E2, unknown>): Fx.Fx<ExcludeStream<E, Fork.Fork | Async.Async | E2>, X> =>
   Fx.bracket(
-    Fx.sync(() => new CurrentTask<ExcludeStream<E> | E2>()),
+    Fx.sync(() => new CurrentTask<E2>()),
     task => Fx.sync(() => dispose(task)),
     task => Fx.fx(function* () {
       const x = yield* forEach(fx, a => task.run(f(a)))

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -13,7 +13,7 @@ export class Stream<A> extends Effect.Effect('fx/Stream')<A, void> { }
 
 export type Event<T> = T extends Stream<infer A> ? A : never
 
-export type ExcludeStream<E> = Exclude<E, Stream<any>>
+export type ExcludeStream<E, E2 = never> = Fx.Handle<E, Stream<any>, E2>
 
 /**
  * Emit a value
@@ -23,25 +23,25 @@ export const emit = <const A>(a: A) => new Stream(a)
 /**
  * Apply an effectul function to each value in a stream
  */
-export const forEach = <E, R, E2>(fx: Fx.Fx<E, R>, f: (a: Event<E>) => Fx.Fx<E2, void>): Fx.Fx<ExcludeStream<E> | E2, R> =>
+export const forEach = <E, R, E2>(fx: Fx.Fx<E, R>, f: (a: Event<E>) => Fx.Fx<E2, void>): Fx.Fx<ExcludeStream<E, E2>, R> =>
   fx.pipe(Fx.handle(Stream, a => f(a as Event<E>)))
 
 /**
  * Transform each value in a stream
  */
-export const map = <E, A, B>(fx: Fx.Fx<E, A>, f: (a: Event<E>) => B): Fx.Fx<ExcludeStream<E> | Stream<B>, A> =>
+export const map = <E, A, B>(fx: Fx.Fx<E, A>, f: (a: Event<E>) => B): Fx.Fx<ExcludeStream<E, Stream<B>>, A> =>
   forEach(fx, a => emit(f(a)))
 
 /**
  * Drop values from the stream that don't satisfy the predicate
  */
 export const filter: {
-  <E, A, B extends Event<E>>(fx: Fx.Fx<E, A>, refinement: (a: Event<E>) => a is B): Fx.Fx<ExcludeStream<E> | Stream<B>, A>
-  <E, A>(fx: Fx.Fx<E, A>, predicate: (a: Event<E>) => boolean): Fx.Fx<ExcludeStream<E> | Stream<Event<E>>, A>
-} = <E, A>(fx: Fx.Fx<E, A>, predicate: (a: Event<E>) => boolean): Fx.Fx<ExcludeStream<E> | Stream<Event<E>>, A> =>
+  <E, A, B extends Event<E>>(fx: Fx.Fx<E, A>, refinement: (a: Event<E>) => a is B): Fx.Fx<ExcludeStream<E, Stream<B>>, A>
+  <E, A>(fx: Fx.Fx<E, A>, predicate: (a: Event<E>) => boolean): Fx.Fx<E, A>
+} = <E, A>(fx: Fx.Fx<E, A>, predicate: (a: Event<E>) => boolean): Fx.Fx<ExcludeStream<E, Stream<Event<E>>>, A> =>
     forEach(fx, a => predicate(a) ? emit(a) : Fx.unit)
 
-export const switchMap = <E, X, E2>(fx: Fx.Fx<E, X>, f: (a: Event<E>) => Fx.Fx<E2, unknown>): Fx.Fx<Fork.Fork | Async.Async | ExcludeStream<E> | E2, X> =>
+export const switchMap = <E, X, E2>(fx: Fx.Fx<E, X>, f: (a: Event<E>) => Fx.Fx<E2, unknown>): Fx.Fx<ExcludeStream<E, Fork.Fork | Async.Async | E2>, X> =>
   Fx.bracket(
     Fx.sync(() => new CurrentTask<ExcludeStream<E> | E2>()),
     task => Fx.sync(() => dispose(task)),
@@ -52,7 +52,7 @@ export const switchMap = <E, X, E2>(fx: Fx.Fx<E, X>, f: (a: Event<E>) => Fx.Fx<E
 
       return x
     })
-  )
+  ) as Fx.Fx<ExcludeStream<E, Fork.Fork | Async.Async | E2>, X>
 
 /**
  * Create a stream that emits all values from a {@link Queue.Dequeue}


### PR DESCRIPTION
Previously, `handle` used `Exclude` with a new union, e.g. `Fx<Exclude<E, A> | B, ...>` to say that the handler removes effects A and introduces effects B.  That's not quite right because `B` could only be introduced if `E` contains `A`.  If `E` does not contain `A`, then the handler will never be invoked, and thus `B` would not be introduced.

Most of the time, that was fine, but it created some weird situations.  For example, given a handler only re-yielded the same effect it handles, applying that handler to an Fx that never produces the effect in the first place _introduces_ the effect into the type, even though it would never be produced.  I had previously added the `handleIso` handler to deal with that, but you had to know when to use it.

This PR adds a `Handle` type function that _replaces_ effects instead of blindly removing and then introducing.  That should make `handle` work in cases where `handleIso` was needed before.
