### PR TITLE
[codex] Improve error diagnostics and trace origins

### DIFF
--- a/src/Effect.test.ts
+++ b/src/Effect.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { Effect } from './Effect.js'
+import { at } from './Breadcrumb.js'
+import { Effect, EffectOriginTypeId, originOf, traceOriginOf, withOrigin, withTraceOrigin } from './Effect.js'
+import { captureTrace, setTraceCapturePolicy } from './Trace.js'
 
 describe('Effect', () => {
   describe('is', () => {
@@ -14,6 +16,58 @@ describe('Effect', () => {
       class U extends Effect('U')<void, void> { }
       assert.ok(!T.is(new U()))
       assert.ok(!U.is(new T()))
+    })
+  })
+
+  describe('withOrigin', () => {
+    it('attaches a non-enumerable diagnostic trace origin', () => {
+      class T extends Effect('T')<void, void> { }
+      const origin = at('test/origin')
+      const effect = withOrigin(new T(), origin)
+      const traceOrigin = traceOriginOf(effect)
+
+      assert.equal(originOf(effect), origin)
+      assert.equal(traceOrigin?.origin, origin)
+      assert.equal(traceOrigin?.trace?.frame.message, 'test/origin')
+      assert.equal(Object.getOwnPropertyDescriptor(effect, EffectOriginTypeId)?.enumerable, false)
+    })
+
+    it('preserves an explicit trace origin', () => {
+      class T extends Effect('T')<void, void> { }
+      const origin = at('test/explicit-origin')
+      const traceOrigin = { origin, trace: undefined }
+      const effect = withTraceOrigin(new T(), traceOrigin)
+
+      assert.equal(traceOriginOf(effect), traceOrigin)
+    })
+
+    it('accepts an explicit trace', () => {
+      class T extends Effect('T')<void, void> { }
+      const origin = at('test/explicit-trace-origin')
+      const trace = captureTrace(origin)
+      const effect = withOrigin(new T(), origin, trace)
+
+      assert.equal(traceOriginOf(effect)?.origin, origin)
+      assert.equal(traceOriginOf(effect)?.trace, trace)
+    })
+
+    it('respects trace capture policy', () => {
+      class T extends Effect('T')<void, void> { }
+      const previous = setTraceCapturePolicy('off')
+      try {
+        const effect = withOrigin(new T(), at('test/off-origin'))
+
+        assert.equal(traceOriginOf(effect)?.trace, undefined)
+      } finally {
+        setTraceCapturePolicy(previous)
+      }
+    })
+
+    it('given an untagged value, originOf returns undefined', () => {
+      assert.equal(originOf({}), undefined)
+      assert.equal(traceOriginOf({}), undefined)
+      assert.equal(originOf(null), undefined)
+      assert.equal(traceOriginOf(null), undefined)
     })
   })
 })

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -1,4 +1,7 @@
+import type { Breadcrumb } from './Breadcrumb.js'
 import { Fx } from './Fx.js'
+import { captureTrace } from './Trace.js'
+import type { Trace, TraceOrigin } from './Trace.js'
 import { Once } from './internal/generator.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 
@@ -8,11 +11,16 @@ export interface EffectType {
 }
 
 export const EffectTypeId = Symbol('fx/Effect')
