### PR TITLE
Play around with naming, add trySync and tryPromise

### DIFF
--- a/examples/concurrency/fork-bounded.ts
+++ b/examples/concurrency/fork-bounded.ts
@@ -1,4 +1,4 @@
-import { Fork, Task, Time, fx, runAsync } from '../../src'
+import { Fork, Task, Time, fx, runToTask } from '../../src'
 
 // Number of tasks to fork
 const tasks = 4
@@ -25,5 +25,5 @@ const main = fx(function* () {
 main.pipe(
   Time.defaultTime,
   Fork.bounded(concurrency),
-  runAsync
+  runToTask
 ).promise.catch(console.error)

--- a/examples/concurrency/map-reduce.ts
+++ b/examples/concurrency/map-reduce.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from 'node:timers/promises'
-import { Async, Fork, Fx, Task, fx, ok, runAsync } from '../../src'
+import { Async, Fork, Fx, Task, fx, ok, runToTask } from '../../src'
 
 // Concurrent map-reduce
 // Splits the input in half and runs mapReduce on each half concurrently
@@ -20,7 +20,7 @@ const mapReduce = <A, B, EM, ER>(inputs: readonly A[], map: (a: A) => Fx<EM, B>,
 
 // Simulate a long running computation or network request
 // for the mapping operation
-const delay = <const A>(ms: number, a: A) => Async.run(
+const delay = <const A>(ms: number, a: A) => Async.promise(
   signal => setTimeout(ms, a, { signal })
 )
 
@@ -31,7 +31,7 @@ const inputs = Array.from({ length: 1000 }, (_, i) => i)
 // This should take a little over 1 second, not inputs.length seconds
 const start = performance.now()
 mapReduce(inputs, i => delay(1000, i + 1), (a, b) => ok(a + b), 0).pipe(
-  Fork.unbounded, runAsync
+  Fork.unbounded, runToTask
 ).promise.then(result =>
   console.log(`result: ${result}, elapsed: ${performance.now() - start}ms`)
 )

--- a/examples/echo.ts
+++ b/examples/echo.ts
@@ -1,7 +1,7 @@
 
 import { createInterface } from 'node:readline/promises'
 
-import { Async, Effect, Fx, bracket, fx, handle, ok, runAsync, sync } from '../src'
+import { Async, Effect, Fx, bracket, fx, handle, ok, runToTask, sync } from '../src'
 
 class Print extends Effect('Print')<string, void> { }
 
@@ -25,11 +25,11 @@ const handleRead = <E, A>(f: Fx<E, A>) => bracket(
   sync(() => createInterface({ input: process.stdin, output: process.stdout })),
   readline => ok(readline.close()),
   readline => f.pipe(
-    handle(Read, prompt => Async.run(signal => readline.question(prompt, { signal })))
+    handle(Read, prompt => Async.promise(signal => readline.question(prompt, { signal })))
   ))
 
 // Run with "real" Read and Print effects
-main.pipe(handleRead, handlePrint, runAsync)
+main.pipe(handleRead, handlePrint, runToTask)
   .promise.then(console.log)
 
 // const handlePrintPure = <E, A>(f: Fx<E, A>) => {

--- a/examples/http-counter/counter-keyv.ts
+++ b/examples/http-counter/counter-keyv.ts
@@ -7,18 +7,18 @@ import { Next } from './counter'
 
 export const keyvCounter = <E, A>(f: Fx<E, A>) => bracket(
   sync(() => new Keyv<number>('sqlite://http-counter.sqlite')),
-  db => Async.run(() => db.disconnect()),
+  db => Async.promise(() => db.disconnect()),
   db => f.pipe(
     handle(Next, key => fx(function* () {
       const value = (yield* get(db, key)) + 1
       yield* set(db, key, value)
       return value
     })
-  ))
+    ))
 )
 
 const get = (db: Keyv<number>, key: string) =>
-  Async.run(async _ => await db.get(key) ?? 0)
+  Async.promise(async _ => await db.get(key) ?? 0)
 
 const set = (db: Keyv<number>, key: string, value: number) =>
-  Async.run(_ => db.set(key, value))
+  Async.promise(_ => db.set(key, value))

--- a/examples/http-counter/index.ts
+++ b/examples/http-counter/index.ts
@@ -1,4 +1,4 @@
-import { Env, Fork, Log, fx, runAsync } from '../../src'
+import { Env, Fork, Log, fx, runToTask } from '../../src'
 
 import { Request, runServer } from './HttpServer'
 import { next } from './counter'
@@ -32,7 +32,7 @@ runServer(myHandler).pipe(
   mapCounter,
   // keyvCounter,
   Fork.unbounded,
-  runAsync
+  runToTask
 )
 
 //#endregion

--- a/examples/state.ts
+++ b/examples/state.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from 'timers/promises'
 import { inspect } from 'util'
 
-import { Async, Effect, Fork, Fx, Task, fx, handle, map, ok, runAsync } from '../src'
+import { Async, Effect, Fork, Fx, Task, fx, handle, map, ok, runToTask } from '../src'
 
 // The usual state monad, as an effect
 class Get<A> extends Effect('State/Set')<void, A> { }
@@ -29,7 +29,7 @@ type State<E> = U2I<StateOf<E>>
 type StateOf<E> = E extends Get<infer S> | Set<infer S> ? S : never
 type U2I<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
 
-const delay = (ms: number) => Async.run(
+const delay = (ms: number) => Async.promise(
   signal => setTimeout(ms, undefined, { signal })
 )
 
@@ -65,4 +65,4 @@ const main = fx(function* () {
   }
 })
 
-const r = main.pipe(Fork.unbounded, runAsync).promise.then(x => console.log(inspect(x, false, Infinity)))
+const r = main.pipe(Fork.unbounded, runToTask).promise.then(x => console.log(inspect(x, false, Infinity)))

--- a/examples/stream/stream-split.ts
+++ b/examples/stream/stream-split.ts
@@ -1,4 +1,4 @@
-import { Sink, Stream, flatMap, fx, ok, runSync } from '../../src'
+import { Sink, Stream, flatMap, fx, ok, runToValue } from '../../src'
 
 // From Effect-TS discord
 // https://discord.com/channels/795981131316985866/1125094089281511474/1245070996621365318
@@ -54,5 +54,5 @@ Stream.fromIterable(numbers).pipe(
   _ => Stream.to(_, groupDivBy7),
   flatMap(Stream.emit), // emit trailing numbers
   _ => Stream.forEach(_, numbers => ok(console.log(numbers))),
-  runSync
+  runToValue
 )

--- a/examples/wttr-client/index.ts
+++ b/examples/wttr-client/index.ts
@@ -1,4 +1,4 @@
-import { Env, Log, fx, runAsync } from '../../src'
+import { Env, Log, fx, runToTask } from '../../src'
 import * as wttr from './wttr'
 import { wttrFetch } from './wttr-fetch'
 
@@ -14,5 +14,5 @@ main.pipe(
   wttrFetch,
   Log.console,
   Env.provide({ location: process.env.location }),
-  runAsync
+  runToTask
 )

--- a/examples/wttr-client/wttr-fetch.ts
+++ b/examples/wttr-client/wttr-fetch.ts
@@ -2,7 +2,7 @@ import { Async, handle } from '../../src'
 import * as wttr from './wttr'
 
 export const wttrFetch = handle(wttr.GetWeather, ({ location }) =>
-  Async.run(signal =>
+  Async.promise(signal =>
     fetch(`https://wttr.in/${encodeURIComponent(location ?? '')}?format=j1`, { signal })
       .then(res => res.json())
   ))

--- a/src/Async.ts
+++ b/src/Async.ts
@@ -1,7 +1,20 @@
 import { Effect } from './Effect'
+import { Fail, fail } from './Fail'
+import { Fx, flatMap, ok } from './Fx'
 
 type Run<A> = (abort: AbortSignal) => Promise<A>
 
 export class Async extends Effect('fx/Async')<Run<any>> { }
 
-export const run = <const A>(run: Run<A>) => new Async(run).returning<A>()
+export const promise = <const A>(run: Run<A>) => new Async(run).returning<A>()
+
+export const tryPromise: {
+  <const A>(tryPromise: Run<A>): Fx<Async | Fail<unknown>, A>
+  <const A, const E>(tryPromise: Run<A>, catchError: (e: unknown) => E): Fx<Async | Fail<E>, A>
+} = <const A, const E>(tryPromise: Run<A>, catchError?: (e: unknown) => E) =>
+    promise<Fx<Async | Fail<E>, A>>(
+      s => tryPromise(s).then(
+        ok,
+        e => catchError ? fail(catchError(e)) : fail(e)
+      )
+    ).pipe(flatMap(r => r))

--- a/src/Env.test.ts
+++ b/src/Env.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { fx, runSync } from './Fx'
+import { fx, runToValue } from './Fx'
 
 import { get, provide, provideAll } from './Env'
 
@@ -10,14 +10,14 @@ describe('Env', () => {
     it('given environment, returns requested items', () => {
       const f = get<{ x: number, y: string }>()
       const expected = { x: Math.random(), y: `${Math.random()}` }
-      const result = runSync(f.pipe(provideAll(expected)))
+      const result = runToValue(f.pipe(provideAll(expected)))
       assert.equal(result, expected)
     })
 
     it('given environment, returns requested item subset', () => {
       const f = get<{ x: number }>()
       const expected = Math.random()
-      const { x } = runSync(f.pipe(provideAll({ x: expected })))
+      const { x } = runToValue(f.pipe(provideAll({ x: expected })))
       assert.equal(x, expected)
     })
 
@@ -32,7 +32,7 @@ describe('Env', () => {
 
       const expected = { x: Math.random(), y: `${Math.random()}` }
       const f2 = f.pipe(provideAll(expected))
-      const [xy, { x }, { y }] = runSync(f2)
+      const [xy, { x }, { y }] = runToValue(f2)
 
       assert.deepEqual(xy, { x, y })
     })
@@ -50,7 +50,7 @@ describe('Env', () => {
       const x = Math.random()
       const y = `${Math.random()}`
 
-      const result = runSync(f.pipe(provide({ y }), provide({ x, y: '' })))
+      const result = runToValue(f.pipe(provide({ y }), provide({ x, y: '' })))
 
       assert.equal(result.x, x)
       assert.equal(result.y, y)

--- a/src/Fail.test.ts
+++ b/src/Fail.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { fx, ok, runSync } from './Fx'
+import { fx, ok, runToValue } from './Fx'
 
 import { catchOnly, fail } from './Fail'
 
@@ -11,7 +11,7 @@ describe('Fail', () => {
       const expected = Math.random()
       const f = ok(expected)
 
-      const actual = runSync(f.pipe(catchOnly((x): x is unknown => true)))
+      const actual = runToValue(f.pipe(catchOnly((x): x is unknown => true)))
       assert.equal(actual, expected)
     })
 
@@ -23,7 +23,7 @@ describe('Fail', () => {
       })
 
       // @ts-expect-error failure is not handled
-      const result = runSync(f.pipe(catchOnly((x): x is string => typeof x === 'string')))
+      const result = runToValue(f.pipe(catchOnly((x): x is string => typeof x === 'string')))
       assert.notEqual(result, unexpected)
     })
 
@@ -36,7 +36,7 @@ describe('Fail', () => {
         return result
       })
 
-      const actual = runSync(f.pipe(catchOnly((x): x is number => typeof x === 'number')))
+      const actual = runToValue(f.pipe(catchOnly((x): x is number => typeof x === 'number')))
       assert.equal(actual, expected)
     })
   })

--- a/src/Fork.test.ts
+++ b/src/Fork.test.ts
@@ -2,17 +2,17 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import * as Async from './Async'
 import { fork, unbounded } from './Fork'
-import { fx, runSync } from './Fx'
+import { fx, runToValue } from './Fx'
 import * as Task from './Task'
 
-const asyncValue = <A>(a: A) => Async.run(() => Promise.resolve(a))
+const asyncValue = <A>(a: A) => Async.promise(() => Promise.resolve(a))
 
 describe('Fork', () => {
   describe('unbounded', () => {
     it('given Fork, returns task', async () => {
       const x = Math.random()
       const f = unbounded(fork(asyncValue(x)))
-      const t = runSync(f)
+      const t = runToValue(f)
       const r = await t.promise
       assert.equal(r, x)
     })
@@ -24,7 +24,7 @@ describe('Fork', () => {
         return t
       }))
 
-      const t = runSync(f)
+      const t = runToValue(f)
       const r = await t.promise
       assert.equal(r, x)
     })
@@ -38,7 +38,7 @@ describe('Fork', () => {
         return [t1, t2]
       }))
 
-      const t = runSync(f)
+      const t = runToValue(f)
       const r = await Promise.all(t.map(t => t.promise))
       assert.deepEqual(r, [x1, x2])
     })
