### PR TITLE
Rename Fx run functions, add assert/try variants for sync and promise constructors

### DIFF
--- a/examples/concurrency/concurrent-race.ts
+++ b/examples/concurrency/concurrent-race.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from 'node:timers/promises'
-import { Fork, Task, Time, flatMap, fx, unsafeRunPromise } from '../../src'
+import { Fork, Task, Time, flatMap, fx, runPromise } from '../../src'
 
 const randomWait = () => Math.floor(Math.random() * 100)
 
@@ -30,5 +30,5 @@ Fork.race([
   flatMap(Task.wait),
   Time.defaultTime,
   Fork.unbounded,
-  unsafeRunPromise
+  runPromise
 ).then(_ => console.log('Fx done'), console.error)

--- a/examples/concurrency/concurrent-race.ts
+++ b/examples/concurrency/concurrent-race.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from 'node:timers/promises'
-import { Fork, Task, Time, flatMap, fx, runAsync } from '../../src'
+import { Fork, Task, Time, flatMap, fx, unsafeRunPromise } from '../../src'
 
 const randomWait = () => Math.floor(Math.random() * 100)
 
@@ -30,5 +30,5 @@ Fork.race([
   flatMap(Task.wait),
   Time.defaultTime,
   Fork.unbounded,
-  runAsync
-).promise.then(_ => console.log('Fx done'), console.error)
+  unsafeRunPromise
+).then(_ => console.log('Fx done'), console.error)

--- a/examples/concurrency/fork-bounded.ts
+++ b/examples/concurrency/fork-bounded.ts
@@ -1,4 +1,4 @@
-import { Fork, Task, Time, fx, unsafeRunPromise } from '../../src'
+import { Fork, Task, Time, fx, runPromise } from '../../src'
 
 // Number of tasks to fork
 const tasks = 4
@@ -25,5 +25,5 @@ const main = fx(function* () {
 main.pipe(
   Fork.bounded(concurrency),
   Time.defaultTime,
-  unsafeRunPromise
+  runPromise
 ).catch(console.error)

--- a/examples/concurrency/fork-bounded.ts
+++ b/examples/concurrency/fork-bounded.ts
@@ -1,4 +1,4 @@
-import { Fork, Task, Time, fx, runAsync } from '../../src'
+import { Fork, Task, Time, fx, unsafeRunPromise } from '../../src'
 
 // Number of tasks to fork
 const tasks = 4
@@ -25,5 +25,5 @@ const main = fx(function* () {
 main.pipe(
   Fork.bounded(concurrency),
   Time.defaultTime,
-  runAsync
-).promise.catch(console.error)
+  unsafeRunPromise
+).catch(console.error)

--- a/examples/concurrency/map-reduce.ts
+++ b/examples/concurrency/map-reduce.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from 'node:timers/promises'
-import { Async, Fork, Fx, Task, fx, ok, runAsync } from '../../src'
+import { Async, Fork, Fx, Task, fx, ok, unsafeRunPromise } from '../../src'
 
 // Concurrent map-reduce
 // Splits the input in half and runs mapReduce on each half concurrently
@@ -31,7 +31,7 @@ const inputs = Array.from({ length: 1000 }, (_, i) => i)
 // This should take a little over 1 second, not inputs.length seconds
 const start = performance.now()
 mapReduce(inputs, i => delay(1000, i + 1), (a, b) => ok(a + b), 0).pipe(
-  Fork.unbounded, runAsync
-).promise.then(result =>
+  Fork.unbounded, unsafeRunPromise
+).then(result =>
   console.log(`result: ${result}, elapsed: ${performance.now() - start}ms`)
 )

--- a/examples/concurrency/map-reduce.ts
+++ b/examples/concurrency/map-reduce.ts
@@ -1,5 +1,4 @@
-import { setTimeout } from 'node:timers/promises'
-import { Async, Fork, Fx, Task, fx, ok, unsafeRunPromise } from '../../src'
+import { Async, Fork, Fx, Task, Time, fx, ok, runPromise } from '../../src'
 
 // Concurrent map-reduce
 // Splits the input in half and runs mapReduce on each half concurrently
@@ -20,9 +19,10 @@ const mapReduce = <A, B, EM, ER>(inputs: readonly A[], map: (a: A) => Fx<EM, B>,
 
 // Simulate a long running computation or network request
 // for the mapping operation
-const delay = <const A>(ms: number, a: A) => Async.run(
-  signal => setTimeout(ms, a, { signal })
-)
+const delay = <const A>(ms: number, a: A) => fx(function* () {
+  yield* Time.sleep(ms)
+  return a
+})
 
 // Generate inputs
 const inputs = Array.from({ length: 1000 }, (_, i) => i)
@@ -31,7 +31,9 @@ const inputs = Array.from({ length: 1000 }, (_, i) => i)
 // This should take a little over 1 second, not inputs.length seconds
 const start = performance.now()
 mapReduce(inputs, i => delay(1000, i + 1), (a, b) => ok(a + b), 0).pipe(
-  Fork.unbounded, unsafeRunPromise
+  Time.defaultTime,
+  Fork.unbounded,
+  runPromise
 ).then(result =>
   console.log(`result: ${result}, elapsed: ${performance.now() - start}ms`)
 )

--- a/examples/echo.ts
+++ b/examples/echo.ts
@@ -1,7 +1,7 @@
 
 import { createInterface } from 'node:readline/promises'
 
-import { Async, Effect, Fx, bracket, fx, handle, ok, sync, unsafeRunPromise } from '../src'
+import { Async, Effect, Fx, bracket, fx, handle, ok, runPromise, sync } from '../src'
 
 class Print extends Effect('Print')<string, void> { }
 
@@ -25,11 +25,11 @@ const handleRead = <E, A>(f: Fx<E, A>) => bracket(
   sync(() => createInterface({ input: process.stdin, output: process.stdout })),
   readline => ok(readline.close()),
   readline => f.pipe(
-    handle(Read, prompt => Async.run(signal => readline.question(prompt, { signal })))
+    handle(Read, prompt => Async.promise(signal => readline.question(prompt, { signal })))
   ))
 
 // Run with "real" Read and Print effects
-main.pipe(handleRead, handlePrint, unsafeRunPromise)
+main.pipe(handleRead, handlePrint, runPromise)
   .then(console.log)
 
 // const handlePrintPure = <E, A>(f: Fx<E, A>) => {

--- a/examples/echo.ts
+++ b/examples/echo.ts
@@ -1,7 +1,7 @@
 
 import { createInterface } from 'node:readline/promises'
 
-import { Async, Effect, Fx, bracket, fx, handle, ok, runAsync, sync } from '../src'
+import { Async, Effect, Fx, bracket, fx, handle, ok, sync, unsafeRunPromise } from '../src'
 
 class Print extends Effect('Print')<string, void> { }
 
@@ -29,8 +29,8 @@ const handleRead = <E, A>(f: Fx<E, A>) => bracket(
   ))
 
 // Run with "real" Read and Print effects
-main.pipe(handleRead, handlePrint, runAsync)
-  .promise.then(console.log)
+main.pipe(handleRead, handlePrint, unsafeRunPromise)
+  .then(console.log)
 
 // const handlePrintPure = <E, A>(f: Fx<E, A>) => {
 //   const printed = [] as string[]

--- a/examples/fp-to-the-max/index.ts
+++ b/examples/fp-to-the-max/index.ts
@@ -5,7 +5,7 @@
 
 import { createInterface } from 'node:readline/promises'
 
-import { Async, Env, Fx, Random, bracket, fx, handle, ok, sync, unsafeRunPromise } from '../../src'
+import { Async, Env, Fx, Random, bracket, fx, handle, ok, runPromise, sync } from '../../src'
 
 import { GenerateSecret, Print, Read, main } from './main'
 
@@ -15,7 +15,7 @@ const handleRead = <E, A>(f: Fx<E, A>) => bracket(
   sync(() => createInterface({ input: process.stdin, output: process.stdout })),
   readline => ok(readline.close()),
   readline => f.pipe(
-    handle(Read, prompt => Async.run(signal => readline.question(prompt, { signal })))
+    handle(Read, prompt => Async.promise(signal => readline.question(prompt, { signal })))
   ))
 
 const handleGenerateSecret = handle(GenerateSecret, max => fx(function* () {
@@ -30,5 +30,5 @@ main.pipe(
   Random.defaultRandom(),
   handlePrint,
   handleRead,
-  unsafeRunPromise
+  runPromise
 )

--- a/examples/fp-to-the-max/index.ts
+++ b/examples/fp-to-the-max/index.ts
@@ -5,7 +5,7 @@
 
 import { createInterface } from 'node:readline/promises'
 
-import { Async, Env, Fx, Random, bracket, fx, handle, ok, runAsync, sync } from '../../src'
+import { Async, Env, Fx, Random, bracket, fx, handle, ok, sync, unsafeRunPromise } from '../../src'
 
 import { GenerateSecret, Print, Read, main } from './main'
 
@@ -30,5 +30,5 @@ main.pipe(
   Random.defaultRandom(),
   handlePrint,
   handleRead,
-  runAsync
+  unsafeRunPromise
 )

--- a/examples/fp-to-the-max/main.test.ts
+++ b/examples/fp-to-the-max/main.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { Env, Fx, handle, map, ok, unsafeRun } from '../../src'
+import { Env, Fx, handle, map, ok, run } from '../../src'
 
 import { GenerateSecret, Print, Read, checkAnswer, main } from './main'
 
@@ -56,7 +56,7 @@ describe('main', () => {
       handleRead(['Brian', '1', 'y', '2', 'y', '3', 'y', '1', 'n']),
       handlePrint,
       Env.provide(range),
-      unsafeRun
+      run
     )
 
     assert.deepEqual(result, [

--- a/examples/fp-to-the-max/main.test.ts
+++ b/examples/fp-to-the-max/main.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { Env, Fx, handle, map, ok, runSync } from '../../src'
+import { Env, Fx, handle, map, ok, unsafeRun } from '../../src'
 
 import { GenerateSecret, Print, Read, checkAnswer, main } from './main'
 
@@ -56,7 +56,7 @@ describe('main', () => {
       handleRead(['Brian', '1', 'y', '2', 'y', '3', 'y', '1', 'n']),
       handlePrint,
       Env.provide(range),
-      runSync
+      unsafeRun
     )
 
     assert.deepEqual(result, [

--- a/examples/http-counter/counter-keyv.ts
+++ b/examples/http-counter/counter-keyv.ts
@@ -7,18 +7,18 @@ import { Next } from './counter'
 
 export const keyvCounter = <E, A>(f: Fx<E, A>) => bracket(
   sync(() => new Keyv<number>('sqlite://http-counter.sqlite')),
-  db => Async.run(() => db.disconnect()),
+  db => Async.promise(() => db.disconnect()),
   db => f.pipe(
     handle(Next, key => fx(function* () {
       const value = (yield* get(db, key)) + 1
       yield* set(db, key, value)
       return value
     })
-  ))
+    ))
 )
 
 const get = (db: Keyv<number>, key: string) =>
-  Async.run(async _ => await db.get(key) ?? 0)
+  Async.promise(async _ => await db.get(key) ?? 0)
 
 const set = (db: Keyv<number>, key: string, value: number) =>
-  Async.run(_ => db.set(key, value))
+  Async.promise(_ => db.set(key, value))

--- a/examples/http-counter/index.ts
+++ b/examples/http-counter/index.ts
@@ -1,4 +1,4 @@
-import { Env, Fork, Log, fx, unsafeRunPromise } from '../../src'
+import { Env, Fork, Log, fx, runPromise } from '../../src'
 
 import { Request, runServer } from './HttpServer'
 import { next } from './counter'
@@ -32,7 +32,7 @@ runServer(myHandler).pipe(
   mapCounter,
   // keyvCounter,
   Fork.unbounded,
-  unsafeRunPromise
+  runPromise
 )
 
 //#endregion

--- a/examples/http-counter/index.ts
+++ b/examples/http-counter/index.ts
@@ -1,4 +1,4 @@
-import { Env, Fork, Log, fx, runAsync } from '../../src'
+import { Env, Fork, Log, fx, unsafeRunPromise } from '../../src'
 
 import { Request, runServer } from './HttpServer'
 import { next } from './counter'
@@ -32,7 +32,7 @@ runServer(myHandler).pipe(
   mapCounter,
   // keyvCounter,
   Fork.unbounded,
-  runAsync
+  unsafeRunPromise
 )
 
 //#endregion

--- a/examples/state.ts
+++ b/examples/state.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util'
 
-import { Effect, Fork, Fx, Task, Time, fx, handle, map, ok, runAsync } from '../src'
+import { Effect, Fork, Fx, Task, Time, fx, handle, map, ok, unsafeRunPromise } from '../src'
 
 // The usual state monad, as an effect
 class Get<A> extends Effect('State/Set')<void, A> { }
@@ -60,4 +60,4 @@ const main = fx(function* () {
   }
 })
 
-const r = main.pipe(Time.defaultTime, Fork.unbounded, runAsync).promise.then(x => console.log(inspect(x, false, Infinity)))
+const r = main.pipe(Time.defaultTime, Fork.unbounded, unsafeRunPromise).then(x => console.log(inspect(x, false, Infinity)))

--- a/examples/state.ts
+++ b/examples/state.ts
@@ -1,6 +1,6 @@
 import { inspect } from 'util'
 
-import { Effect, Fork, Fx, Task, Time, fx, handle, map, ok, unsafeRunPromise } from '../src'
+import { Effect, Fork, Fx, Task, Time, fx, handle, map, ok, runPromise } from '../src'
 
 // The usual state monad, as an effect
 class Get<A> extends Effect('State/Set')<void, A> { }
@@ -60,4 +60,4 @@ const main = fx(function* () {
   }
 })
 
-const r = main.pipe(Time.defaultTime, Fork.unbounded, unsafeRunPromise).then(x => console.log(inspect(x, false, Infinity)))
+const r = main.pipe(Time.defaultTime, Fork.unbounded, runPromise).then(x => console.log(inspect(x, false, Infinity)))

--- a/examples/stream/stream-split.ts
+++ b/examples/stream/stream-split.ts
@@ -1,4 +1,4 @@
-import { Sink, Stream, flatMap, fx, ok, runSync } from '../../src'
+import { Sink, Stream, flatMap, fx, ok, unsafeRun } from '../../src'
 
 // From Effect-TS discord
 // https://discord.com/channels/795981131316985866/1125094089281511474/1245070996621365318
@@ -54,5 +54,5 @@ Stream.fromIterable(numbers).pipe(
   _ => Stream.to(_, groupDivBy7),
   flatMap(Stream.emit), // emit trailing numbers
   _ => Stream.forEach(_, numbers => ok(console.log(numbers))),
-  runSync
+  unsafeRun
 )

--- a/examples/stream/stream-split.ts
+++ b/examples/stream/stream-split.ts
@@ -1,4 +1,4 @@
-import { Sink, Stream, flatMap, fx, ok, unsafeRun } from '../../src'
+import { Sink, Stream, flatMap, fx, ok, run } from '../../src'
 
 // From Effect-TS discord
 // https://discord.com/channels/795981131316985866/1125094089281511474/1245070996621365318
@@ -54,5 +54,5 @@ Stream.fromIterable(numbers).pipe(
   _ => Stream.to(_, groupDivBy7),
   flatMap(Stream.emit), // emit trailing numbers
   _ => Stream.forEach(_, numbers => ok(console.log(numbers))),
-  unsafeRun
+  run
 )

--- a/examples/wttr-client/index.ts
+++ b/examples/wttr-client/index.ts
@@ -1,4 +1,4 @@
-import { Env, Log, fx, unsafeRunPromise } from '../../src'
+import { Env, Log, fx, runPromise } from '../../src'
 import * as wttr from './wttr'
 import { wttrFetch } from './wttr-fetch'
 
@@ -14,5 +14,5 @@ main.pipe(
   wttrFetch,
   Log.console,
   Env.provide({ location: process.env.location }),
-  unsafeRunPromise
+  runPromise
 )

--- a/examples/wttr-client/index.ts
+++ b/examples/wttr-client/index.ts
@@ -1,4 +1,4 @@
-import { Env, Log, fx, runAsync } from '../../src'
+import { Env, Log, fx, unsafeRunPromise } from '../../src'
 import * as wttr from './wttr'
 import { wttrFetch } from './wttr-fetch'
 
@@ -14,5 +14,5 @@ main.pipe(
   wttrFetch,
   Log.console,
   Env.provide({ location: process.env.location }),
-  runAsync
+  unsafeRunPromise
 )

--- a/examples/wttr-client/wttr-fetch.ts
+++ b/examples/wttr-client/wttr-fetch.ts
@@ -2,7 +2,7 @@ import { Async, handle } from '../../src'
 import * as wttr from './wttr'
 
 export const wttrFetch = handle(wttr.GetWeather, ({ location }) =>
-  Async.run(signal =>
+  Async.assertPromise(signal =>
     fetch(`https://wttr.in/${encodeURIComponent(location ?? '')}?format=j1`, { signal })
       .then(res => res.json() as Promise<wttr.Weather>)
   ))

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,89 +12,9 @@
         "@eslint/js": "^9.5.0",
         "@types/node": "^20.14.8",
         "eslint": "^8.57.0",
-        "tsx": "^4.15.7",
+        "tsx": "^4.15.6",
         "typescript": "^5.5.2",
-        "typescript-eslint": "^7.13.1"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
+        "typescript-eslint": "^7.13.0"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
@@ -108,278 +28,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -514,21 +162,22 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
       "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
-      "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
+      "integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.13.1",
-        "@typescript-eslint/type-utils": "7.13.1",
-        "@typescript-eslint/utils": "7.13.1",
-        "@typescript-eslint/visitor-keys": "7.13.1",
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/type-utils": "7.13.0",
+        "@typescript-eslint/utils": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -552,15 +201,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
-      "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
+      "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.13.1",
-        "@typescript-eslint/types": "7.13.1",
-        "@typescript-eslint/typescript-estree": "7.13.1",
-        "@typescript-eslint/visitor-keys": "7.13.1",
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -580,13 +229,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
-      "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.13.1",
-        "@typescript-eslint/visitor-keys": "7.13.1"
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -597,13 +246,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
-      "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
+      "integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.13.1",
-        "@typescript-eslint/utils": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.0",
+        "@typescript-eslint/utils": "7.13.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -624,9 +273,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
-      "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -637,13 +286,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
-      "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.13.1",
-        "@typescript-eslint/visitor-keys": "7.13.1",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/visitor-keys": "7.13.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -689,15 +338,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
-      "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.13.1",
-        "@typescript-eslint/types": "7.13.1",
-        "@typescript-eslint/typescript-estree": "7.13.1"
+        "@typescript-eslint/scope-manager": "7.13.0",
+        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -711,12 +360,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
-      "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/types": "7.13.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1920,9 +1569,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.15.7",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.15.7.tgz",
-      "integrity": "sha512-u3H0iSFDZM3za+VxkZ1kywdCeHCn+8/qHQS1MNoO2sONDgD95HlWtt8aB23OzeTmFP9IU4/8bZUdg58Uu5J4cg==",
+      "version": "4.15.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.15.6.tgz",
+      "integrity": "sha512-is0VQQlfNZRHEuSSTKA6m4xw74IU4AizmuB6lAYLRt9XtuyeQnyJYexhNZOPCB59SqC4JzmSzPnHGBXxf3k0hA==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.21.4",
@@ -1967,6 +1616,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
       "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1976,14 +1626,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.1.tgz",
-      "integrity": "sha512-pvLEuRs8iS9s3Cnp/Wt//hpK8nKc8hVa3cLljHqzaJJQYP8oys8GUyIFqtlev+2lT/fqMPcyQko+HJ6iYK3nFA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.0.tgz",
+      "integrity": "sha512-upO0AXxyBwJ4BbiC6CRgAJKtGYha2zw4m1g7TIVPSonwYEuf7vCicw3syjS1OxdDMTz96sZIXl3Jx3vWJLLKFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.13.1",
-        "@typescript-eslint/parser": "7.13.1",
-        "@typescript-eslint/utils": "7.13.1"
+        "@typescript-eslint/eslint-plugin": "7.13.0",
+        "@typescript-eslint/parser": "7.13.0",
+        "@typescript-eslint/utils": "7.13.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@eslint/js": "^9.5.0",
         "@types/node": "^20.14.8",
         "eslint": "^8.57.0",
-        "tsx": "^4.15.6",
+        "tsx": "^4.15.7",
         "typescript": "^5.5.2",
-        "typescript-eslint": "^7.13.0"
+        "typescript-eslint": "^7.13.1"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
@@ -168,16 +168,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
-      "integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
+      "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/type-utils": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/type-utils": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -201,15 +202,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
-      "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
+      "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/typescript-estree": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -229,13 +231,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
-      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
+      "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0"
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -246,13 +249,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
-      "integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
+      "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -273,10 +277,11 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
+      "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -286,13 +291,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
-      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
+      "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/visitor-keys": "7.13.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -318,6 +324,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -327,6 +334,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -338,15 +346,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
-      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
+      "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/typescript-estree": "7.13.0"
+        "@typescript-eslint/scope-manager": "7.13.1",
+        "@typescript-eslint/types": "7.13.1",
+        "@typescript-eslint/typescript-estree": "7.13.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -360,12 +369,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
-      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
+      "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/types": "7.13.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -454,6 +464,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -479,6 +490,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -577,6 +589,7 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -808,6 +821,7 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -824,6 +838,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -869,6 +884,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -996,6 +1012,7 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -1102,6 +1119,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1199,6 +1217,7 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -1208,6 +1227,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
       "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -1340,6 +1360,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1349,6 +1370,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1465,6 +1487,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1498,6 +1521,7 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1549,6 +1573,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1561,6 +1586,7 @@
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -1569,10 +1595,11 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.15.6",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.15.6.tgz",
-      "integrity": "sha512-is0VQQlfNZRHEuSSTKA6m4xw74IU4AizmuB6lAYLRt9XtuyeQnyJYexhNZOPCB59SqC4JzmSzPnHGBXxf3k0hA==",
+      "version": "4.15.7",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.15.7.tgz",
+      "integrity": "sha512-u3H0iSFDZM3za+VxkZ1kywdCeHCn+8/qHQS1MNoO2sONDgD95HlWtt8aB23OzeTmFP9IU4/8bZUdg58Uu5J4cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "~0.21.4",
         "get-tsconfig": "^4.7.5"
@@ -1626,14 +1653,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.0.tgz",
-      "integrity": "sha512-upO0AXxyBwJ4BbiC6CRgAJKtGYha2zw4m1g7TIVPSonwYEuf7vCicw3syjS1OxdDMTz96sZIXl3Jx3vWJLLKFw==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.1.tgz",
+      "integrity": "sha512-pvLEuRs8iS9s3Cnp/Wt//hpK8nKc8hVa3cLljHqzaJJQYP8oys8GUyIFqtlev+2lT/fqMPcyQko+HJ6iYK3nFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.13.0",
-        "@typescript-eslint/parser": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0"
+        "@typescript-eslint/eslint-plugin": "7.13.1",
+        "@typescript-eslint/parser": "7.13.1",
+        "@typescript-eslint/utils": "7.13.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@eslint/js": "^9.5.0",
     "@types/node": "^20.14.8",
     "eslint": "^8.57.0",
-    "tsx": "^4.15.6",
+    "tsx": "^4.15.7",
     "typescript": "^5.5.2",
-    "typescript-eslint": "^7.13.0"
+    "typescript-eslint": "^7.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@eslint/js": "^9.5.0",
     "@types/node": "^20.14.8",
     "eslint": "^8.57.0",
-    "tsx": "^4.15.7",
+    "tsx": "^4.15.6",
     "typescript": "^5.5.2",
-    "typescript-eslint": "^7.13.1"
+    "typescript-eslint": "^7.13.0"
   }
 }

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -1,20 +1,20 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { abort, orReturn } from './Abort'
-import { ok, runSync } from './Fx'
+import { ok, unsafeRun } from './Fx'
 
 describe('Abort', () => {
   describe('orReturn', () => {
     it('given Abort, returns alternative', () => {
       const r = Math.random()
-      const a = abort.pipe(orReturn(r), runSync)
+      const a = abort.pipe(orReturn(r), unsafeRun)
 
       assert.equal(a, r)
     })
 
     it('given success, returns original value', () => {
       const r = Math.random()
-      const a = ok(r).pipe(orReturn(r + 1), runSync)
+      const a = ok(r).pipe(orReturn(r + 1), unsafeRun)
 
       assert.equal(a, r)
     })

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -1,20 +1,20 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { abort, orReturn } from './Abort'
-import { ok, unsafeRun } from './Fx'
+import { ok, run } from './Fx'
 
 describe('Abort', () => {
   describe('orReturn', () => {
     it('given Abort, returns alternative', () => {
       const r = Math.random()
-      const a = abort.pipe(orReturn(r), unsafeRun)
+      const a = abort.pipe(orReturn(r), run)
 
       assert.equal(a, r)
     })
 
     it('given success, returns original value', () => {
       const r = Math.random()
-      const a = ok(r).pipe(orReturn(r + 1), unsafeRun)
+      const a = ok(r).pipe(orReturn(r + 1), run)
 
       assert.equal(a, r)
     })

--- a/src/Async.ts
+++ b/src/Async.ts
@@ -1,7 +1,12 @@
 import { Effect } from './Effect'
+import { Fail, fail } from './Fail'
+import { Fx, flatten, ok } from './Fx'
 
 type Run<A> = (abort: AbortSignal) => Promise<A>
 
 export class Async extends Effect('fx/Async')<Run<any>> { }
 
-export const run = <const A>(run: Run<A>) => new Async(run).returning<A>()
+export const assertPromise = <const A>(run: Run<A>) => new Async(run).returning<A>()
+
+export const tryPromise = <const A>(f: Run<A>): Fx<Async | Fail<unknown>, A> =>
+  flatten(assertPromise(signal => f(signal).then(ok, fail)))

--- a/src/Env.test.ts
+++ b/src/Env.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { fx, unsafeRun } from './Fx'
+import { fx, run } from './Fx'
 
 import { get, provide, provideAll } from './Env'
 
@@ -10,14 +10,14 @@ describe('Env', () => {
     it('given environment, returns requested items', () => {
       const f = get<{ x: number, y: string }>()
       const expected = { x: Math.random(), y: `${Math.random()}` }
-      const result = unsafeRun(f.pipe(provideAll(expected)))
+      const result = run(f.pipe(provideAll(expected)))
       assert.equal(result, expected)
     })
 
     it('given environment, returns requested item subset', () => {
       const f = get<{ x: number }>()
       const expected = Math.random()
-      const { x } = unsafeRun(f.pipe(provideAll({ x: expected })))
+      const { x } = run(f.pipe(provideAll({ x: expected })))
       assert.equal(x, expected)
     })
 
@@ -32,7 +32,7 @@ describe('Env', () => {
 
       const expected = { x: Math.random(), y: `${Math.random()}` }
       const f2 = f.pipe(provideAll(expected))
-      const [xy, { x }, { y }] = unsafeRun(f2)
+      const [xy, { x }, { y }] = run(f2)
 
       assert.deepEqual(xy, { x, y })
     })
@@ -50,7 +50,7 @@ describe('Env', () => {
       const x = Math.random()
       const y = `${Math.random()}`
 
-      const result = unsafeRun(f.pipe(provide({ y }), provide({ x, y: '' })))
+      const result = run(f.pipe(provide({ y }), provide({ x, y: '' })))
 
       assert.equal(result.x, x)
       assert.equal(result.y, y)

--- a/src/Env.test.ts
+++ b/src/Env.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { fx, runSync } from './Fx'
+import { fx, unsafeRun } from './Fx'
 
 import { get, provide, provideAll } from './Env'
 
@@ -10,14 +10,14 @@ describe('Env', () => {
     it('given environment, returns requested items', () => {
       const f = get<{ x: number, y: string }>()
       const expected = { x: Math.random(), y: `${Math.random()}` }
-      const result = runSync(f.pipe(provideAll(expected)))
+      const result = unsafeRun(f.pipe(provideAll(expected)))
       assert.equal(result, expected)
     })
 
     it('given environment, returns requested item subset', () => {
       const f = get<{ x: number }>()
       const expected = Math.random()
-      const { x } = runSync(f.pipe(provideAll({ x: expected })))
+      const { x } = unsafeRun(f.pipe(provideAll({ x: expected })))
       assert.equal(x, expected)
     })
 
@@ -32,7 +32,7 @@ describe('Env', () => {
 
       const expected = { x: Math.random(), y: `${Math.random()}` }
       const f2 = f.pipe(provideAll(expected))
-      const [xy, { x }, { y }] = runSync(f2)
+      const [xy, { x }, { y }] = unsafeRun(f2)
 
       assert.deepEqual(xy, { x, y })
     })
@@ -50,7 +50,7 @@ describe('Env', () => {
       const x = Math.random()
       const y = `${Math.random()}`
 
-      const result = runSync(f.pipe(provide({ y }), provide({ x, y: '' })))
+      const result = unsafeRun(f.pipe(provide({ y }), provide({ x, y: '' })))
 
       assert.equal(result.x, x)
       assert.equal(result.y, y)

--- a/src/Fail.test.ts
+++ b/src/Fail.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { fx, ok, runSync } from './Fx'
+import { fx, ok, unsafeRun } from './Fx'
 
 import { catchOnly, fail } from './Fail'
 
@@ -11,7 +11,7 @@ describe('Fail', () => {
       const expected = Math.random()
       const f = ok(expected)
 
-      const actual = runSync(f.pipe(catchOnly((x): x is unknown => true)))
+      const actual = unsafeRun(f.pipe(catchOnly((x): x is unknown => true)))
       assert.equal(actual, expected)
     })
 
@@ -23,7 +23,7 @@ describe('Fail', () => {
       })
 
       // @ts-expect-error failure is not handled
-      const result = runSync(f.pipe(catchOnly((x): x is string => typeof x === 'string')))
+      const result = unsafeRun(f.pipe(catchOnly((x): x is string => typeof x === 'string')))
       assert.notEqual(result, unexpected)
     })
 
@@ -35,7 +35,7 @@ describe('Fail', () => {
         return result
       })
 
-      const actual = runSync(f.pipe(catchOnly((x): x is number => typeof x === 'number')))
+      const actual = unsafeRun(f.pipe(catchOnly((x): x is number => typeof x === 'number')))
       assert.equal(actual, expected)
     })
   })

--- a/src/Fail.test.ts
+++ b/src/Fail.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { fx, ok, unsafeRun } from './Fx'
+import { fx, ok, run } from './Fx'
 
 import { catchOnly, fail } from './Fail'
 
@@ -11,7 +11,7 @@ describe('Fail', () => {
       const expected = Math.random()
       const f = ok(expected)
 
-      const actual = unsafeRun(f.pipe(catchOnly((x): x is unknown => true)))
+      const actual = run(f.pipe(catchOnly((x): x is unknown => true)))
       assert.equal(actual, expected)
     })
 
@@ -23,7 +23,7 @@ describe('Fail', () => {
       })
 
       // @ts-expect-error failure is not handled
-      const result = unsafeRun(f.pipe(catchOnly((x): x is string => typeof x === 'string')))
+      const result = run(f.pipe(catchOnly((x): x is string => typeof x === 'string')))
       assert.notEqual(result, unexpected)
     })
 
@@ -35,7 +35,7 @@ describe('Fail', () => {
         return result
       })
 
-      const actual = unsafeRun(f.pipe(catchOnly((x): x is number => typeof x === 'number')))
+      const actual = run(f.pipe(catchOnly((x): x is number => typeof x === 'number')))
       assert.equal(actual, expected)
     })
   })

--- a/src/Fork.test.ts
+++ b/src/Fork.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import * as Async from './Async'
 import { fork, unbounded } from './Fork'
-import { fx, handle, ok, runSync } from './Fx'
+import { fx, handle, ok, unsafeRun } from './Fx'
 import * as Task from './Task'
 import { GetHandlerContext } from './internal/HandlerContext'
 
@@ -14,7 +14,7 @@ describe('Fork', () => {
   describe('unbounded', () => {
     it('given Fork, returns task', async () => {
       const x = Math.random()
-      const t = asyncValue(x).pipe(fork, unbounded, emptyHandlerContext, runSync)
+      const t = asyncValue(x).pipe(fork, unbounded, emptyHandlerContext, unsafeRun)
       const r = await t.promise
       assert.equal(r, x)
     })
@@ -26,7 +26,7 @@ describe('Fork', () => {
         return t
       }))
 
-      const t = f.pipe(emptyHandlerContext, runSync)
+      const t = f.pipe(emptyHandlerContext, unsafeRun)
       const r = await t.promise
       assert.equal(r, x)
     })
@@ -40,7 +40,7 @@ describe('Fork', () => {
         return [t1, t2]
       }))
 
-      const t = f.pipe(emptyHandlerContext, runSync)
+      const t = f.pipe(emptyHandlerContext, unsafeRun)
       const r = await Promise.all(t.map(t => t.promise))
       assert.deepEqual(r, [x1, x2])
     })
@@ -52,7 +52,7 @@ describe('Fork', () => {
         return yield* Task.wait(t1)
       })
 
-      const t = f.pipe(fork, unbounded, emptyHandlerContext, runSync)
+      const t = f.pipe(fork, unbounded, emptyHandlerContext, unsafeRun)
       const r = await t.promise
       assert.deepEqual(r, x)
     })

--- a/src/Fork.test.ts
+++ b/src/Fork.test.ts
@@ -2,11 +2,11 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import * as Async from './Async'
 import { fork, unbounded } from './Fork'
-import { fx, handle, ok, unsafeRun } from './Fx'
+import { fx, handle, ok, run } from './Fx'
 import * as Task from './Task'
 import { GetHandlerContext } from './internal/HandlerContext'
 
-const asyncValue = <A>(a: A) => Async.run(() => Promise.resolve(a))
+const asyncValue = <A>(a: A) => Async.assertPromise(() => Promise.resolve(a))
 
 const emptyHandlerContext = handle(GetHandlerContext, () => ok([]))
 
@@ -14,7 +14,7 @@ describe('Fork', () => {
   describe('unbounded', () => {
     it('given Fork, returns task', async () => {
       const x = Math.random()
-      const t = asyncValue(x).pipe(fork, unbounded, emptyHandlerContext, unsafeRun)
+      const t = asyncValue(x).pipe(fork, unbounded, emptyHandlerContext, run)
       const r = await t.promise
       assert.equal(r, x)
     })
@@ -26,7 +26,7 @@ describe('Fork', () => {
         return t
       }))
 
-      const t = f.pipe(emptyHandlerContext, unsafeRun)
+      const t = f.pipe(emptyHandlerContext, run)
       const r = await t.promise
       assert.equal(r, x)
     })
@@ -40,7 +40,7 @@ describe('Fork', () => {
         return [t1, t2]
       }))
 
-      const t = f.pipe(emptyHandlerContext, unsafeRun)
+      const t = f.pipe(emptyHandlerContext, run)
       const r = await Promise.all(t.map(t => t.promise))
       assert.deepEqual(r, [x1, x2])
     })
@@ -52,7 +52,7 @@ describe('Fork', () => {
         return yield* Task.wait(t1)
       })
 
-      const t = f.pipe(fork, unbounded, emptyHandlerContext, unsafeRun)
+      const t = f.pipe(fork, unbounded, emptyHandlerContext, run)
       const r = await t.promise
       assert.deepEqual(r, x)
     })

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Effect } from './Effect'
-import { flatMap, fx, handle, ok, runSync } from './Fx'
+import { flatMap, fx, handle, ok, unsafeRun } from './Fx'
 
 describe('Fx', () => {
   describe('fx', () => {
@@ -9,7 +9,7 @@ describe('Fx', () => {
       const expected = { foo: 'bar' }
       const actual = fx(expected, function* () {
         return this
-      }).pipe(runSync)
+      }).pipe(unsafeRun)
 
       assert.equal(actual, expected)
     })
@@ -18,7 +18,7 @@ describe('Fx', () => {
       const actual = fx(function* () {
         // @ts-expect-error `this` is not set
         return this
-      }).pipe(runSync)
+      }).pipe(unsafeRun)
 
       assert.equal(actual, undefined)
     })
@@ -26,7 +26,7 @@ describe('Fx', () => {
 
   describe('flatMap', () => {
     it('given mapping function, returns result', () => {
-      const r = ok(1).pipe(flatMap(x => ok(x + 1)), runSync)
+      const r = ok(1).pipe(flatMap(x => ok(x + 1)), unsafeRun)
       assert.equal(r, 2)
     })
 
@@ -38,7 +38,7 @@ describe('Fx', () => {
         flatMap(a => new E2(`${a}`)),
         handle(E1, ok),
         handle(E2, ok),
-        runSync
+        unsafeRun
       )
 
       assert.equal(r, '1')
@@ -46,15 +46,15 @@ describe('Fx', () => {
 
     it('has ok as left identity', () => {
       const x = Math.random()
-      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), runSync)
-      const r2 = ok(x).pipe(flatMap(ok), flatMap(x => ok(x + 1)), runSync)
+      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), unsafeRun)
+      const r2 = ok(x).pipe(flatMap(ok), flatMap(x => ok(x + 1)), unsafeRun)
       assert.equal(r1, r2)
     })
 
     it('has ok as right identity', () => {
       const x = Math.random()
-      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), runSync)
-      const r2 = ok(x).pipe(flatMap(x => ok(x + 1)), flatMap(ok), runSync)
+      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), unsafeRun)
+      const r2 = ok(x).pipe(flatMap(x => ok(x + 1)), flatMap(ok), unsafeRun)
       assert.equal(r1, r2)
     })
 
@@ -63,8 +63,8 @@ describe('Fx', () => {
       const f = (x: number) => ok(x + 1)
       const g = (x: number) => ok(x * 2)
 
-      const r1 = ok(x).pipe(flatMap(f), flatMap(g), runSync)
-      const r2 = ok(x).pipe(flatMap(x => f(x).pipe(flatMap(g))), runSync)
+      const r1 = ok(x).pipe(flatMap(f), flatMap(g), unsafeRun)
+      const r2 = ok(x).pipe(flatMap(x => f(x).pipe(flatMap(g))), unsafeRun)
       assert.equal(r1, r2)
     })
   })

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Effect } from './Effect'
-import { flatMap, fx, handle, ok, unsafeRun } from './Fx'
+import { Fail, catchFail } from './Fail'
+import { assertSync, flatMap, fx, handle, ok, run, trySync } from './Fx'
 
 describe('Fx', () => {
   describe('fx', () => {
@@ -9,7 +10,7 @@ describe('Fx', () => {
       const expected = { foo: 'bar' }
       const actual = fx(expected, function* () {
         return this
-      }).pipe(unsafeRun)
+      }).pipe(run)
 
       assert.equal(actual, expected)
     })
@@ -18,7 +19,7 @@ describe('Fx', () => {
       const actual = fx(function* () {
         // @ts-expect-error `this` is not set
         return this
-      }).pipe(unsafeRun)
+      }).pipe(run)
 
       assert.equal(actual, undefined)
     })