+export const EffectOriginTypeId = Symbol('fx/Effect/origin')
 
 export interface AnyEffect {
   readonly _fxTypeId: typeof EffectTypeId
   readonly _fxEffectId: unknown
   readonly arg: unknown
+}
+
+export interface EffectOrigin {
+  readonly [EffectOriginTypeId]: TraceOrigin
 }
 
 export const Effect = <const T extends string>(id: T) => class <A, R = unknown> implements AnyEffect, Pipeable {
@@ -37,3 +45,35 @@ export const Effect = <const T extends string>(id: T) => class <A, R = unknown> 
 
 export const isEffect = <E>(e: E): e is E & AnyEffect =>
   !!e && (e as any)._fxTypeId === EffectTypeId
+
+export const withOrigin = <E extends object>(
+  effect: E,
+  origin: Breadcrumb,
+  trace: Trace | undefined = captureTrace(origin)
+): E & EffectOrigin =>
+  withTraceOrigin(effect, { origin, trace })
+
+export const withTraceOrigin = <E extends object>(effect: E, traceOrigin: TraceOrigin): E & EffectOrigin => {
+  Object.defineProperty(effect, EffectOriginTypeId, {
+    value: traceOrigin,
+    enumerable: false,
+    writable: false,
+    configurable: true
+  })
+
+  return effect as E & EffectOrigin
+}
+
+export function traceOriginOf(effect: EffectOrigin): TraceOrigin
+export function traceOriginOf(effect: unknown): TraceOrigin | undefined
+export function traceOriginOf(effect: unknown): TraceOrigin | undefined {
+  return typeof effect === 'object' && effect !== null
+    ? (effect as Partial<EffectOrigin>)[EffectOriginTypeId]
+    : undefined
+}
+
+export function originOf(effect: EffectOrigin): Breadcrumb
+export function originOf(effect: unknown): Breadcrumb | undefined
+export function originOf(effect: unknown): Breadcrumb | undefined {
+  return traceOriginOf(effect)?.origin
+}

--- a/src/Fail.test.ts
+++ b/src/Fail.test.ts
@@ -2,9 +2,10 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { at } from './Breadcrumb.js'
+import { Effect } from './Effect.js'
 import { fx, ok, run } from './Fx.js'
 
-import { Fail, fail, returnFail, returnIf, returnOnly } from './Fail.js'
+import { Fail, fail, failFrom, returnFail, returnIf, returnOnly } from './Fail.js'
 import { getTrace } from './Trace.js'
 import { runFork } from './internal/runFork.js'
 
@@ -33,6 +34,22 @@ describe('Fail', () => {
         e => e instanceof Error
           && firstLine(e).includes('test/fail-origin')
           && traceMessages(e)[0] === 'test/fail-origin'
+          && e.cause === cause
+      )
+    })
+  })
+
+  describe('failFrom', () => {
+    it('uses its fallback origin when the effect has no trace origin', async () => {
+      class TestEffect extends Effect('test/Effect')<void, void> { }
+      const cause = new Error('failed')
+      const origin = at('test/fail-from-fallback')
+
+      await assert.rejects(
+        runFork(failFrom(new TestEffect(), cause, origin)).promise,
+        e => e instanceof Error
+          && firstLine(e).includes('test/fail-from-fallback')
+          && traceMessages(e)[0] === 'test/fail-from-fallback'
           && e.cause === cause
       )
     })

--- a/src/Fail.ts
+++ b/src/Fail.ts
@@ -1,18 +1,22 @@
 import { Breadcrumb, at } from './Breadcrumb.js'
-import { Effect } from './Effect.js'
+import { Effect, traceOriginOf } from './Effect.js'
+import type { AnyEffect } from './Effect.js'
 import { Fx, ok } from './Fx.js'
 import { control } from './Handler.js'
+import type { TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
 
 export class Fail<const E> extends Effect('fx/Fail')<E, never> {
+  readonly origin: Breadcrumb
   readonly trace?: Trace
 
   constructor(
     e: E,
-    readonly origin: Breadcrumb = at('fx/Fail', Fail)
+    traceOrigin: TraceOrigin = { origin: at('fx/Fail', Fail) }
   ) {
     super(e)
-    this.trace = captureTrace(origin, undefined, { kind: 'fail' })
+    this.origin = traceOrigin.origin
+    this.trace = traceOrigin.trace ?? captureTrace(traceOrigin.origin, undefined, { kind: 'fail' })
   }
 }
 
@@ -22,7 +26,21 @@ export class Fail<const E> extends Effect('fx/Fail')<E, never> {
 export const fail = <const E>(
   e: E,
   origin: Breadcrumb = at('fx/Fail/fail', fail)
-): Fx<Fail<E>, never> => new Fail(e, origin)
+): Fx<Fail<E>, never> => new Fail(e, { origin })
+
+/**
+ * Fail with an error e, using an effect's diagnostic origin when available.
+ */
+export const failFrom = <const E>(
+  effect: AnyEffect,
+  e: E,
+  fallback: Breadcrumb = at('fx/Fail/failFrom', failFrom)
+): Fx<Fail<E>, never> => {
+  const traceOrigin = traceOriginOf(effect)
+  return traceOrigin === undefined
+    ? new Fail(e, { origin: fallback })
+    : new Fail(e, traceOrigin)
+}
 
 /**
  * Catch failures matching a type guard and handle them with the provided function.

--- a/src/HttpClient.test.ts
+++ b/src/HttpClient.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Fail, returnFail } from './Fail.js'
 import { runPromise } from './Fx.js'
+import { snapshotTrace } from './Trace.js'
 import {
   DecodeError,
   TransportError,
@@ -273,6 +274,10 @@ describe('HttpClient', () => {
       assert.equal(actual.arg.request, expectedRequest)
       assert.equal(actual.arg.cause, cause)
       assert.equal(actual.arg.message, 'HTTP request failed: GET https://example.com/users')
+      assert.ok(actual.trace !== undefined)
+      const trace = snapshotTrace(actual.trace)
+      assert.equal(trace.frames[0]?.message, 'fx/HttpClient/request')
+      assert.match(trace.frames[0]?.location?.file ?? '', /HttpClient\.test\.ts$/)
     })
 
     it('converts thrown init errors to TransportError failure', async () => {

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -1,6 +1,7 @@
 import { Async, tryPromise } from './Async.js'
-import { Effect } from './Effect.js'
-import { Fail, catchAll, fail } from './Fail.js'
+import { at } from './Breadcrumb.js'
+import { Effect, withOrigin } from './Effect.js'
+import { Fail, catchAll, fail, failFrom } from './Fail.js'
 import { Fx, flatMap, map, ok } from './Fx.js'
 import { handle } from './Handler.js'
 
@@ -26,7 +27,8 @@ export class HttpRequest extends Effect('fx/HttpClient/HttpRequest')<Request, Re
  *     body: { type: 'json', value: { name: 'Ada' } }
  *   })
  */
-export const request = (r: Request) => new HttpRequest(r)
+export const request = (r: Request) =>
+  withOrigin(new HttpRequest(r), at('fx/HttpClient/request', request))
 
 /**
  * A transport-neutral HTTP request description.
@@ -272,13 +274,14 @@ export const w3cFetch = ({
 }: W3CFetchOptions = {}) =>
   <const E, const A>(f: Fx<E, A>) =>
     f.pipe(
-      handle(HttpRequest, ({ arg: r }) =>
-        tryPromise(signal =>
+      handle(HttpRequest, httpRequest => {
+        const r = httpRequest.arg
+        return tryPromise(signal =>
           fetch(r.url, init(r, toFetchRequest(r, signal))).then(toResponse)
         ).pipe(
-          catchAll(cause => fail(new TransportError(r, { cause })))
+          catchAll(cause => failFrom(httpRequest, new TransportError(r, { cause })))
         )
-      )
+      })
     )
 
 

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -478,6 +478,31 @@ describe('Trace', () => {
     assert.equal(snapshot.aggregate?.errors[1].message, 'plain failure')
   })
 
+  it('snapshots enumerable error fields without duplicating standard fields', () => {
+    const error = new Error('lookup failed') as Error & {
+      errno: number
+      code: string
+      syscall: string
+      hostname: string
+      request: { readonly url: URL }
+    }
+    error.errno = -3008
+    error.code = 'ENOTFOUND'
+    error.syscall = 'getaddrinfo'
+    error.hostname = 'jsonplaceholderx.typicode.com'
+    error.request = { url: new URL('https://jsonplaceholderx.typicode.com/users/1') }
+
+    const snapshot = snapshotError(error)
+
+    assert.equal(snapshot.code, 'ENOTFOUND')
+    assert.deepEqual(snapshot.fields, [
+      { key: 'errno', value: '-3008' },
+      { key: 'syscall', value: 'getaddrinfo' },
+      { key: 'hostname', value: 'jsonplaceholderx.typicode.com' },
+      { key: 'request', value: '{ url: https://jsonplaceholderx.typicode.com/users/1 }' }
+    ])
+  })
+
   it('formats expanded diagnostics without changing compact error formatting', () => {
     const cause = new Error('root failed')
     attachTrace(cause, prependTrace(stackBreadcrumb('cause trace', `Error: cause\n    at fn (${import.meta.filename}:4:5)`), undefined, { kind: 'async' }))
@@ -492,6 +517,32 @@ describe('Trace', () => {
     assert.match(formatted, /Caused by:/)
     assert.match(formatted, /at cause trace \[async\]/)
     assert.match(formatted, new RegExp(`${escapeRegExp(import.meta.filename)}:4:5`))
+  })
+
+  it('formats enumerable error fields in expanded diagnostics', () => {
+    const error = new Error('HTTP request failed') as Error & {
+      request: { readonly method: string, readonly url: URL }
+      cause: Error & { readonly code: string, readonly syscall: string, readonly hostname: string }
+    }
+    error.request = {
+      method: 'GET',
+      url: new URL('https://jsonplaceholderx.typicode.com/users/1')
+    }
+    Object.defineProperty(error, 'cause', {
+      value: Object.assign(new TypeError('fetch failed'), {
+        code: 'ENOTFOUND',
+        syscall: 'getaddrinfo',
+        hostname: 'jsonplaceholderx.typicode.com'
+      })
+    })
+
+    const formatted = formatDiagnostic(error, { colors: 'never' })
+
+    assert.match(formatted, /Error: HTTP request failed/)
+    assert.match(formatted, /request: \{ method: GET, url: https:\/\/jsonplaceholderx\.typicode\.com\/users\/1 \}/)
+    assert.match(formatted, /Caused by:\n  TypeError \[ENOTFOUND\]: fetch failed/)
+    assert.match(formatted, /syscall: getaddrinfo/)
+    assert.match(formatted, /hostname: jsonplaceholderx\.typicode\.com/)
   })
 
   it('formats diagnostics without ansi escapes when colors are disabled', () => {

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -75,10 +75,16 @@ export interface DiagnosticErrorSnapshot {
   readonly name?: string
   readonly message: string
   readonly code?: string
+  readonly fields?: readonly DiagnosticFieldSnapshot[]
   readonly trace?: TraceSnapshot
   readonly cause?: DiagnosticErrorSnapshot
   readonly aggregate?: DiagnosticAggregateSnapshot
   readonly cycleDetected?: true
+}
+
+export interface DiagnosticFieldSnapshot {
+  readonly key: string
+  readonly value: string
 }
 
 export interface DiagnosticAggregateSnapshot {
@@ -393,8 +399,19 @@ const snapshotErrorObject = (error: Error): DiagnosticErrorSnapshot => ({
   type: error.constructor.name,
   name: error.name,
   message: error.message,
-  ...('code' in error ? { code: String((error as { readonly code: unknown }).code) } : {})
+  ...('code' in error ? { code: String((error as { readonly code: unknown }).code) } : {}),
+  ...snapshotErrorFields(error)
 })
+
+const snapshotErrorFields = (error: Error): Pick<DiagnosticErrorSnapshot, 'fields'> => {
+  const fields = Object.keys(error)
+    .filter(key => !excludedErrorFields.has(key))
+    .map(key => ({ key, value: formatDiagnosticFieldValue((error as unknown as Record<string, unknown>)[key], new Set([error])) }))
+
+  return fields.length === 0 ? {} : { fields }
+}
+
+const excludedErrorFields = new Set(['name', 'message', 'stack', 'cause', 'errors', 'code'])
 
 const aggregateErrors = (error: unknown): readonly unknown[] | undefined => {
   if (error instanceof AggregateError) return Array.from(error.errors)
@@ -458,6 +475,7 @@ const formatDiagnosticError = (
 ): void => {
   const prefix = ' '.repeat(indent)
   lines.push(`${prefix}${formatDiagnosticHeader(error, context)}`)
+  formatDiagnosticFields(error.fields, lines, indent, context)
 
   if (error.trace !== undefined) {
     const omitTraceSuffix = options.omitTraceSuffix ?? 0
@@ -486,6 +504,20 @@ const formatDiagnosticHeader = (error: DiagnosticErrorSnapshot, context: FormatC
   const name = error.name ?? error.type
   const message = error.message === '' ? '' : `: ${error.message}`
   return context.style.header(`${name}${code}${message}`)
+}
+
+const formatDiagnosticFields = (
+  fields: readonly DiagnosticFieldSnapshot[] | undefined,
+  lines: string[],
+  indent: number,
+  context: FormatContext
+): void => {
+  if (fields === undefined || fields.length === 0) return
+
+  const prefix = ' '.repeat(indent + 2)
+  for (const field of fields) {
+    lines.push(`${prefix}${context.style.code(field.key)}: ${field.value}`)
+  }
 }
 
 const formatDiagnosticAggregate = (
@@ -754,6 +786,69 @@ const formatErrorValue = (error: unknown): string => {
   }
 
   return String(error)
+}
+
+const formatDiagnosticFieldValue = (value: unknown, seen: Set<unknown>): string => {
+  if (value === null) return 'null'
+
+  switch (typeof value) {
+    case 'string':
+      return value
+
+    case 'number':
+    case 'bigint':
+    case 'boolean':
+    case 'undefined':
+      return String(value)
+
+    case 'symbol':
+      return value.description === undefined ? String(value) : `Symbol(${value.description})`
+
+    case 'function':
+      return `[Function${value.name === '' ? '' : `: ${value.name}`}]`
+
+    case 'object':
+      return formatDiagnosticFieldObject(value, seen)
+  }
+
+  return '[unknown]'
+}
+
+const formatDiagnosticFieldObject = (value: object, seen: Set<unknown>): string => {
+  if (seen.has(value)) return '[cycle]'
+  if (value instanceof Error) return formatErrorValue(value)
+  if (value instanceof URL) return String(value)
+
+  seen.add(value)
+  try {
+    if (Array.isArray(value)) {
+      return `[${formatFieldEntries(value.slice(0, MaxDiagnosticFieldEntries).map(v => formatDiagnosticFieldValue(v, seen)), value.length)}]`
+    }
+
+    if (isPlainObject(value)) {
+      const keys = Object.keys(value)
+      const entries = keys.slice(0, MaxDiagnosticFieldEntries).map(key =>
+        `${key}: ${formatDiagnosticFieldValue((value as Record<string, unknown>)[key], seen)}`
+      )
+      return `{ ${formatFieldEntries(entries, keys.length)} }`
+    }
+
+    return Object.prototype.toString.call(value)
+  } finally {
+    seen.delete(value)
+  }
+}
+
+const formatFieldEntries = (entries: readonly string[], total: number): string => {
+  const suffix = total > entries.length ? `, ... ${total - entries.length} more` : ''
+  return `${entries.join(', ')}${suffix}`
+}
+
+const MaxDiagnosticFieldEntries = 6
+
+const isPlainObject = (value: object): boolean => {
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }
 
 const formatAggregateErrorValue = (error: unknown, aggregate: readonly unknown[]): string =>


### PR DESCRIPTION
## Summary

- Preserve useful enumerable error fields in expanded diagnostics, including transport-style fields like `request`, `errno`, `syscall`, and `hostname`.
- Add opt-in effect origin metadata with `withOrigin` / `withTraceOrigin` so handler-created failures can point back to user-land effect construction sites.
- Use the new origin metadata for `HttpClient.request` transport failures via `failFrom`.

## Why

Transport failures had useful structured data on the original error object, but expanded diagnostics mostly relied on stack/cause output. Separately, failures introduced inside handlers could show an internal handler location instead of the user call site that created the original effect.

This keeps the behavior opt-in: only effects that explicitly call `withOrigin` pay construction-time trace capture cost.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm exec tsx examples/effect-ts/retry.ts`