@@ -50,7 +50,7 @@ describe('Fork', () => {
         return yield* Task.wait(t1)
       })
 
-      const t = runSync(unbounded(fork(f)))
+      const t = runToValue(unbounded(fork(f)))
       const r = await t.promise
       assert.deepEqual(r, x)
     })

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -1,12 +1,12 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Effect } from './Effect'
-import { flatMap, handle, ok, runSync } from './Fx'
+import { flatMap, handle, ok, runToValue } from './Fx'
 
 describe('Fx', () => {
   describe('flatMap', () => {
     it('given mapping function, returns result', () => {
-      const r = ok(1).pipe(flatMap(x => ok(x + 1)), runSync)
+      const r = ok(1).pipe(flatMap(x => ok(x + 1)), runToValue)
       assert.equal(r, 2)
     })
 
@@ -18,7 +18,7 @@ describe('Fx', () => {
         flatMap(a => new E2(`${a}`)),
         handle(E1, ok),
         handle(E2, ok),
-        runSync
+        runToValue
       )
 
       assert.equal(r, '1')
@@ -26,15 +26,15 @@ describe('Fx', () => {
 
     it('has ok as left identity', () => {
       const x = Math.random()
-      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), runSync)
-      const r2 = ok(x).pipe(flatMap(ok), flatMap(x => ok(x + 1)), runSync)
+      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), runToValue)
+      const r2 = ok(x).pipe(flatMap(ok), flatMap(x => ok(x + 1)), runToValue)
       assert.equal(r1, r2)
     })
 
     it('has ok as right identity', () => {
       const x = Math.random()
-      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), runSync)
-      const r2 = ok(x).pipe(flatMap(x => ok(x + 1)), flatMap(ok), runSync)
+      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), runToValue)
+      const r2 = ok(x).pipe(flatMap(x => ok(x + 1)), flatMap(ok), runToValue)
       assert.equal(r1, r2)
     })
 