@@ -26,7 +27,7 @@ describe('Fx', () => {
 
   describe('flatMap', () => {
     it('given mapping function, returns result', () => {
-      const r = ok(1).pipe(flatMap(x => ok(x + 1)), unsafeRun)
+      const r = ok(1).pipe(flatMap(x => ok(x + 1)), run)
       assert.equal(r, 2)
     })
 
@@ -38,7 +39,7 @@ describe('Fx', () => {
         flatMap(a => new E2(`${a}`)),
         handle(E1, ok),
         handle(E2, ok),
-        unsafeRun
+        run
       )
 
       assert.equal(r, '1')
@@ -46,15 +47,15 @@ describe('Fx', () => {
 
     it('has ok as left identity', () => {
       const x = Math.random()
-      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), unsafeRun)
-      const r2 = ok(x).pipe(flatMap(ok), flatMap(x => ok(x + 1)), unsafeRun)
+      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), run)
+      const r2 = ok(x).pipe(flatMap(ok), flatMap(x => ok(x + 1)), run)
       assert.equal(r1, r2)
     })
 
     it('has ok as right identity', () => {
       const x = Math.random()
-      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), unsafeRun)
-      const r2 = ok(x).pipe(flatMap(x => ok(x + 1)), flatMap(ok), unsafeRun)
+      const r1 = ok(x).pipe(flatMap(x => ok(x + 1)), run)
+      const r2 = ok(x).pipe(flatMap(x => ok(x + 1)), flatMap(ok), run)
       assert.equal(r1, r2)
     })
 
@@ -63,9 +64,37 @@ describe('Fx', () => {
       const f = (x: number) => ok(x + 1)
       const g = (x: number) => ok(x * 2)
 
-      const r1 = ok(x).pipe(flatMap(f), flatMap(g), unsafeRun)
-      const r2 = ok(x).pipe(flatMap(x => f(x).pipe(flatMap(g))), unsafeRun)
+      const r1 = ok(x).pipe(flatMap(f), flatMap(g), run)
+      const r2 = ok(x).pipe(flatMap(x => f(x).pipe(flatMap(g))), run)
       assert.equal(r1, r2)
+    })
+  })
+
+  describe('sync', () => {
+    it('given thunk, returns result', () => {
+      const x = Math.random()
+      const r = assertSync(() => x).pipe(run)
+      assert.equal(r, x)
+    })
+
+    it('given thunk throws, throws', () => {
+      const e = new Error()
+      assert.throws(() => assertSync(() => { throw e }).pipe(run), e)
+    })
+  })
+
+  describe('trySync', () => {
+    it('given thunk, returns result', () => {
+      const x = Math.random()
+      const r = trySync(() => x).pipe(catchFail, run)
+      assert.equal(r, x)
+    })
+
+    it('given thunk throws, produces Fail', () => {
+      const e = new Error()
+      const r = trySync(() => { throw e }).pipe(catchFail, run)
+      assert.ok(Fail.is(r))
+      assert.equal(r.arg, e)
     })
   })
 })

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -35,10 +35,23 @@ export const flatMap = <const A, const E2, const B>(f: (a: A) => Fx<E2, B>) =>
     return yield* f(yield* x)
   })
 
