### PR TITLE
[codex] Add agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Notes
+
+`fx` is a small TypeScript algebraic effects and handlers library.
+
+Core idea:
+- Programs are `Fx<E, A>` generator computations.
+- Effects are yielded with `yield*`.
+- Handlers progressively eliminate effects via `handle`/`control`.
+- Keep the core minimal; avoid adding framework-like dependency graphs, schedulers, or service containers.
+
+Primary commands:
+- `npm test`
+- `npm run typecheck`
+- `npm run build`
+- `npm run lint`
+
+Development guidance:
+- Prefer existing patterns in `src/Fx.ts`, `src/Effect.ts`, and `src/Handler.ts`.
+- Preserve strong effect typing. Changes should keep `E` unions meaningful and narrowed by handlers.
+- Add focused tests under `src/*.test.ts` for behavior and type-level expectations where relevant.
+- Do not edit `dist/` directly; build output is generated.
+- Keep examples practical and small.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,17 @@
+# Example Notes
+
+Examples should demonstrate how applications are built from effects plus handlers.
+
+Good examples:
+- define small domain effects,
+- write business logic against those effects,
+- provide one or more handlers,
+- compose handlers with `.pipe(...)`,
+- end with `run`, `runPromise`, or `runTask`.
+
+Avoid:
+- turning examples into framework code,
+- hiding effect handling behind large helper layers,
+- depending on generated `dist/`.
+
+Examples may import from `../src` or `../../src` while developing locally.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,17 @@
+# Source Notes
+
+This directory contains the library implementation.
+
+Architecture:
+- `Fx.ts`: public computation type and combinators.
+- `Effect.ts`: effect construction and effect identity.
+- `Handler.ts`: public handler API.
+- `internal/Handler.ts`: generator-level handler machinery.
+- `internal/runFork.ts`: runtime for `Async`, `Fork`, `Fail`, and handler context.
+
+Rules for changes:
+- Effects should be ordinary `Effect(...)` classes unless runtime support is truly required.
+- Simple interpretation belongs in handlers, not in `Fx` itself.
+- Use `control` only when a handler needs to decide whether/how to resume.
+- Keep cleanup paths explicit: call iterator `return`, dispose tasks/resources, and preserve cooperative cancellation.
+- Favor small composable functions over new abstractions.


### PR DESCRIPTION
## Summary

Adds compact `AGENTS.md` guidance for future coding agents working in this repository.

## Changes

- Adds root-level project notes covering the purpose of `fx`, common commands, and general development expectations.
- Adds `src/AGENTS.md` with implementation-specific guidance for the core effect, handler, and runtime modules.
- Adds `examples/AGENTS.md` with expectations for keeping examples focused on effects plus handlers.

## Validation

- `npm run typecheck`