@@ -43,8 +43,8 @@ describe('Fx', () => {
       const f = (x: number) => ok(x + 1)
       const g = (x: number) => ok(x * 2)
 
-      const r1 = ok(x).pipe(flatMap(f), flatMap(g), runSync)
-      const r2 = ok(x).pipe(flatMap(x => f(x).pipe(flatMap(g))), runSync)
+      const r1 = ok(x).pipe(flatMap(f), flatMap(g), runToValue)
+      const r2 = ok(x).pipe(flatMap(x => f(x).pipe(flatMap(g))), runToValue)
       assert.equal(r1, r2)
     })
   })

--- a/src/Random.test.ts
+++ b/src/Random.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fx, runSync } from './Fx'
+import { fx, runToValue } from './Fx'
 import { defaultRandom, float, int, split, xoroshiro128plus } from './Random'
 
 describe('Random', () => {
@@ -12,8 +12,8 @@ describe('Random', () => {
       })
 
       const seed = 42
-      const r1 = f.pipe(defaultRandom(seed), runSync)
-      const r2 = f.pipe(defaultRandom(seed), runSync)
+      const r1 = f.pipe(defaultRandom(seed), runToValue)
+      const r2 = f.pipe(defaultRandom(seed), runToValue)
 
       assert.deepEqual(r1, r2)
     })