-export const runAsync = <const R>(f: Fx<Async | GetHandlerContext, R>): Task<R, never> =>
-  runFork(f.pipe(provideAll({})), { name: 'Fx:runAsync' })
+/**
+ * Execute all the effects of the provided Fx, and return a {@link Task} for its result.
+ */
+export const unsafeRunTask = <const R>(f: Fx<Async | GetHandlerContext, R>): Task<R, never> =>
+  runFork(f.pipe(provideAll({})), { name: 'Fx:unsafeRunTask' })
 
-export const runSync = <const R>(f: Fx<never, R>): R =>
+/**
+ * Execute all the effects of the provided Fx, and return a Promise for its result,
+ * discarding the ability to cancel the computation.
+ */
+export const unsafeRunPromise = <const R>(f: Fx<Async | GetHandlerContext, R>): Promise<R> =>
+  unsafeRunTask(f).promise
+
+/**
+ * Execute all the effects of the provided Fx, and return its result.
+ */
+export const unsafeRun = <const R>(f: Fx<never, R>): R =>
   f.pipe(provideAll({}), getResult)
 
 const getResult = <const R>(f: Fx<never, R>): R => f[Symbol.iterator]().next().value

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -1,6 +1,7 @@
 import { Async } from './Async'
 import { EffectType } from './Effect'
 import { provideAll } from './Env'
