### PR TITLE
[codex] Refactor handlers to receive effect instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const getUser = fx(function* () {
 
 const program =
   getUser.pipe(
-    handle(DbQuery, ({ sql, params }) => runQuery(sql, params)),
+    handle(DbQuery, ({ arg: { sql, params } }) => runQuery(sql, params)),
     defaultConsole,
     runPromise
   )

--- a/benchmarks/runtime-context.ts
+++ b/benchmarks/runtime-context.ts
@@ -36,7 +36,7 @@ const ProgramIterations = 25_000
 const EffectsPerProgram = 100
 const context: RuntimeContext = { traceCapturePolicy: 'off' }
 
-const pingHandler = handle(Ping, n => ok(n + 1))
+const pingHandler = handle(Ping, ping => ok(ping.arg + 1))
 const program = pingProgram(EffectsPerProgram)
 const programOff = program.pipe(withTraceCapture('off'))
 const programLabels = program.pipe(withTraceCapture('labels'))

--- a/examples/echo.ts
+++ b/examples/echo.ts
@@ -20,13 +20,13 @@ const main = fx(function* () {
   }
 })
 
-const handlePrint = handle(Print, s => ok(console.log(s)))
+const handlePrint = handle(Print, print => ok(console.log(print.arg)))
 
 const handleRead = <E, A>(f: Fx<E, A>) => bracket(
   assertSync(() => createInterface({ input: process.stdin, output: process.stdout })),
   readline => ok(readline.close()),
   readline => f.pipe(
-    handle(Read, prompt => assertPromise(signal => readline.question(prompt, { signal })))
+    handle(Read, read => assertPromise(signal => readline.question(read.arg, { signal })))
   ))
 
 // Run with "real" Read and Print effects
@@ -36,7 +36,7 @@ await main.pipe(handleRead, handlePrint, runPromise)
 // const handlePrintPure = <E, A>(f: Fx<E, A>) => {
 //   const printed = [] as string[]
 //   return f.pipe(
-//     handle(Print, s => ok(void printed.push(s))),
+//     handle(Print, print => ok(void printed.push(print.arg))),
 //     map(_ => printed)
 //   )
 // }

--- a/examples/effect-ts/retry.ts
+++ b/examples/effect-ts/retry.ts
@@ -1,8 +1,12 @@
-import { flatMap, runPromise, tap } from "../../src"
+import { flatMap, runPromise, setTraceCapturePolicy, tap } from "../../src"
 import { defaultConsole, error, log } from "../../src/Console"
 import { catchAll } from "../../src/Fail"
 import { expectSuccess, json, request, w3cFetch } from "../../src/HttpClient"
 import { defaultRetry, retry } from "../../src/Retry"
+import { formatDiagnostic } from '../../src/Trace'
+import { nodeSourceLookup } from '../../src/TraceNode'
+
+setTraceCapturePolicy('full')
 
 const findUserById = (id: number) => request({
   url: new URL(`https://jsonplaceholderx.typicode.com/users/${id}`)
@@ -22,7 +26,7 @@ await main.pipe(
   defaultRetry({ // with attempt logging
     observe: event => log(`Attempt ${event.attempt}`, event)
   }),
-  catchAll(e => error(`Error fetching user`, e)),
+  catchAll(e => error(`Error fetching user`, formatDiagnostic(e, { source: { lookup: nodeSourceLookup() } }))),
   defaultConsole,
   runPromise
 )

--- a/examples/fp-to-the-max/index.ts
+++ b/examples/fp-to-the-max/index.ts
@@ -12,17 +12,17 @@ import { int, defaultRandom } from '../../src/Random'
 
 import { GenerateSecret, Print, Read, main } from './main'
 
-const handlePrint = handle(Print, s => ok(console.log(s)))
+const handlePrint = handle(Print, print => ok(console.log(print.arg)))
 
 const handleRead = <E, A>(f: Fx<E, A>) => bracket(
   assertSync(() => createInterface({ input: process.stdin, output: process.stdout })),
   readline => ok(readline.close()),
   readline => f.pipe(
-    handle(Read, prompt => assertPromise(signal => readline.question(prompt, { signal })))
+    handle(Read, read => assertPromise(signal => readline.question(read.arg, { signal })))
   ))
 
 const handleGenerateSecret = handle(GenerateSecret, max => fx(function* () {
-  return 1 + (yield* int(max))
+  return 1 + (yield* int(max.arg))
 }))
 
 const { max = 10 } = process.env

--- a/examples/fp-to-the-max/main.test.ts
+++ b/examples/fp-to-the-max/main.test.ts
@@ -14,7 +14,7 @@ import { GenerateSecret, Print, Read, checkAnswer, main } from './main'
 const handlePrint = <E, A>(f: Fx<E, A>) => {
   const printed = [] as string[]
   return f.pipe(
-    handle(Print, s => ok(void printed.push(s))),
+    handle(Print, print => ok(void printed.push(print.arg))),
     map(_ => printed)
   )
 }
@@ -23,7 +23,7 @@ const handleRead = ([...inputs]: readonly string[]) =>
   handle(Read, _ => ok(inputs.shift()!))
 
 const handleGenerateSecret = ([...values]: readonly number[]) =>
-  handle(GenerateSecret, max => ok(Math.min(max, values.shift()!)))
+  handle(GenerateSecret, max => ok(Math.min(max.arg, values.shift()!)))
 
 // #endregion
 // -------------------------------------------------------------------

--- a/examples/http-counter/counter-keyv.ts
+++ b/examples/http-counter/counter-keyv.ts
@@ -10,9 +10,9 @@ export const keyvCounter = <E, A>(f: Fx<E, A>) => bracket(
   assertSync(() => new Keyv<number>('sqlite://http-counter.sqlite')),
   db => assertPromise(() => db.disconnect()),
   db => f.pipe(
-    handle(Next, key => fx(function* () {
-      const value = (yield* get(db, key)) + 1
-      yield* set(db, key, value)
+    handle(Next, next => fx(function* () {
+      const value = (yield* get(db, next.arg)) + 1
+      yield* set(db, next.arg, value)
       return value
     })
     ))

--- a/examples/http-counter/counter-map.ts
+++ b/examples/http-counter/counter-map.ts
@@ -6,9 +6,9 @@ import { Next } from './counter.js'
 export const mapCounter = <E, A>(f: Fx<E, A>) => {
   const store = new Map<string, number>()
   return f.pipe(
-    handle(Next, key => {
-      const value = (store.get(key) ?? 0) + 1
-      store.set(key, value)
+    handle(Next, next => {
+      const value = (store.get(next.arg) ?? 0) + 1
+      store.set(next.arg, value)
       return ok(value)
     })
   )

--- a/examples/http-server-client/api.ts
+++ b/examples/http-server-client/api.ts
@@ -36,8 +36,8 @@ export function memoryNotes() {
   return <E, A>(program: Fx<E, A>) =>
     program.pipe(
       handle(ListNotes, () => ok(notes)),
-      handle(AddNote, (text: string) => {
-        const note = { id: String(nextId++), text }
+      handle(AddNote, addNote => {
+        const note = { id: String(nextId++), text: addNote.arg }
         notes.push(note)
         return ok(note)
       })

--- a/examples/state.ts
+++ b/examples/state.ts
@@ -18,7 +18,7 @@ const withState = <const E, const A, const S = State<E>>(s: S, f: Fx<E, A>) => {
   return f.pipe(
     handle(Get, _ => ok(state)),
     handle(Set, newState => {
-      state = newState as S
+      state = newState.arg as S
       return ok(undefined)
     }),
     map(a => [a, state])

--- a/examples/wttr-client/wttr-http.ts
+++ b/examples/wttr-client/wttr-http.ts
@@ -2,7 +2,7 @@ import { flatMap, handle, map } from '../../src'
 import { expectSuccess, json, request } from '../../src/HttpClient'
 import { GetWeather, Weather } from './wttr'
 
-export const wttrHttp = handle(GetWeather, ({ location }) =>
+export const wttrHttp = handle(GetWeather, ({ arg: { location } }) =>
   request({
     url: new URL(`https://wttr.in/${encodeURIComponent(location ?? '')}?format=j1`),
     headers: [['accept', 'application/json']]

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -223,8 +223,8 @@ export const bounded = (maxConcurrency: number) => <const E, const A>(f: Fx<E, A
 export const unbounded = bounded(Infinity)
 
 const runForkWith = (s: Semaphore) =>
-  (f: ForkContext): Fx<never, Task<unknown, unknown>> =>
-    ok(acquireAndRunFork(f, s))
+  (fork: Fork): Fx<never, Task<unknown, unknown>> =>
+    ok(acquireAndRunFork(fork.arg, s))
 
 const childFrameKind = (trace: Trace | undefined) =>
   trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'
@@ -246,27 +246,27 @@ const childTraceOrigin = (parent: TraceOrigin, index: number, kind: TraceFrameKi
 }
 
 const runAll = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  a: ConcurrentContext<Fxs>
+  all: All<Fxs>
 ): Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
   readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
 }> =>
-  forkEach(a.fxs, a).pipe(
+  forkEach(all.arg.fxs, all.arg).pipe(
     flatMap(tasks => waitTask(taskAll(tasks)))
   ) as Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
     readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
   }>
 
 const runRace = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  r: ConcurrentContext<Fxs>
+  race: Race<Fxs>
 ): Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, ResultOf<Fxs[number]>> =>
-  forkEach(r.fxs, r).pipe(
+  forkEach(race.arg.fxs, race.arg).pipe(
     flatMap(tasks => waitTask(taskRace(tasks)))
   ) as Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, ResultOf<Fxs[number]>>
 
 const runFirstSuccessRace = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  r: ConcurrentContext<Fxs>
+  race: Race<Fxs>
 ): Fx<Fork | Async | FirstSuccessRaceFailure<Race<Fxs>>, ResultOf<Fxs[number]>> =>
-  forkEach(r.fxs, r).pipe(
+  forkEach(race.arg.fxs, race.arg).pipe(
     flatMap(tasks => waitTask(taskFirstSuccess(tasks)))
   ) as Fx<Fork | Async | FirstSuccessRaceFailure<Race<Fxs>>, ResultOf<Fxs[number]>>
 

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -14,6 +14,6 @@ export const error = (...args: readonly unknown[]) => new Error(args)
 
 export const defaultConsole = <const E, const A>(f: Fx<E, A>) =>
   f.pipe(
-    handle(Log, args => ok(globalThis.console.log(...args))),
-    handle(Error, args => ok(globalThis.console.error(...args)))
+    handle(Log, log => ok(globalThis.console.log(...log.arg))),
+    handle(Error, error => ok(globalThis.console.error(...error.arg)))
   )

--- a/src/Env.test.ts
+++ b/src/Env.test.ts
@@ -128,7 +128,7 @@ describe('Env', () => {
         withUser,
         provideAll({ request }),
         handle(Authenticate, request => fx(function* () {
-          return { id: `user:${request.id}` }
+          return { id: `user:${request.arg.id}` }
         }))
       ))
 
@@ -157,7 +157,7 @@ describe('Env', () => {
 
       // @ts-expect-error request remains required
       const _missingRequest: Fx<never, string> = secured.pipe(handle(Authenticate, request => fx(function* () {
-        return { id: `user:${request.id}` }
+        return { id: `user:${request.arg.id}` }
       })))
 
       // @ts-expect-error Authenticate remains required
@@ -166,7 +166,7 @@ describe('Env', () => {
       const actual = run(secured.pipe(
         provideAll({ request }),
         handle(Authenticate, request => fx(function* () {
-          return { id: `user:${request.id}` }
+          return { id: `user:${request.arg.id}` }
         }))
       ))
 

--- a/src/Fail.ts
+++ b/src/Fail.ts
@@ -34,8 +34,8 @@ export const catchIf = <const E1, const E extends ExtractFail<E1>, const E2, con
   handle: (e: E) => Fx<E2, B>
 ) => <const A>(f: Fx<E1, A>): Fx<Exclude<E1, Fail<E>> | E2, A | B> =>
     f.pipe(
-      control(Fail<ExtractFail<E>>, (_, e) =>
-        (match(e) ? handle(e) : fail(e)) as Fx<Exclude<E1, Fail<E>> | E2, A | B>)
+      control(Fail<ExtractFail<E>>, (_, failure) =>
+        (match(failure.arg) ? handle(failure.arg) : failure) as Fx<Exclude<E1, Fail<E>> | E2, A | B>)
     ) as Fx<Exclude<E1, Fail<E>> | E2, A | B>
 
 type AnyConstructor = abstract new (...args: any[]) => any
@@ -91,14 +91,14 @@ export const returnAll = <const E, const A>(f: Fx<E, A>) => f.pipe(catchAll(ok))
  *   const resultOrFail = computation.pipe(returnFail)
  */
 export const returnFail = <const E, const A>(f: Fx<E, A>) =>
-  f.pipe(catchAll(e => ok(fail(e)))) as Fx<Exclude<E, Fail<any>>, A | Extract<E, Fail<any>>>
+  f.pipe(control(Fail<any>, (_, failure) => ok(failure))) as Fx<Exclude<E, Fail<any>>, A | Extract<E, Fail<any>>>
 
 /**
  * Assert that an Fx does not fail, throwing the error if it does.
  * @example
  *   const result = trySync(f).pipe(assert) // Crashes if f fails
  */
-export const assert = control(Fail<any>, (_, e) => { throw e })
+export const assert = control(Fail<any>, (_, failure) => { throw failure.arg })
 
 type UnwrapFail<F> = F extends Fail<infer E> ? E : never
 type ExtractFail<F> = UnwrapFail<Extract<F, Fail<any>>>

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -5,7 +5,7 @@ import { Effect } from './Effect.js'
 import { provideAll } from './Env.js'
 import { Fail, returnFail } from './Fail.js'
 import { assertSync, flatMap, fx, ok, run, runPromise, runTask, trySync } from './Fx.js'
-import { handle } from './Handler.js'
+import { control, handle } from './Handler.js'
 import { getTrace } from './Trace.js'
 
 describe('Fx', () => {
@@ -65,12 +65,54 @@ describe('Fx', () => {
 
       const r = new E1(1).pipe(
         flatMap(a => new E2(`${a}`)),
-        handle(E1, ok),
-        handle(E2, ok),
+        handle(E1, e => ok(e.arg)),
+        handle(E2, e => ok(e.arg)),
         run
       )
 
       assert.equal(r, '1')
+    })
+
+    it('handler callbacks receive the original effect instance', () => {
+      class Request extends Effect('Request')<number, number> {
+        readonly metadata = 'request metadata'
+      }
+
+      let handled: Request | undefined
+      const request = new Request(1)
+
+      const actual = request.pipe(
+        handle(Request, effect => {
+          handled = effect
+          return ok(effect.arg + 1)
+        }),
+        run
+      )
+
+      assert.equal(actual, 2)
+      assert.equal(handled, request)
+      assert.equal(handled.metadata, 'request metadata')
+    })
+
+    it('control callbacks receive the original effect instance', () => {
+      class Request extends Effect('ControlledRequest')<number, number> {
+        readonly metadata = 'controlled metadata'
+      }
+
+      let handled: Request | undefined
+      const request = new Request(1)
+
+      const actual = request.pipe(
+        control(Request, (resume, effect) => {
+          handled = effect
+          return ok(resume(effect.arg + 1))
+        }),
+        run
+      )
+
+      assert.equal(actual, 2)
+      assert.equal(handled, request)
+      assert.equal(handled.metadata, 'controlled metadata')
     })
 
     it('has ok as left identity', () => {

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -1,6 +1,7 @@
 import { EffectType } from './Effect.js'
 import { Fx } from './Fx.js'
 import { Answer, Arg, Control, Handler } from './internal/Handler.js'
+export type { Arg }
 
 export type Handle<E, A, B = never> = E extends A ? B : E
 
@@ -8,7 +9,7 @@ export type HandleReturn<E, A, R> = E extends A ? R : never
 
 export const handle = <T extends EffectType, HandlerEffects>(
   e: T,
-  f: (e: Arg<T>) => Fx<HandlerEffects, Answer<T>>
+  f: (effect: InstanceType<T>) => Fx<HandlerEffects, Answer<T>>
 ) => <const E, const A>(
   fx: Fx<E, A>
 ): Fx<Handle<E, InstanceType<T>, HandlerEffects>, A> =>
@@ -16,7 +17,7 @@ export const handle = <T extends EffectType, HandlerEffects>(
 
 export const control = <T extends EffectType, HandlerEffects = never, R = never>(
   e: T,
-  f: <A>(resume: (a: Answer<T>) => A, e: Arg<T>) => Fx<HandlerEffects, R>
+  f: <A>(resume: (a: Answer<T>) => A, effect: InstanceType<T>) => Fx<HandlerEffects, R>
 ) => <const E, const A>(
   fx: Fx<E, A>
 ): Fx<Handle<E, InstanceType<T>, HandlerEffects>, HandleReturn<E, InstanceType<T>, R> | A> =>

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -272,7 +272,7 @@ export const w3cFetch = ({
 }: W3CFetchOptions = {}) =>
   <const E, const A>(f: Fx<E, A>) =>
     f.pipe(
-      handle(HttpRequest, r =>
+      handle(HttpRequest, ({ arg: r }) =>
         tryPromise(signal =>
           fetch(r.url, init(r, toFetchRequest(r, signal))).then(toResponse)
         ).pipe(

--- a/src/HttpServerNode.ts
+++ b/src/HttpServerNode.ts
@@ -59,7 +59,7 @@ export const nodeHttp = ({
   <const E, const A>(f: Fx<E, A>): Fx<NodeHttpHandled<E>, A> =>
     scoped(ServeScope, f).pipe(
       flatMap(fx =>
-        ok(fx.pipe(handleScoped(ServeScope, Serve, r => runNodeServer(r, makeServer))))
+        ok(fx.pipe(handleScoped(ServeScope, Serve, serve => runNodeServer(serve.arg, makeServer))))
       ),
       flatten
     ) as Fx<NodeHttpHandled<E>, A>

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -27,7 +27,7 @@ export interface LogMessage {
   readonly data?: { readonly [key: string]: unknown }
 }
 
-export const console = handle(Log, ({ level, component, ...m }) => fx(function* () {
+export const console = handle(Log, ({ arg: { level, component, ...m } }) => fx(function* () {
   const console = globalThis.console
   const l = Level[level].padEnd(5, ' ')
   const t = new Date(yield* now).toISOString()
@@ -44,13 +44,17 @@ export const console = handle(Log, ({ level, component, ...m }) => fx(function* 
 export const collect = <const E, const A>(f: Fx<E | Log, A>) => fx(function* () {
   const log = [] as LogMessage[]
   return yield* f.pipe(
-    handle(Log, m => ok(void log.push(m))),
+    handle(Log, message => ok(void log.push(message.arg))),
     mapFx(a => [a, log as readonly LogMessage[]])
   )
 })
 
 export const minLevel = (min: Level) =>
-  handle(Log, m => m.level < min ? unit : log(m))
+  handle(Log, message => message.arg.level < min ? unit : log(message.arg))
 
 export const child = <C extends { readonly [key: string]: unknown }>(component: string, context?: C) =>
-  handle(Log, m => log({ ...m, component: [component, ...m.component], data: { ...context, ...m.data } }))
+  handle(Log, message => log({
+    ...message.arg,
+    component: [component, ...message.arg.component],
+    data: { ...context, ...message.arg.data }
+  }))

--- a/src/Random.ts
+++ b/src/Random.ts
@@ -61,11 +61,11 @@ export const defaultRandom = (seed: number = generateSeed()) =>
   xoroshiro128plus(seed)
 
 const runXoroShiro128Plus = <const E, const A>(gen: XoroShiro128Plus, f: Fx<E, A>): Fx<Exclude<E, Random>, A> => f.pipe(
-  handle(Int, max => ok(uniformIntMax(max, gen))),
+  handle(Int, max => ok(uniformIntMax(max.arg, gen))),
   handle(Float, _ => ok(uniformFloat(gen))),
   handle(Split, f => {
     const gen2 = gen.clone()
     gen2.unsafeJump()
-    return ok(runXoroShiro128Plus(gen2, f))
+    return ok(runXoroShiro128Plus(gen2, f.arg))
   })
 ) as Fx<Exclude<E, Random>, A>

--- a/src/Retry.test.ts
+++ b/src/Retry.test.ts
@@ -6,7 +6,8 @@ import { fx, ok, run, runPromise } from './Fx.js'
 import { handle } from './Handler.js'
 import { RetryEvent, defaultRetry, retry } from './Retry.js'
 import { sleep, withClock } from './Time.js'
-import { getTrace, snapshotError } from './Trace.js'
+import { formatDiagnostic, getTrace, setTraceCapturePolicy, snapshotError, withTraceCapture } from './Trace.js'
+import { nodeSourceLookup } from './TraceNode.js'
 import { VirtualClock } from './internal/time.js'
 
 describe('Retry', () => {
@@ -62,20 +63,82 @@ describe('Retry', () => {
     ])
   })
 
-  it('attaches one retry trace frame when retries are exhausted', () => {
-    const cause = new Error('nope')
+  it('attaches failure and retry trace frames when retries are exhausted', () => {
+    const previous = setTraceCapturePolicy('full')
+    try {
+      const cause = new Error('nope')
 
-    const r = fail(cause).pipe(
-      retry({ retries: 5 }),
-      defaultRetry(),
-      returnFail,
-      run
-    )
+      const r = fail(cause).pipe(
+        retry({ retries: 5 }),
+        defaultRetry(),
+        returnFail,
+        run
+      )
+
+      assert.ok(Fail.is(r))
+      assert.equal(r.arg, cause)
+      assert.equal(r.trace?.frame.message, 'fx/Fail/fail')
+      assert.equal(r.trace?.parent, undefined)
+      assert.deepEqual(traceMessages(cause), ['fx/Fail/fail', 'fx/Retry/retry'])
+
+      const frames = snapshotError(cause).trace?.frames ?? []
+      assert.equal(frames[0]?.kind, 'fail')
+      assert.ok(frames[0]?.location?.file?.endsWith('Retry.test.ts'))
+      assert.doesNotMatch(frames[0]?.location?.file ?? '', /\/Fail\.ts$/)
+      assert.equal(frames[1]?.kind, 'retry')
+      assert.ok(frames[1]?.location?.file?.endsWith('Retry.test.ts'))
+      assert.equal(typeof frames[1]?.location?.line, 'number')
+      assert.equal(typeof frames[1]?.location?.column, 'number')
+      assert.doesNotMatch(frames[1]?.location?.file ?? '', /internal\/pipe/)
+    } finally {
+      setTraceCapturePolicy(previous)
+    }
+  })
+
+  it('preserves label-only retry traces without locations', async () => {
+    const cause = new Error('nope')
+    const program = fx(function* () {
+      return yield* fail(cause).pipe(retry({ retries: 0 }), defaultRetry())
+    })
+
+    const r = await program.pipe(withTraceCapture('labels'), returnFail, runPromise)
 
     assert.ok(Fail.is(r))
     assert.equal(r.arg, cause)
-    assert.deepEqual(traceMessages(cause), ['fx/Retry/retry'])
-    assert.equal(snapshotError(cause).trace?.frames[0].kind, 'retry')
+    assert.deepEqual(traceMessages(cause), ['fx/Fail/fail', 'fx/Retry/retry'])
+    assert.equal(snapshotError(cause).trace?.frames[0]?.location, undefined)
+    assert.equal(snapshotError(cause).trace?.frames[1]?.location, undefined)
+  })
+
+  it('formats source snippets for retry-only traces', () => {
+    const cause = new Error('nope')
+    const previous = setTraceCapturePolicy('off')
+    const failed = fail(cause)
+
+    try {
+      setTraceCapturePolicy('full')
+      const r = failed.pipe(
+        retry({ retries: 0 }),
+        defaultRetry(),
+        returnFail,
+        run
+      )
+
+      assert.ok(Fail.is(r))
+      assert.equal(r.arg, cause)
+
+      const formatted = formatDiagnostic(cause, {
+        colors: 'never',
+        source: { lookup: nodeSourceLookup() }
+      })
+
+      assert.match(formatted, /at fx\/Retry\/retry \[retry\]/)
+      assert.match(formatted, /src\/Retry\.test\.ts:\d+:\d+/)
+      assert.match(formatted, /\d+ \|/)
+      assert.match(formatted, /\| +\^/)
+    } finally {
+      setTraceCapturePolicy(previous)
+    }
   })
 
   it('stops retrying when the predicate rejects the failure', () => {

--- a/src/Retry.ts
+++ b/src/Retry.ts
@@ -4,7 +4,7 @@ import { Fail, returnFail } from './Fail.js'
 import { flatMap, flatten, Fx, fx, ok, unit } from './Fx.js'
 import { Handle } from './Handler.js'
 import { Scoped, handleScoped, scoped } from './Scoped.js'
-import { Trace, attachTrace, captureTrace } from './Trace.js'
+import { Trace, appendTrace, attachTrace, captureTrace } from './Trace.js'
 
 /**
  * A retry effect. Programs yield {@link Retry} values to request that a
@@ -15,9 +15,9 @@ export class Retry<const E, const A> extends Effect('fx/Retry')<RetryContext<E, 
 /**
  * Request that an Fx be retried when it fails.
  */
-export const retry = <const RE>(options: RetryOptions<RE>) =>
-  <const E, const A>(f: Fx<E, A>): Fx<Exclude<E, Fail<any>> | Retry<ErrorsOf<E>, A> | Scoped<'fx/Retry'>, A> => {
-    const origin = at('fx/Retry/retry', retry)
+export const retry = <const RE>(options: RetryOptions<RE>) => {
+  function retryWith<const E, const A>(f: Fx<E, A>): Fx<Exclude<E, Fail<any>> | Retry<ErrorsOf<E>, A> | Scoped<'fx/Retry'>, A> {
+    const origin = at('fx/Retry/retry', retryWith)
     const trace = captureTrace(origin, undefined, { kind: 'retry' })
 
     return scoped('fx/Retry', f).pipe(
@@ -31,6 +31,9 @@ export const retry = <const RE>(options: RetryOptions<RE>) =>
       flatten
     )
   }
+
+  return retryWith
+}
 
 /**
  * Handle Retry by rerunning the captured Fx until it succeeds, the retry budget
@@ -84,7 +87,8 @@ export type ErrorsOf<E> = UnwrapFail<Extract<E, Fail<any>>>
 export type ErrorsOfRetry<E> = E extends Retry<infer R, any> ? R : never
 
 const runRetry = <OE>(observe: (e: RetryEvent) => Fx<OE, void>) =>
-  <const E, const A>(r: RetryContext<E, A>): Fx<never, Fx<Fail<E> | OE, A>> => ok(fx(function* () {
+  <const E, const A>(retry: Retry<E, A>): Fx<never, Fx<Fail<E> | OE, A>> => ok(fx(function* () {
+    const r = retry.arg
     let attempt = 1
 
     while (true) {
@@ -98,7 +102,9 @@ const runRetry = <OE>(observe: (e: RetryEvent) => Fx<OE, void>) =>
       const retrying = attempt <= r.retries && r.while(result.arg, attempt)
       yield* observe({ type: 'failure', attempt, failure: result.arg, retrying })
       if (!retrying) {
-        if (typeof result.arg === 'object' && result.arg !== null && r.trace !== undefined) attachTrace(result.arg, r.trace)
+        if (typeof result.arg === 'object' && result.arg !== null && r.trace !== undefined) {
+          attachTrace(result.arg, result.trace === undefined ? r.trace : appendTrace(result.trace, r.trace))
+        }
         return yield* result
       }
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -15,7 +15,7 @@ export const finalize = <E>(f: Fx<E, void>) =>
 export const scope = <const E, const A>(f: Fx<E, A>) => fx(function* () {
   const finalizers = [] as Fx<unknown, unknown>[]
   const result = yield* f.pipe(
-    handle(Finalize, f => ok(void finalizers.push(f))),
+    handle(Finalize, finalize => ok(void finalizers.push(finalize.arg))),
     returnFail
   )
 

--- a/src/Scoped.ts
+++ b/src/Scoped.ts
@@ -1,6 +1,6 @@
 import { Effect, EffectType, isEffect } from './Effect.js'
 import { Fx, map } from './Fx.js'
-import { Answer, Arg, Handler } from './internal/Handler.js'
+import { Answer, Handler } from './internal/Handler.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 
 export interface HandlerContext {
@@ -37,7 +37,7 @@ export const closeScoped = <const Name extends string>(name: Name) =>
 export const handleScoped = <const Name extends string, T extends EffectType, HandlerEffects>(
   name: Name,
   e: T,
-  f: (e: Arg<T>) => Fx<HandlerEffects, Answer<T>>
+  f: (effect: InstanceType<T>) => Fx<HandlerEffects, Answer<T>>
 ) => <const E, const A>(
   fx: Fx<E, A>
 ): Fx<Handle<Handle<E, InstanceType<T>, HandlerEffects>, Scoped<Name>>, A> =>

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -37,17 +37,17 @@ export const repeat = <const E, const A>(f: Fx<E, A>): Fx<E | Stream<A>, void> =
  * Apply an effectful function to each value in a stream
  */
 export const forEach = <E, R, E2>(f: Fx<E, R>, each: (a: Event<E>) => Fx<E2, void>): Fx<ExcludeStream<E, E2>, R> =>
-  f.pipe(handle(Stream, a => each(a as Event<E>)))
+  f.pipe(handle(Stream, stream => each(stream.arg as Event<E>)))
 
 /**
  * Take the first n values from a stream
  */
 export const take = (n: number) => <const E, const A, const R>(f: Fx<E | Stream<A>, R>) => {
   let i = n
-  return f.pipe(control(Stream, (resume, a) => gen(function* () {
+  return f.pipe(control(Stream, (resume, stream) => gen(function* () {
     if (i > 0) {
       --i
-      return resume(yield* emit(a))
+      return resume(yield* emit(stream.arg))
     } else {
       return yield* abort
     }

--- a/src/Time.ts
+++ b/src/Time.ts
@@ -40,8 +40,8 @@ export const sleep = (ms: number) => new Sleep(ms)
 export const withClock = (c: Clock) => <E, A>(f: Fx<E, A>): Fx<Handle<Handle<E, Sleep, Async>, Now | Monotonic>, A> => f.pipe(
   handle(Now, () => ok(c.now())),
   handle(Monotonic, () => ok(c.monotonic())),
-  handle(Sleep, ms => assertPromise(signal => new Promise(resolve => {
-    const d = c.schedule(ms, () => {
+  handle(Sleep, sleep => assertPromise(signal => new Promise(resolve => {
+    const d = c.schedule(sleep.arg, () => {
       signal.removeEventListener('abort', disposeOnAbort)
       resolve()
     })

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -95,7 +95,8 @@ export type ErrorsOf<E> = UnwrapFail<Extract<E, Fail<any>>>
 export type ErrorsOfTimeout<E> = E extends Timeout<infer R, any, any> ? R : never
 export type TimeoutErrorOf<E> = E extends Timeout<any, any, infer TE> ? TE : never
 
-const runTimeout = <const E, const A, const TE>(t: TimeoutContext<E, A, TE>): Fx<Fork | Sleep | Async, Fx<Fail<E | TE>, A>> => fx(function* () {
+const runTimeout = <const E, const A, const TE>(timeout: Timeout<E, A, TE>): Fx<Fork | Sleep | Async, Fx<Fail<E | TE>, A>> => fx(function* () {
+  const t = timeout.arg
   const result = yield* race([
     attempt(t.fx as Fx<Fail<E>, A>),
     sleep(t.ms).pipe(map(() => ({ type: 'timeout', failure: t.onTimeout(t) } as const)))

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -292,8 +292,10 @@ describe('Trace', () => {
 
     assert.ok(Fail.is(retryResult))
     assert.equal(retryResult.arg, retryError)
-    assert.equal(snapshotError(retryError).trace?.frames[0]?.kind, 'retry')
+    assert.equal(snapshotError(retryError).trace?.frames[0]?.kind, 'fail')
     assert.equal(snapshotError(retryError).trace?.frames[0]?.location, undefined)
+    assert.equal(snapshotError(retryError).trace?.frames[1]?.kind, 'retry')
+    assert.equal(snapshotError(retryError).trace?.frames[1]?.location, undefined)
   })
 
   it('prepends frames newest first', () => {

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -303,7 +303,15 @@ const firstStackLocation = (stack: string | undefined): TraceLocation | undefine
   if (stack === undefined) return undefined
 
   const lines = stack.split('\n')
-  return lines.length > 1 ? parseStackLocation(lines[1].trim()) : undefined
+  let fallback: TraceLocation | undefined
+
+  for (let i = 1; i < lines.length; i++) {
+    const location = parseStackLocation(lines[i].trim())
+    fallback ??= location
+    if (!isTraceTrampolineLocation(location)) return location
+  }
+
+  return fallback
 }
 
 const parseStackLocation = (raw: string): TraceLocation => {
@@ -330,6 +338,16 @@ const parseStackLocation = (raw: string): TraceLocation => {
   }
 
   return { raw }
+}
+
+const isTraceTrampolineLocation = (location: TraceLocation): boolean => {
+  if (location.file === undefined) return false
+
+  const file = location.file.replaceAll('\\', '/')
+  if (file.endsWith('/src/internal/pipe.ts') || file.endsWith('/dist/internal/pipe.js')) return true
+
+  const isGeneratorPipe = location.functionName?.endsWith('.pipe') ?? false
+  return isGeneratorPipe && (file.endsWith('/src/internal/generator.ts') || file.endsWith('/dist/internal/generator.js'))
 }
 
 const snapshotFrame = (frame: TraceFrame): TraceSnapshotFrame => {

--- a/src/internal/Handler.ts
+++ b/src/internal/Handler.ts
@@ -13,7 +13,7 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, HandlerContext {
   constructor(
     public readonly fx: Fx<E, A>,
     public readonly effectId: unknown,
-    public readonly handler: (e: unknown) => Fx<unknown, unknown>
+    public readonly handler: (effect: any) => Fx<unknown, unknown>
   ) { }
 
   wrap(fx: Fx<unknown, unknown>): Fx<unknown, unknown> {
@@ -32,8 +32,8 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, HandlerContext {
           if (effectId === effect._fxEffectId) {
             const context = getRuntimeContext(effect)
             const handled = context === undefined
-              ? handler(effect.arg)
-              : withActiveRuntimeContext(context, () => handler(effect.arg))
+              ? handler(effect)
+              : withActiveRuntimeContext(context, () => handler(effect))
             ir = i.next(yield* withRuntimeContext(context, handled) as any)
           } else if (Scoped.is(effect)) {
             ir = i.next([this, ...(yield effect) as any])
@@ -58,7 +58,7 @@ export class Control<E, A> implements Fx<E, A>, Pipeable {
   constructor(
     public readonly fx: Fx<E, A>,
     public readonly effectId: unknown,
-    public readonly handler: (resume: (a: any) => unknown, e: unknown) => Fx<unknown, unknown>
+    public readonly handler: (resume: (a: any) => unknown, effect: any) => Fx<unknown, unknown>
   ) { }
 
   *[Symbol.iterator](): Iterator<E, A> {
@@ -80,8 +80,8 @@ export class Control<E, A> implements Fx<E, A>, Pipeable {
           if (effectId === effect._fxEffectId) {
             const context = getRuntimeContext(effect)
             const handled = context === undefined
-              ? handler(k, effect.arg)
-              : withActiveRuntimeContext(context, () => handler(k, effect.arg))
+              ? handler(k, effect)
+              : withActiveRuntimeContext(context, () => handler(k, effect))
             const hr = yield* withRuntimeContext(context, handled) as any
             if (!done) return hr
             done = false


### PR DESCRIPTION
## Summary
- change `handle` and `control` callbacks to receive the original effect instance instead of only `effect.arg`
- update source, tests, examples, README, and benchmark call sites to read payloads via `.arg`
- preserve original `Fail` instances in `returnFail`, and keep retry diagnostics showing the original failure site plus retry call site

## Why
Handlers were discarding effect-instance metadata at the boundary. That made helpers like `returnFail` reconstruct `Fail` effects, which lost the original trace and pointed diagnostics at internal helper code.

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`