@@ -23,8 +23,8 @@ describe('Random', () => {
         return [yield* int(10), yield* int(10), yield* int(10)]
       })
 
-      const r1 = f.pipe(defaultRandom(), runSync)
-      const r2 = f.pipe(defaultRandom(), runSync)
+      const r1 = f.pipe(defaultRandom(), runToValue)
+      const r2 = f.pipe(defaultRandom(), runToValue)
 
       assert.notDeepEqual(r1, r2)
     })
@@ -41,16 +41,16 @@ describe('Random', () => {
 
       it('given same seed, generates same sequence', () => {
         const seed = 42
-        const r1 = ints.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = ints.pipe(xoroshiro128plus(seed), runSync)
+        const r1 = ints.pipe(xoroshiro128plus(seed), runToValue)
+        const r2 = ints.pipe(xoroshiro128plus(seed), runToValue)
 
         assert.deepEqual(r1, r2)
       })
 
       it('given different seed, generates different sequence', () => {
         const seed = 42
-        const r1 = ints.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = ints.pipe(xoroshiro128plus(seed + 1), runSync)
+        const r1 = ints.pipe(xoroshiro128plus(seed), runToValue)
+        const r2 = ints.pipe(xoroshiro128plus(seed + 1), runToValue)
 
         assert.notDeepEqual(r1, r2)
       })
@@ -66,16 +66,16 @@ describe('Random', () => {
 
       it('given same seed, generates same sequence', () => {
         const seed = 42
-        const r1 = floats.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = floats.pipe(xoroshiro128plus(seed), runSync)
+        const r1 = floats.pipe(xoroshiro128plus(seed), runToValue)
+        const r2 = floats.pipe(xoroshiro128plus(seed), runToValue)
 
         assert.deepEqual(r1, r2)
       })
 
       it('given different seed, generates different sequence', () => {
         const seed = 42
-        const r1 = floats.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = floats.pipe(xoroshiro128plus(seed + 1), runSync)
+        const r1 = floats.pipe(xoroshiro128plus(seed), runToValue)
+        const r2 = floats.pipe(xoroshiro128plus(seed + 1), runToValue)
 
         assert.notDeepEqual(r1, r2)
       })
@@ -88,8 +88,8 @@ describe('Random', () => {
         })
 
         const seed = 42
-        const r1 = f.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = split(f).pipe(xoroshiro128plus(seed), runSync)
+        const r1 = f.pipe(xoroshiro128plus(seed), runToValue)
+        const r2 = split(f).pipe(xoroshiro128plus(seed), runToValue)
 
         assert.notDeepEqual(r1, r2)
       })

--- a/src/Stream.test.ts
+++ b/src/Stream.test.ts
@@ -16,7 +16,7 @@ describe('Stream', () => {
       _ => Stream.filter(_, a => a % 2 === 0),
       _ => Stream.map(_, a => a * 2),
       collectAll,
-      Fx.runSync
+      Fx.runToValue
     )
 
     assert.equal(r, 42)
@@ -35,7 +35,7 @@ describe('Stream', () => {
         })),
         collectAll,
         Fork.unbounded,
-        Fx.runAsync
+        Fx.runToTask
       ).promise
 
       assert.equal(r, 42)
@@ -52,7 +52,7 @@ describe('Stream', () => {
       enqueueAllAsync(queue, expected)
 
       const [r, events] = await Stream.fromDequeue(queue)
-        .pipe(collectAll, Fx.runAsync)
+        .pipe(collectAll, Fx.runToTask)
         .promise
 
       assert.equal(r, undefined)
@@ -74,7 +74,7 @@ describe('Stream', () => {
           [Symbol.dispose]: () => { disposed = true }
         }
       }, queue)
-        .pipe(collectAll, Fx.runAsync)
+        .pipe(collectAll, Fx.runToTask)
         .promise
 
       assert.equal(r, undefined)
@@ -94,7 +94,7 @@ describe('Stream', () => {
       }
 
       const [r, events] = Stream.fromIterable(makeIterable())
-        .pipe(collectAll, Fx.runSync)
+        .pipe(collectAll, Fx.runToValue)
 
       assert.equal(r, 42)
       assert.deepEqual(events, inputs)
@@ -112,7 +112,7 @@ describe('Stream', () => {
       }
 
       const [r, events] = await Stream.fromAsyncIterable(makeAsyncGenerator)
-        .pipe(collectAll, Fx.runAsync)
+        .pipe(collectAll, Fx.runToTask)
         .promise
 
       assert.equal(r, 42)
@@ -157,7 +157,7 @@ describe('Stream', () => {
         while (true) actual.push(yield* Sink.next<number>())
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runSync)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runToValue)
 
       assert.equal(r, undefined)
       assert.deepEqual(actual, expected)
@@ -176,7 +176,7 @@ describe('Stream', () => {
         return 'sink'
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runSync)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runToValue)
 
       assert.equal(r, 'sink')
       assert.deepEqual(actual, [1, 2, 3])
@@ -193,7 +193,7 @@ describe('Stream', () => {
         return 'sink'
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runSync)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runToValue)
 
       assert.equal(r, 'sink')
       assert.deepEqual(actual, expected)

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -107,9 +107,9 @@ export interface AsyncIterableWithReturn<Y, R> {
  */
 export const fromAsyncIterable = <A, R>(f: () => AsyncIterableWithReturn<A, R>): Fx.Fx<Async.Async | Stream<A>, R> => Fx.bracket(
   Fx.sync(() => f()[Symbol.asyncIterator]()),
-  iterator => Async.run(() => iterator.return?.().then(() => { }) ?? Promise.resolve()),
+  iterator => Async.promise(() => iterator.return?.().then(() => { }) ?? Promise.resolve()),
   iterator => Fx.fx(function* () {
-    const next = Async.run(() => iterator.next())
+    const next = Async.promise(() => iterator.next())
     let result = yield* next
     while (!result.done) {
       yield* emit(result.value)

--- a/src/Time.test.ts
+++ b/src/Time.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fx, runAsync, runSync } from './Fx'
+import { fx, runToTask, runToValue } from './Fx'
 import * as Time from './Time'
 import { VirtualClock } from './internal/time'
 
@@ -9,7 +9,7 @@ describe('Time', () => {
     it('starts at origin', () => {
       const origin = Date.now()
       const c = new VirtualClock(origin)
-      const r = Time.now.pipe(Time.withClock(c), runSync)
+      const r = Time.now.pipe(Time.withClock(c), runToValue)
       assert.equal(r, origin)
     })
 
@@ -20,7 +20,7 @@ describe('Time', () => {
       const step = 10000 * Math.random()
       await c.step(step)
 
-      const r = Time.now.pipe(Time.withClock(c), runSync)
+      const r = Time.now.pipe(Time.withClock(c), runToValue)
       assert.equal(r, origin + Math.floor(step))
     })
   })
@@ -28,7 +28,7 @@ describe('Time', () => {
   describe('monotonic', () => {
     it('starts at 0', () => {
       const c = new VirtualClock(Date.now())
-      const r = Time.monotonic.pipe(Time.withClock(c), runSync)
+      const r = Time.monotonic.pipe(Time.withClock(c), runToValue)
       assert.equal(r, 0)
     })
 
@@ -39,7 +39,7 @@ describe('Time', () => {
       const step = 10000 * Math.random()
       await c.step(step)
 
-      const r = Time.monotonic.pipe(Time.withClock(c), runSync)
+      const r = Time.monotonic.pipe(Time.withClock(c), runToValue)
       assert.equal(r, step)
     })
   })
@@ -60,7 +60,7 @@ describe('Time', () => {
       })
 
       const c = new VirtualClock(1)
-      const p = test.pipe(Time.withClock(c), runAsync).promise
+      const p = test.pipe(Time.withClock(c), runToTask).promise
 
       await c.step(1000)
       assert.deepEqual(results, [[1000, 1001]])

--- a/src/Time.ts
+++ b/src/Time.ts
@@ -37,7 +37,7 @@ export const sleep = (millis: number) => new Sleep(millis)
 export const withClock = (c: Clock) => <E, A>(f: Fx<E, A>): Fx<Handle<Handle<E, Sleep, Async.Async>, Now | Monotonic>, A> => f.pipe(
   handle(Now, () => ok(c.now)),
   handle(Monotonic, () => ok(c.monotonic)),
-  handle(Sleep, ms => Async.run(signal => new Promise(resolve => {
+  handle(Sleep, ms => Async.promise(signal => new Promise(resolve => {
     const d = c.schedule(ms, () => {
       signal.removeEventListener('abort', disposeOnAbort)
       resolve()

--- a/src/internal/Queue.ts
+++ b/src/internal/Queue.ts
@@ -19,7 +19,7 @@ export interface Queue<A> extends Disposable {
 export type Enqueue<A> = Pick<Queue<A>, 'enqueue' | 'disposed' | keyof Disposable>
 export type Dequeue<A> = Pick<Queue<A>, 'dequeue' | 'disposed' | keyof Disposable>
 
-export const dequeue = <A>(q: Dequeue<A>): Fx<Async.Async, Dequeued<A> | Disposed> => Async.run(() => q.dequeue())
+export const dequeue = <A>(q: Dequeue<A>): Fx<Async.Async, Dequeued<A> | Disposed> => Async.promise(() => q.dequeue())
 
 export class UnboundedQueue<A> implements Queue<A> {
   private readonly items: A[] = []


### PR DESCRIPTION
Playing around with a few naming ideas:

1. Running an Fx uses the style `runToX` where X corresponds to the result type, e.g. runToValue returns a value (and can only be called on synchronous Fxs) and runToPromise returns a Promise
2. Adding a `trySync` variant of `sync` for synchronous side effects that might throw
3. Renaming `Async.run` to `Async.promise` and adding an `Async.tryPromise` variant for asynchronous functions that might throw.  I'm not crazy about this one.  Some other ideas:
    - Keep `Async.run` and add `Async.tryRun` as the "try" variant.
    - Move `Async.run` to `Fx.async` and add `Fx.tryAsync` as the "try" variant.