+import { Fail, fail } from './Fail'
 import { Task } from './Task'
 import { Answer, Arg, Handler, empty } from './internal/Handler'
 import { GetHandlerContext } from './internal/HandlerContext'
@@ -23,7 +24,15 @@ export const fx: {
 
 export const ok = <const A>(a: A): Fx<never, A> => new generator.Ok(a)
 
-export const sync = <const A>(f: () => A): Fx<never, A> => new generator.Sync(f)
+export const assertSync = <const A>(f: () => A): Fx<never, A> => new generator.Sync(f)
+
+export const trySync = <const A>(f: () => A): Fx<Fail<unknown>, A> => fx(function* () {
+  try {
+    return f()
+  } catch (e) {
+    return yield* fail(e)
+  }
+})
 
 export const unit = ok(undefined)
 
@@ -35,23 +44,28 @@ export const flatMap = <const A, const E2, const B>(f: (a: A) => Fx<E2, B>) =>
     return yield* f(yield* x)
   })
 
+export const flatten = <const E1, const E2, const A>(x: Fx<E1, Fx<E2, A>>): Fx<E1 | E2, A> =>
+  fx(function* () {
+    return yield* (yield* x)
+  })
+
 /**
  * Execute all the effects of the provided Fx, and return a {@link Task} for its result.
  */
