### PR TITLE
Switch from getters to methods

### DIFF
--- a/src/Time.ts
+++ b/src/Time.ts
@@ -35,8 +35,8 @@ export const sleep = (millis: number) => new Sleep(millis)
  * Handle Now, Monotonic, and Schedule using the provided Clock
  */
 export const withClock = (c: Clock) => <E, A>(f: Fx<E, A>): Fx<Handle<Handle<E, Sleep, Async.Async>, Now | Monotonic>, A> => f.pipe(
-  handle(Now, () => ok(c.now)),
-  handle(Monotonic, () => ok(c.monotonic)),
+  handle(Now, () => ok(c.now())),
+  handle(Monotonic, () => ok(c.monotonic())),
   handle(Sleep, ms => Async.run(signal => new Promise(resolve => {
     const d = c.schedule(ms, () => {
       signal.removeEventListener('abort', disposeOnAbort)

--- a/src/internal/time.test.ts
+++ b/src/internal/time.test.ts
@@ -80,8 +80,8 @@ describe('time', () => {
       it('given negative duration, does not advance', async () => {
         const s = new VirtualClock(1n)
         await s.step(-1000)
-        assert.equal(s.now, 1n)
-        assert.equal(s.monotonic, 0)
+        assert.equal(s.now(), 1n)
+        assert.equal(s.monotonic(), 0)
       })
     })
 

--- a/src/internal/time.ts
+++ b/src/internal/time.ts
@@ -5,8 +5,8 @@ export interface ScheduledTask {
 }
 
 export interface Clock {
-  readonly now: bigint
-  readonly monotonic: number
+  now(): bigint
+  monotonic(): number
   schedule(ms: number, task: () => void): Disposable
 }
 
@@ -14,11 +14,11 @@ export interface Clock {
  * Clock that uses Date.now, performance.now, and setTimeout.
  */
 export class RealClock implements Clock {
-  get now(): bigint {
+  now(): bigint {
     return BigInt(Date.now())
   }
 
-  get monotonic(): number {
+  monotonic(): number {
     return performance.now()
   }
 
@@ -56,15 +56,15 @@ export class VirtualClock {
 
   constructor(public readonly nowOrigin = 0n) { }
 
-  get monotonic(): number {
+  monotonic(): number {
     return this._monotonic
   }
 
-  get now(): bigint {
+  now(): bigint {
     return this.nowOrigin + BigInt(Math.floor(this._monotonic))
   }
 
-  get target(): number {
+  target(): number {
     return this._target
   }
 
@@ -89,7 +89,7 @@ export class VirtualClock {
   }
 
   schedule(ms: number, task: () => void): Disposable {
-    const t = { at: this.monotonic + Math.max(0, ms), task }
+    const t = { at: this.monotonic() + Math.max(0, ms), task }
     this._tasks.push(t)
     return new SpliceDisposable(this._tasks, t)
   }


### PR DESCRIPTION
Just to see and discuss what we want our direction to be.  These are practically implementation details, so it doesn't matter too much yet.

Some thoughts on getters:

1. 👍 They seem to perform at least as well as equivalent methods in most VMs, sometimes better for simple getters/methods that directly return a property of `this`.
2. 👍 They reduce parenthesis and provide a visually clean interface to readonly time-varying properties
3. 👎 They can't be distinguished easily from other _immutable_ readonly properties (especially in a FP setting), so may lead to mistakes such as caching a value that should have been read as a property again.