### PR TITLE
[codex] Add timestamps to HTTP server events

### DIFF
--- a/examples/http-counter/index.ts
+++ b/examples/http-counter/index.ts
@@ -57,10 +57,14 @@ await server.pipe(
 function logHttpServerEvent(event: ServerEvent) {
   switch (event.type) {
     case 'listening':
-      return info('HTTP server ready', addressData(event.address))
+      return info('HTTP server ready', {
+        timestamp: event.timestamp,
+        ...addressData(event.address)
+      })
 
     case 'request':
       return info('HTTP request', {
+        timestamp: event.timestamp,
         method: event.method,
         path: event.path,
         status: event.status,
@@ -69,6 +73,7 @@ function logHttpServerEvent(event: ServerEvent) {
 
     case 'requestFailed':
       return info('HTTP request failed', {
+        timestamp: event.timestamp,
         method: event.method,
         path: event.path,
         status: event.status,
@@ -77,7 +82,7 @@ function logHttpServerEvent(event: ServerEvent) {
       })
 
     case 'closed':
-      return info('HTTP server closed')
+      return info('HTTP server closed', { timestamp: event.timestamp })
   }
 }
 

--- a/examples/http-server-client/server.ts
+++ b/examples/http-server-client/server.ts
@@ -37,10 +37,14 @@ await server.pipe(
 function logHttpServerEvent(event: ServerEvent) {
   switch (event.type) {
     case 'listening':
-      return info('HTTP server ready', addressData(event.address))
+      return info('HTTP server ready', {
+        timestamp: event.timestamp,
+        ...addressData(event.address)
+      })
 
     case 'request':
       return info('HTTP request', {
+        timestamp: event.timestamp,
         method: event.method,
         path: event.path,
         status: event.status,
@@ -49,6 +53,7 @@ function logHttpServerEvent(event: ServerEvent) {
 
     case 'requestFailed':
       return info('HTTP request failed', {
+        timestamp: event.timestamp,
         method: event.method,
         path: event.path,
         status: event.status,
@@ -57,7 +62,7 @@ function logHttpServerEvent(event: ServerEvent) {
       })
 
     case 'closed':
-      return info('HTTP server closed')
+      return info('HTTP server closed', { timestamp: event.timestamp })
   }
 }
 

--- a/src/HttpServer.test.ts
+++ b/src/HttpServer.test.ts
@@ -164,15 +164,17 @@ describe('HttpServer', () => {
     it('emits listening with the actual bound address', async () => {
       const app = route('GET', '/health', () => ok(text('ok')))
       const events: ServerEvent[] = []
+      const before = Date.now()
 
       await withServer(createServer => serve(app, {
         port: 0,
         host: '127.0.0.1',
-          observe: event => ok(void events.push(event))
+        observe: event => ok(void events.push(event))
       }).pipe(
         nodeHttp({ createServer })
       ), async port => {
         const event = await waitForEvent(events, isListening)
+        const after = Date.now()
 
         assert.equal(typeof event.address, 'object')
         if (event.address === null) {
@@ -180,6 +182,7 @@ describe('HttpServer', () => {
         }
         assert.equal(event.address.host, '127.0.0.1')
         assert.equal(event.address.port, port)
+        assertTimestamp(event.timestamp, before, after)
       })
     })
 
@@ -190,12 +193,14 @@ describe('HttpServer', () => {
       await withServer(createServer => serve(app, {
         port: 0,
         host: '127.0.0.1',
-          observe: event => ok(void events.push(event))
+        observe: event => ok(void events.push(event))
       }).pipe(
         nodeHttp({ createServer })
       ), async port => {
+        const before = Date.now()
         const response = await httpGet(port, '/health')
         const event = await waitForEvent(events, isRequest)
+        const after = Date.now()
 
         assert.equal(response.status, 200)
         assert.deepEqual(
@@ -213,6 +218,7 @@ describe('HttpServer', () => {
           }
         )
         assert.equal(event.durationMs >= 0, true)
+        assertTimestamp(event.timestamp, before, after)
       })
     })
 
@@ -361,12 +367,15 @@ describe('HttpServer', () => {
       }).pipe(
         nodeHttp({ createServer })
       ), async port => {
+        const before = Date.now()
         const response = await httpGet(port, '/fail')
         const event = await waitForEvent(events, isRequestFailed)
+        const after = Date.now()
 
         assert.equal(response.status, 500)
         assert.equal(event.status, 500)
         assert.equal(event.error, failure)
+        assertTimestamp(event.timestamp, before, after)
       })
     })
 
@@ -522,6 +531,12 @@ const isRequestFailed = (
   event: ServerEvent
 ): event is Extract<ServerEvent, { readonly type: 'requestFailed' }> =>
   event.type === 'requestFailed'
+
+const assertTimestamp = (timestamp: number, before: number, after: number): void => {
+  assert.equal(Number.isInteger(timestamp), true)
+  assert.equal(timestamp >= before, true)
+  assert.equal(timestamp <= after, true)
+}
 
 const httpGet = (
   port: number,

--- a/src/HttpServer.ts
+++ b/src/HttpServer.ts
@@ -40,11 +40,13 @@ export type ServerAddress = {
 
 export type ServerListening = {
   readonly type: 'listening'
+  readonly timestamp: number
   readonly address: ServerAddress | null
 }
 
 export type ServerRequestCompleted = {
   readonly type: 'request'
+  readonly timestamp: number
   readonly method: Method
   readonly path: string
   readonly status: number
@@ -53,6 +55,7 @@ export type ServerRequestCompleted = {
 
 export type ServerRequestFailed = {
   readonly type: 'requestFailed'
+  readonly timestamp: number
   readonly method: Method
   readonly path: string
   readonly status: number
@@ -62,6 +65,7 @@ export type ServerRequestFailed = {
 
 export type ServerClosed = {
   readonly type: 'closed'
+  readonly timestamp: number
 }
 
 export type ResponseBody<_E = never> =

--- a/src/HttpServerNode.ts
+++ b/src/HttpServerNode.ts
@@ -83,7 +83,7 @@ const runNodeServer = <E, OE>(
         void runNodeRequest(compiled, request.context, events, incoming, outgoing)
       }),
       server => closeNodeServer(server).pipe(
-        flatMap(() => observe({ type: 'closed' }))
+        flatMap(() => observe({ type: 'closed', timestamp: eventTimestamp() }))
       ),
       server => drainNodeHttpEvents(events, server, observe)
     )
@@ -139,7 +139,11 @@ const startNodeServer = (
         onAbort()
         return
       }
-      events.enqueue({ type: 'listening', address: toServerAddress(server.address?.() ?? null) })
+      events.enqueue({
+        type: 'listening',
+        timestamp: eventTimestamp(),
+        address: toServerAddress(server.address?.() ?? null)
+      })
       resolve({ server, cleanup })
     })
 
@@ -243,6 +247,7 @@ const runNodeRequest = async <E>(
     const finalStatus = outgoing.headersSent ? outgoing.statusCode : status
     const event = failure ? {
       type: 'requestFailed' as const,
+      timestamp: eventTimestamp(),
       method: request.method,
       path: request.path,
       status: finalStatus,
@@ -250,6 +255,7 @@ const runNodeRequest = async <E>(
       error: failure.error
     } : {
       type: 'request' as const,
+      timestamp: eventTimestamp(),
       method: request.method,
       path: request.path,
       status: finalStatus,
@@ -270,6 +276,9 @@ const writeInternalServerError = (
       headers: [['content-type', 'text/plain; charset=utf-8']],
       body: { type: 'text', value: 'Internal Server Error' }
     })
+
+const eventTimestamp = (): number =>
+  Date.now()
 
 const toServerRequest = (request: IncomingMessage): ServerRequest => {
   const url = new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`)


### PR DESCRIPTION
## Summary

Adds wall-clock timestamps to the HTTP server observation event contract and updates the Node HTTP interpreter to populate them when events are created.

## Motivation

Observers should receive the time the server event actually occurred, not the later time at which an observer drains or handles the event. This makes the event stream more useful for logging, correlation, and telemetry while keeping request duration measured separately with a monotonic clock.

## Approach

- Add `timestamp: number` to every `ServerEvent` variant.
- Populate timestamps in `nodeHttp` with `Date.now()` for `listening`, `request`, `requestFailed`, and `closed` events.
- Preserve `durationMs` for request events using `performance.now()`.
- Update HTTP examples to log observed event timestamps.
- Add focused timestamp assertions for listening, successful request, and failed request events.

## Validation

- `node --import tsx --test src/HttpServer.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test`