-export const unsafeRunTask = <const R>(f: Fx<Async | GetHandlerContext, R>): Task<R, never> =>
-  runFork(f.pipe(provideAll({})), { name: 'Fx:unsafeRunTask' })
+export const runTask = <const R>(f: Fx<Async | GetHandlerContext, R>): Task<R, never> =>
+  runFork(f.pipe(provideAll({})), { name: 'Fx:toTask' })
 
 /**
  * Execute all the effects of the provided Fx, and return a Promise for its result,
  * discarding the ability to cancel the computation.
  */
-export const unsafeRunPromise = <const R>(f: Fx<Async | GetHandlerContext, R>): Promise<R> =>
-  unsafeRunTask(f).promise
+export const runPromise = <const R>(f: Fx<Async | GetHandlerContext, R>): Promise<R> =>
+  runTask(f).promise
 
 /**
  * Execute all the effects of the provided Fx, and return its result.
  */
-export const unsafeRun = <const R>(f: Fx<never, R>): R =>
+export const run = <const R>(f: Fx<never, R>): R =>
   f.pipe(provideAll({}), getResult)
 
 const getResult = <const R>(f: Fx<never, R>): R => f[Symbol.iterator]().next().value
@@ -67,12 +81,12 @@ export const bracket = <const IE, const FE, const E, const R, const A>(init: Fx<
 
 export type Handle<E, A, B = never> = E extends A ? B : E
 
-export type HandleReturn<E, A, R> = E extends A ? R : E
+export type HandleReturn<E, A, R> = E extends A ? R : never
 
 export const handle = <T extends EffectType, HandlerEffects>(e: T, f: (e: Arg<T>) => Fx<HandlerEffects, Answer<T>>) =>
-  <const E, const A>(fx: Fx<E, A>): Handler<Handle<E, InstanceType<T>, HandlerEffects>, A> =>
-    new Handler(fx, new Map().set(e._fxEffectId, f), empty) as Handler<Handle<E, InstanceType<T>, HandlerEffects>, A>
+  <const E, const A>(fx: Fx<E, A>): Fx<Handle<E, InstanceType<T>, HandlerEffects>, A> =>
+    new Handler(fx, new Map().set(e._fxEffectId, f), empty) as Fx<Handle<E, InstanceType<T>, HandlerEffects>, A>
 
 export const control = <T extends EffectType, HandlerEffects, R = never>(e: T, f: <A>(resume: (a: Answer<T>) => A, e: Arg<T>) => Fx<HandlerEffects, R>) =>
-  <const E, const A>(fx: Fx<E, A>): Handler<Handle<E, InstanceType<T>, HandlerEffects>, HandleReturn<E, InstanceType<T>, R> | A> =>
-    new Handler(fx, empty, new Map().set(e._fxEffectId, f)) as Handler<Handle<E, InstanceType<T>, HandlerEffects>, HandleReturn<E, InstanceType<T>, R> | A>
+  <const E, const A>(fx: Fx<E, A>): Fx<Handle<E, InstanceType<T>, HandlerEffects>, HandleReturn<E, InstanceType<T>, R> | A> =>
+    new Handler(fx, empty, new Map().set(e._fxEffectId, f)) as Fx<Handle<E, InstanceType<T>, HandlerEffects>, HandleReturn<E, InstanceType<T>, R> | A>

--- a/src/Random.test.ts
+++ b/src/Random.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fx, unsafeRun } from './Fx'
+import { fx, run } from './Fx'
 import { defaultRandom, float, int, split, xoroshiro128plus } from './Random'
 
 describe('Random', () => {
@@ -12,8 +12,8 @@ describe('Random', () => {
       })
 
       const seed = 42
-      const r1 = f.pipe(defaultRandom(seed), unsafeRun)
-      const r2 = f.pipe(defaultRandom(seed), unsafeRun)
+      const r1 = f.pipe(defaultRandom(seed), run)
+      const r2 = f.pipe(defaultRandom(seed), run)
 
       assert.deepEqual(r1, r2)
     })
