### PR TITLE
Release finalizers in LIFO order

### DIFF
--- a/src/Scope.test.ts
+++ b/src/Scope.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { Fail, fail, returnFail } from './Fail.js'
+import { fx, run } from './Fx.js'
+import { finalize, scope } from './Scope.js'
+
+describe('Scope', () => {
+  it('releases finalizers in reverse registration order after success', () => {
+    const released = [] as string[]
+
+    const result = run(scope(fx(function* () {
+      yield* finalize(record(released, 'A'))
+      yield* finalize(record(released, 'B'))
+      yield* finalize(record(released, 'C'))
+      return 'done'
+    })).pipe(returnFail))
+
+    assert.equal(result, 'done')
+    assert.deepEqual(released, ['C', 'B', 'A'])
+  })
+
+  it('releases finalizers in reverse registration order after failure', () => {
+    const released = [] as string[]
+    const programFailure = new Error('program failed')
+
+    const result = run(scope(fx(function* () {
+      yield* finalize(record(released, 'A'))
+      yield* finalize(record(released, 'B'))
+      yield* finalize(record(released, 'C'))
+      yield* fail(programFailure)
+    })).pipe(returnFail))
+
+    assert.ok(Fail.is(result))
+    assert.equal(result.arg, programFailure)
+    assert.deepEqual(released, ['C', 'B', 'A'])
+  })
+
+  it('aggregates cleanup failures in release order', () => {
+    const released = [] as string[]
+    const aFailure = new Error('A release failed')
+    const cFailure = new Error('C release failed')
+
+    const result = run(scope(fx(function* () {
+      yield* finalize(record(released, 'A', aFailure))
+      yield* finalize(record(released, 'B'))
+      yield* finalize(record(released, 'C', cFailure))
+      return 'done'
+    })).pipe(returnFail))
+
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.deepEqual(result.arg.errors, [cFailure, aFailure])
+    assert.deepEqual(released, ['C', 'B', 'A'])
+  })
+
+  it('keeps program failure first before cleanup failures in release order', () => {
+    const released = [] as string[]
+    const programFailure = new Error('program failed')
+    const aFailure = new Error('A release failed')
+    const cFailure = new Error('C release failed')
+
+    const result = run(scope(fx(function* () {
+      yield* finalize(record(released, 'A', aFailure))
+      yield* finalize(record(released, 'B'))
+      yield* finalize(record(released, 'C', cFailure))
+      yield* fail(programFailure)
+    })).pipe(returnFail))
+
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.deepEqual(result.arg.errors, [programFailure, cFailure, aFailure])
+    assert.deepEqual(released, ['C', 'B', 'A'])
+  })
+})
+
+const record = (released: string[], label: string, failure?: unknown) => fx(function* () {
+  released.push(label)
+  if (failure !== undefined) yield* fail(failure)
+})

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -33,8 +33,7 @@ export const scope = <const E, const A>(f: Fx<E, A>) => fx(function* () {
 const releaseSafely = (resources: readonly Fx<unknown, unknown>[]) => fx(function* () {
   const failures = [] as unknown[]
   for (let i = resources.length - 1; i >= 0; --i) {
-    const release = resources[i]
-    const r = yield* returnFail(release)
+    const r = yield* returnFail(resources[i])
     if (Fail.is(r)) failures.push(r.arg)
   }
   return failures

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -32,7 +32,8 @@ export const scope = <const E, const A>(f: Fx<E, A>) => fx(function* () {
 
 const releaseSafely = (resources: readonly Fx<unknown, unknown>[]) => fx(function* () {
   const failures = [] as unknown[]
-  for (const release of resources) {
+  for (let i = resources.length - 1; i >= 0; --i) {
+    const release = resources[i]
     const r = yield* returnFail(release)
     if (Fail.is(r)) failures.push(r.arg)
   }


### PR DESCRIPTION
## Summary
- Release Scope finalizers in reverse registration order without mutating the finalizer array
- Add focused Scope tests for success, failure, cleanup aggregation, and combined program/cleanup failure ordering

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`