### PR TITLE
Extend handler context sharing

### DIFF
--- a/examples/concurrency/fork-bounded.ts
+++ b/examples/concurrency/fork-bounded.ts
@@ -23,7 +23,7 @@ const main = fx(function* () {
 })
 
 main.pipe(
-  Time.defaultTime,
   Fork.bounded(concurrency),
+  Time.defaultTime,
   runAsync
 ).promise.catch(console.error)

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -3,6 +3,7 @@ import { EffectType } from './Effect'
 import { provideAll } from './Env'
 import { Task } from './Task'
 import { Answer, Arg, Handler, empty, isHandler } from './internal/Handler'
+import { GetHandlerContext } from './internal/HandlerContext'
 import * as generator from './internal/generator'
 import { Pipeable } from './internal/pipe'
 import { runFork } from './internal/runFork'
@@ -34,7 +35,7 @@ export const flatMap = <const A, const E2, const B>(f: (a: A) => Fx<E2, B>) =>
     return yield* f(yield* x)
   })
 
-export const runAsync = <const R>(f: Fx<Async, R>): Task<R, never> =>
+export const runAsync = <const R>(f: Fx<Async | GetHandlerContext, R>): Task<R, never> =>
   runFork(f.pipe(provideAll({})), { name: 'Fx:runAsync' })
 
 export const runSync = <const R>(f: Fx<never, R>): R =>

--- a/src/internal/Handler.ts
+++ b/src/internal/Handler.ts
@@ -1,6 +1,7 @@
 import { EffectType, isEffect } from '../Effect'
 import { Fork } from '../Fork'
 import { Fx } from '../Fx'
+import { GetHandlerContext, HandlerContext } from './HandlerContext'
 import { Pipeable, pipeThis } from './pipe'
 
 export type Answer<E extends EffectType> = InstanceType<E>['R']
@@ -8,7 +9,7 @@ export type Arg<E extends EffectType> = InstanceType<E>['arg']
 
 const HandlerTypeId = Symbol('fx/Handler')
 
-export class Handler<E, A> implements Fx<E, A>, Pipeable {
+export class Handler<E, A> implements Fx<E, A>, Pipeable, HandlerContext {
   public readonly _fxTypeId = HandlerTypeId
   public readonly pipe = pipeThis as Pipeable['pipe']
 
@@ -44,6 +45,8 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable {
               ir = i.next(hr)
             } else if (Fork.is(ir.value)) {
               ir = i.next(yield new Fork({ ...ir.value.arg, context: [...ir.value.arg.context, this] }) as any)
+            } else if (GetHandlerContext.is(ir.value)) {
+              ir = i.next([this, ...(yield ir.value) as any])
             } else {
               ir = i.next(yield ir.value as any)
             }

--- a/src/internal/HandlerContext.ts
+++ b/src/internal/HandlerContext.ts
@@ -1,6 +1,10 @@
+import { Effect } from '../Effect'
 import { Fx } from '../Fx'
 
 export interface HandlerContext extends Fx<unknown, unknown> {
   readonly handlers: ReadonlyMap<unknown, (e: unknown) => Fx<unknown, unknown>>
-  readonly controls: ReadonlyMap<unknown, (resume: (a: any) => unknown, e: unknown) => Fx<unknown, unknown>>
 }
+
+export class GetHandlerContext extends Effect('fx/GetHandlerContext')<void, readonly HandlerContext[]> { }
+
+export const getHandlerContext = new GetHandlerContext()


### PR DESCRIPTION
This allows handlers from all enclosing forks to propagate into new forks.