@@ -23,8 +23,8 @@ describe('Random', () => {
         return [yield* int(10), yield* int(10), yield* int(10)]
       })
 
-      const r1 = f.pipe(defaultRandom(), unsafeRun)
-      const r2 = f.pipe(defaultRandom(), unsafeRun)
+      const r1 = f.pipe(defaultRandom(), run)
+      const r2 = f.pipe(defaultRandom(), run)
 
       assert.notDeepEqual(r1, r2)
     })
@@ -41,16 +41,16 @@ describe('Random', () => {
 
       it('given same seed, generates same sequence', () => {
         const seed = 42
-        const r1 = ints.pipe(xoroshiro128plus(seed), unsafeRun)
-        const r2 = ints.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r1 = ints.pipe(xoroshiro128plus(seed), run)
+        const r2 = ints.pipe(xoroshiro128plus(seed), run)
 
         assert.deepEqual(r1, r2)
       })
 
       it('given different seed, generates different sequence', () => {
         const seed = 42
-        const r1 = ints.pipe(xoroshiro128plus(seed), unsafeRun)
-        const r2 = ints.pipe(xoroshiro128plus(seed + 1), unsafeRun)
+        const r1 = ints.pipe(xoroshiro128plus(seed), run)
+        const r2 = ints.pipe(xoroshiro128plus(seed + 1), run)
 
         assert.notDeepEqual(r1, r2)
       })
@@ -66,16 +66,16 @@ describe('Random', () => {
 
       it('given same seed, generates same sequence', () => {
         const seed = 42
-        const r1 = floats.pipe(xoroshiro128plus(seed), unsafeRun)
-        const r2 = floats.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r1 = floats.pipe(xoroshiro128plus(seed), run)
+        const r2 = floats.pipe(xoroshiro128plus(seed), run)
 
         assert.deepEqual(r1, r2)
       })
 
       it('given different seed, generates different sequence', () => {
         const seed = 42
-        const r1 = floats.pipe(xoroshiro128plus(seed), unsafeRun)
-        const r2 = floats.pipe(xoroshiro128plus(seed + 1), unsafeRun)
+        const r1 = floats.pipe(xoroshiro128plus(seed), run)
+        const r2 = floats.pipe(xoroshiro128plus(seed + 1), run)
 
         assert.notDeepEqual(r1, r2)
       })
@@ -88,8 +88,8 @@ describe('Random', () => {
         })
 
         const seed = 42
-        const r1 = f.pipe(xoroshiro128plus(seed), unsafeRun)
-        const r2 = split(f).pipe(xoroshiro128plus(seed), unsafeRun)
+        const r1 = f.pipe(xoroshiro128plus(seed), run)
+        const r2 = split(f).pipe(xoroshiro128plus(seed), run)
 
         assert.notDeepEqual(r1, r2)
       })

--- a/src/Random.test.ts
+++ b/src/Random.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fx, runSync } from './Fx'
+import { fx, unsafeRun } from './Fx'
 import { defaultRandom, float, int, split, xoroshiro128plus } from './Random'
 
 describe('Random', () => {
@@ -12,8 +12,8 @@ describe('Random', () => {
       })
 
       const seed = 42
-      const r1 = f.pipe(defaultRandom(seed), runSync)
-      const r2 = f.pipe(defaultRandom(seed), runSync)
+      const r1 = f.pipe(defaultRandom(seed), unsafeRun)
+      const r2 = f.pipe(defaultRandom(seed), unsafeRun)
 
       assert.deepEqual(r1, r2)
     })
@@ -23,8 +23,8 @@ describe('Random', () => {
         return [yield* int(10), yield* int(10), yield* int(10)]
       })
 
-      const r1 = f.pipe(defaultRandom(), runSync)
-      const r2 = f.pipe(defaultRandom(), runSync)
+      const r1 = f.pipe(defaultRandom(), unsafeRun)
+      const r2 = f.pipe(defaultRandom(), unsafeRun)
 
       assert.notDeepEqual(r1, r2)
     })
@@ -41,16 +41,16 @@ describe('Random', () => {
 
       it('given same seed, generates same sequence', () => {
         const seed = 42
-        const r1 = ints.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = ints.pipe(xoroshiro128plus(seed), runSync)
+        const r1 = ints.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r2 = ints.pipe(xoroshiro128plus(seed), unsafeRun)
 
         assert.deepEqual(r1, r2)
       })
 
       it('given different seed, generates different sequence', () => {
         const seed = 42
-        const r1 = ints.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = ints.pipe(xoroshiro128plus(seed + 1), runSync)
+        const r1 = ints.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r2 = ints.pipe(xoroshiro128plus(seed + 1), unsafeRun)
 
         assert.notDeepEqual(r1, r2)
       })
@@ -66,16 +66,16 @@ describe('Random', () => {
 
       it('given same seed, generates same sequence', () => {
         const seed = 42
-        const r1 = floats.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = floats.pipe(xoroshiro128plus(seed), runSync)
+        const r1 = floats.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r2 = floats.pipe(xoroshiro128plus(seed), unsafeRun)
 
         assert.deepEqual(r1, r2)
       })
 
       it('given different seed, generates different sequence', () => {
         const seed = 42
-        const r1 = floats.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = floats.pipe(xoroshiro128plus(seed + 1), runSync)
+        const r1 = floats.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r2 = floats.pipe(xoroshiro128plus(seed + 1), unsafeRun)
 
         assert.notDeepEqual(r1, r2)
       })
@@ -88,8 +88,8 @@ describe('Random', () => {
         })
 
         const seed = 42
-        const r1 = f.pipe(xoroshiro128plus(seed), runSync)
-        const r2 = split(f).pipe(xoroshiro128plus(seed), runSync)
+        const r1 = f.pipe(xoroshiro128plus(seed), unsafeRun)
+        const r2 = split(f).pipe(xoroshiro128plus(seed), unsafeRun)
 
         assert.notDeepEqual(r1, r2)
       })

--- a/src/Stream.test.ts
+++ b/src/Stream.test.ts
@@ -17,7 +17,7 @@ describe('Stream', () => {
       _ => Stream.filter(_, a => a % 2 === 0),
       _ => Stream.map(_, a => a * 2),
       collectAll,
-      Fx.unsafeRun
+      Fx.run
     )
 
     assert.equal(r, 42)
@@ -32,7 +32,7 @@ describe('Stream', () => {
         Stream.take(n),
         Abort.orReturn(n),
         collectAll,
-        Fx.unsafeRun
+        Fx.run
       )
 
       assert.equal(r, n)
@@ -51,7 +51,7 @@ describe('Stream', () => {
         Stream.take(n - 1),
         Abort.orReturn('aborted'),
         collectAll,
-        Fx.unsafeRun
+        Fx.run
       )
 
       assert.equal(r, 'aborted')
@@ -68,7 +68,7 @@ describe('Stream', () => {
         Stream.take(n),
         Abort.orReturn('aborted'),
         collectAll,
-        Fx.unsafeRun
+        Fx.run
       )
 
       assert.equal(r, 'done')
@@ -88,7 +88,7 @@ describe('Stream', () => {
         })),
         collectAll,
         Fork.unbounded,
-        Fx.unsafeRunPromise
+        Fx.runPromise
       )
 
       assert.equal(r, 42)
@@ -105,7 +105,7 @@ describe('Stream', () => {
       enqueueAllAsync(queue, expected)
 
       const [r, events] = await Stream.fromDequeue(queue)
-        .pipe(collectAll, Fx.unsafeRunPromise)
+        .pipe(collectAll, Fx.runPromise)
 
       assert.equal(r, undefined)
       assert.deepEqual(events, expected)
@@ -126,7 +126,7 @@ describe('Stream', () => {
           [Symbol.dispose]: () => { disposed = true }
         }
       }, queue)
-        .pipe(collectAll, Fx.unsafeRunPromise)
+        .pipe(collectAll, Fx.runPromise)
 
       assert.equal(r, undefined)
       assert.deepEqual(events, expected)
@@ -145,7 +145,7 @@ describe('Stream', () => {
       }
 
       const [r, events] = Stream.fromIterable(makeIterable())
-        .pipe(collectAll, Fx.unsafeRun)
+        .pipe(collectAll, Fx.run)
 
       assert.equal(r, 42)
       assert.deepEqual(events, inputs)
@@ -163,7 +163,7 @@ describe('Stream', () => {
       }
 
       const [r, events] = await Stream.fromAsyncIterable(makeAsyncGenerator)
-        .pipe(collectAll, Fx.unsafeRunPromise)
+        .pipe(collectAll, Fx.runPromise)
 
       assert.equal(r, 42)
       assert.deepEqual(events, inputs)
@@ -206,7 +206,7 @@ describe('Stream', () => {
         while (true) actual.push(yield* Sink.next<number>())
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.unsafeRun)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.run)
 
       assert.equal(r, undefined)
       assert.deepEqual(actual, expected)
@@ -225,7 +225,7 @@ describe('Stream', () => {
         return 'sink'
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.unsafeRun)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.run)
 
       assert.equal(r, 'sink')
       assert.deepEqual(actual, [1, 2, 3])
@@ -242,7 +242,7 @@ describe('Stream', () => {
         return 'sink'
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.unsafeRun)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.run)
 
       assert.equal(r, 'sink')
       assert.deepEqual(actual, expected)

--- a/src/Stream.test.ts
+++ b/src/Stream.test.ts
@@ -17,7 +17,7 @@ describe('Stream', () => {
       _ => Stream.filter(_, a => a % 2 === 0),
       _ => Stream.map(_, a => a * 2),
       collectAll,
-      Fx.runSync
+      Fx.unsafeRun
     )
 
     assert.equal(r, 42)
@@ -32,7 +32,7 @@ describe('Stream', () => {
         Stream.take(n),
         Abort.orReturn(n),
         collectAll,
-        Fx.runSync
+        Fx.unsafeRun
       )
 
       assert.equal(r, n)
@@ -51,7 +51,7 @@ describe('Stream', () => {
         Stream.take(n - 1),
         Abort.orReturn('aborted'),
         collectAll,
-        Fx.runSync
+        Fx.unsafeRun
       )
 
       assert.equal(r, 'aborted')
@@ -68,7 +68,7 @@ describe('Stream', () => {
         Stream.take(n),
         Abort.orReturn('aborted'),
         collectAll,
-        Fx.runSync
+        Fx.unsafeRun
       )
 
       assert.equal(r, 'done')
@@ -88,8 +88,8 @@ describe('Stream', () => {
         })),
         collectAll,
         Fork.unbounded,
-        Fx.runAsync
-      ).promise
+        Fx.unsafeRunPromise
+      )
 
       assert.equal(r, 42)
       assert.deepEqual(events, ['24', 24n])
@@ -105,8 +105,7 @@ describe('Stream', () => {
       enqueueAllAsync(queue, expected)
 
       const [r, events] = await Stream.fromDequeue(queue)
-        .pipe(collectAll, Fx.runAsync)
-        .promise
+        .pipe(collectAll, Fx.unsafeRunPromise)
 
       assert.equal(r, undefined)
       assert.deepEqual(events, expected)
@@ -127,8 +126,7 @@ describe('Stream', () => {
           [Symbol.dispose]: () => { disposed = true }
         }
       }, queue)
-        .pipe(collectAll, Fx.runAsync)
-        .promise
+        .pipe(collectAll, Fx.unsafeRunPromise)
 
       assert.equal(r, undefined)
       assert.deepEqual(events, expected)
@@ -147,7 +145,7 @@ describe('Stream', () => {
       }
 
       const [r, events] = Stream.fromIterable(makeIterable())
-        .pipe(collectAll, Fx.runSync)
+        .pipe(collectAll, Fx.unsafeRun)
 
       assert.equal(r, 42)
       assert.deepEqual(events, inputs)
@@ -165,8 +163,7 @@ describe('Stream', () => {
       }
 
       const [r, events] = await Stream.fromAsyncIterable(makeAsyncGenerator)
-        .pipe(collectAll, Fx.runAsync)
-        .promise
+        .pipe(collectAll, Fx.unsafeRunPromise)
 
       assert.equal(r, 42)
       assert.deepEqual(events, inputs)
@@ -209,7 +206,7 @@ describe('Stream', () => {
         while (true) actual.push(yield* Sink.next<number>())
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runSync)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.unsafeRun)
 
       assert.equal(r, undefined)
       assert.deepEqual(actual, expected)
@@ -228,7 +225,7 @@ describe('Stream', () => {
         return 'sink'
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runSync)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.unsafeRun)
 
       assert.equal(r, 'sink')
       assert.deepEqual(actual, [1, 2, 3])
@@ -245,7 +242,7 @@ describe('Stream', () => {
         return 'sink'
       })
 
-      const r = stream.pipe(_ => Stream.to(_, sink), Fx.runSync)
+      const r = stream.pipe(_ => Stream.to(_, sink), Fx.unsafeRun)
 
       assert.equal(r, 'sink')
       assert.deepEqual(actual, expected)

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,4 +1,4 @@
-import { Async, run } from './Async'
+import { Async, assertPromise } from './Async'
 
 import { Fail, fail } from './Fail'
 import { Fx, fx, ok } from './Fx'
@@ -17,7 +17,7 @@ export class Task<A, E> {
 }
 
 export const wait = <const A, const E>(t: Task<A, E>) => fx(function* () {
-  const r = yield* run<Fx<E | Fail<unknown>, A>>(
+  const r = yield* assertPromise<Fx<E | Fail<unknown>, A>>(
     s => new Promise(resolve => void t.promise.then(
       a => { s.aborted || resolve(ok(a)) },
       e => { s.aborted || resolve(fail(e) as Fail<unknown>) }

--- a/src/Time.test.ts
+++ b/src/Time.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fx, unsafeRun, unsafeRunPromise } from './Fx'
+import { fx, run, runPromise } from './Fx'
 import * as Time from './Time'
 import { VirtualClock } from './internal/time'
 
@@ -9,7 +9,7 @@ describe('Time', () => {
     it('starts at origin', () => {
       const origin = Date.now()
       const c = new VirtualClock(origin)
-      const r = Time.now.pipe(Time.withClock(c), unsafeRun)
+      const r = Time.now.pipe(Time.withClock(c), run)
       assert.equal(r, origin)
     })
 
@@ -20,7 +20,7 @@ describe('Time', () => {
       const step = 10000 * Math.random()
       await c.step(step)
 
-      const r = Time.now.pipe(Time.withClock(c), unsafeRun)
+      const r = Time.now.pipe(Time.withClock(c), run)
       assert.equal(r, origin + Math.floor(step))
     })
   })
@@ -28,7 +28,7 @@ describe('Time', () => {
   describe('monotonic', () => {
     it('starts at 0', () => {
       const c = new VirtualClock(Date.now())
-      const r = Time.monotonic.pipe(Time.withClock(c), unsafeRun)
+      const r = Time.monotonic.pipe(Time.withClock(c), run)
       assert.equal(r, 0)
     })
 
@@ -39,7 +39,7 @@ describe('Time', () => {
       const step = 10000 * Math.random()
       await c.step(step)
 
-      const r = Time.monotonic.pipe(Time.withClock(c), unsafeRun)
+      const r = Time.monotonic.pipe(Time.withClock(c), run)
       assert.equal(r, step)
     })
   })
@@ -60,7 +60,7 @@ describe('Time', () => {
       })
 
       const c = new VirtualClock(1)
-      const p = test.pipe(Time.withClock(c), unsafeRunPromise)
+      const p = test.pipe(Time.withClock(c), runPromise)
 
       await c.step(1000)
       assert.deepEqual(results, [[1000, 1001]])

--- a/src/Time.test.ts
+++ b/src/Time.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { fx, runAsync, runSync } from './Fx'
+import { fx, unsafeRun, unsafeRunPromise } from './Fx'
 import * as Time from './Time'
 import { VirtualClock } from './internal/time'
 
@@ -9,7 +9,7 @@ describe('Time', () => {
     it('starts at origin', () => {
       const origin = Date.now()
       const c = new VirtualClock(origin)
-      const r = Time.now.pipe(Time.withClock(c), runSync)
+      const r = Time.now.pipe(Time.withClock(c), unsafeRun)
       assert.equal(r, origin)
     })
 
@@ -20,7 +20,7 @@ describe('Time', () => {
       const step = 10000 * Math.random()
       await c.step(step)
 
-      const r = Time.now.pipe(Time.withClock(c), runSync)
+      const r = Time.now.pipe(Time.withClock(c), unsafeRun)
       assert.equal(r, origin + Math.floor(step))
     })
   })
@@ -28,7 +28,7 @@ describe('Time', () => {
   describe('monotonic', () => {
     it('starts at 0', () => {
       const c = new VirtualClock(Date.now())
-      const r = Time.monotonic.pipe(Time.withClock(c), runSync)
+      const r = Time.monotonic.pipe(Time.withClock(c), unsafeRun)
       assert.equal(r, 0)
     })
 
@@ -39,7 +39,7 @@ describe('Time', () => {
       const step = 10000 * Math.random()
       await c.step(step)
 
-      const r = Time.monotonic.pipe(Time.withClock(c), runSync)
+      const r = Time.monotonic.pipe(Time.withClock(c), unsafeRun)
       assert.equal(r, step)
     })
   })
@@ -60,7 +60,7 @@ describe('Time', () => {
       })
 
       const c = new VirtualClock(1)
-      const p = test.pipe(Time.withClock(c), runAsync).promise
+      const p = test.pipe(Time.withClock(c), unsafeRunPromise)
 
       await c.step(1000)
       assert.deepEqual(results, [[1000, 1001]])

--- a/src/Time.ts
+++ b/src/Time.ts
@@ -37,7 +37,7 @@ export const sleep = (millis: number) => new Sleep(millis)
 export const withClock = (c: Clock) => <E, A>(f: Fx<E, A>): Fx<Handle<Handle<E, Sleep, Async.Async>, Now | Monotonic>, A> => f.pipe(
   handle(Now, () => ok(c.now)),
   handle(Monotonic, () => ok(c.monotonic)),
-  handle(Sleep, ms => Async.run(signal => new Promise(resolve => {
+  handle(Sleep, ms => Async.assertPromise(signal => new Promise(resolve => {
     const d = c.schedule(ms, () => {
       signal.removeEventListener('abort', disposeOnAbort)
       resolve()

--- a/src/internal/Queue.ts
+++ b/src/internal/Queue.ts
@@ -19,7 +19,7 @@ export interface Queue<A> extends Disposable {
 export type Enqueue<A> = Pick<Queue<A>, 'enqueue' | 'disposed' | keyof Disposable>
 export type Dequeue<A> = Pick<Queue<A>, 'dequeue' | 'disposed' | keyof Disposable>
 
-export const dequeue = <A>(q: Dequeue<A>): Fx<Async.Async, Dequeued<A> | Disposed> => Async.run(() => q.dequeue())
+export const dequeue = <A>(q: Dequeue<A>): Fx<Async.Async, Dequeued<A> | Disposed> => Async.assertPromise(() => q.dequeue())
 
 export class UnboundedQueue<A> implements Queue<A> {
   private readonly items: A[] = []


### PR DESCRIPTION
Since these will be used so infrequently, seems ok for them to have longer names, and use "unsafe" to indicate they actually initiate side-effects.