### PR TITLE
[codex] Add named scope control effects

### DIFF
--- a/examples/fp-to-the-max/main.ts
+++ b/examples/fp-to-the-max/main.ts
@@ -1,5 +1,6 @@
 import { Effect, fx, ok } from '../../src'
 import { abort, orReturn } from '../../src/Abort'
+import { scope } from '../../src/Scope'
 
 // -------------------------------------------------------------------
 // The number guessing game example from
@@ -16,9 +17,11 @@ export class Read extends Effect('Read')<string, string> { }
 
 const read = (prompt: string) => new Read(prompt)
 
+const ParseInteger = 'examples/fp-to-the-max/ParseInteger' as const
+
 export const toInteger = (s: string) => {
   const i = Number.parseInt(s, 10)
-  return Number.isInteger(i) ? ok(i) : abort
+  return Number.isInteger(i) ? ok(i) : abort(ParseInteger)
 }
 
 export class GenerateSecret extends Effect('GetSecret')<number, number> { }
@@ -55,7 +58,7 @@ const play = (name: string, max: number) => fx(function* () {
 
   const result = yield* read(`Dear ${name}, please guess a number from 1 to ${max}: `)
 
-  const guess = yield* toInteger(result).pipe(orReturn(undefined))
+  const guess = yield* toInteger(result).pipe(scope(ParseInteger), orReturn(ParseInteger, undefined))
   if (typeof guess !== 'number')
     yield* print('You did not enter an integer!')
   else if (checkAnswer(secret, guess))

--- a/examples/resources.ts
+++ b/examples/resources.ts
@@ -3,8 +3,11 @@ import { assertSync, formatDiagnostic, fx, runPromise } from "../src"
 import { all, defaultAll, unbounded } from "../src/Concurrent"
 import { defaultConsole, error } from "../src/Console"
 import { catchAll, fail } from "../src/Fail"
-import { managed, usingManaged, withFinalization } from "../src/Finalization"
+import { managed, usingManaged } from "../src/Finalization"
+import { scope } from "../src/Scope"
 import { defaultTime, sleep } from "../src/Time"
+
+const Resources = 'examples/resources' as const
 
 const myResource = (name: string) => fx(function* () {
   yield* sleep(100)
@@ -15,7 +18,7 @@ const myResource = (name: string) => fx(function* () {
 })
 
 const f = (n: number) => fx(function* () {
-  const resource = yield* usingManaged(myResource(`my-resource-${n}`))
+  const resource = yield* usingManaged(Resources, myResource(`my-resource-${n}`))
 
   console.log(`using resource: ${resource}`)
 
@@ -27,7 +30,7 @@ const f = (n: number) => fx(function* () {
 
 await all([f(1), f(2)]).pipe(
   defaultAll,
-  withFinalization,
+  scope(Resources),
   defaultTime,
   unbounded,
   catchAll(e => error('failed', formatDiagnostic(e, { source: { lookup: nodeSourceLookup() } }))),

--- a/examples/scope/read-csv.ts
+++ b/examples/scope/read-csv.ts
@@ -1,0 +1,95 @@
+import { fx, run } from '../../src'
+import { defaultConsole, log } from '../../src/Console'
+import { managed, usingManaged } from '../../src/Finalization'
+import { returnFrom } from '../../src/ReturnFrom'
+import { scope } from '../../src/Scope'
+
+const ImportCsv = 'examples/scope/ImportCsv' as const
+
+type ImportResult =
+  | { readonly type: 'imported'; readonly count: number }
+  | { readonly type: 'skipped'; readonly reason: string }
+
+type CsvFile = {
+  readonly path: string
+  readonly text: string
+}
+
+const stopImport = (reason: string) =>
+  returnFrom(ImportCsv, { type: 'skipped', reason } satisfies ImportResult)
+
+const openCsv = (path: string, text: string) => fx(function* () {
+  yield* log(`opening ${path}`)
+
+  return managed(
+    { path, text } satisfies CsvFile,
+    exit => log(`closing ${path} after ${exit.type}`)
+  )
+})
+
+const readCsv = (file: CsvFile) => fx(function* () {
+  yield* log(`reading ${file.path}`)
+
+  return file.text
+    .trim()
+    .split('\n')
+    .map(line => line.split(',').map(cell => cell.trim()))
+})
+
+const validateHeader = (header: readonly string[] | undefined) => fx(function* () {
+  if (header === undefined) {
+    yield* stopImport('CSV is empty')
+  }
+
+  if (!header.includes('email')) {
+    yield* stopImport('CSV is missing email column')
+  }
+})
+
+const importRows = (rows: readonly (readonly string[])[]) => fx(function* () {
+  let count = 0
+
+  for (const row of rows) {
+    if (row.every(cell => cell === '')) {
+      yield* stopImport(`Encountered empty row after ${count} imports`)
+    }
+
+    yield* log(`importing ${row.join(' | ')}`)
+    count += 1
+  }
+
+  return count
+})
+
+const importCsv = (path: string, text: string) => fx(function* () {
+  const file = yield* usingManaged(ImportCsv, openCsv(path, text))
+  const [header, ...rows] = yield* readCsv(file)
+
+  yield* validateHeader(header)
+  const count = yield* importRows(rows)
+
+  return { type: 'imported', count } satisfies ImportResult
+}).pipe(scope(ImportCsv))
+
+const goodCsv = `
+name,email
+Ada Lovelace,ada@example.com
+Grace Hopper,grace@example.com
+`
+
+const missingEmailCsv = `
+name,phone
+Ada Lovelace,555-0100
+`
+
+const main = fx(function* () {
+  for (const [path, text] of [
+    ['good.csv', goodCsv],
+    ['missing-email.csv', missingEmailCsv]
+  ] as const) {
+    const result = yield* importCsv(path, text)
+    yield* log(`${path}: ${result.type}`, result)
+  }
+})
+
+run(main.pipe(defaultConsole))

--- a/examples/scope/read-csv.ts
+++ b/examples/scope/read-csv.ts
@@ -1,8 +1,10 @@
-import { fx, run } from '../../src'
+import { fx, run, type Fx } from '../../src'
 import { defaultConsole, log } from '../../src/Console'
+import { assert as assertNoFail } from '../../src/Fail'
 import { managed, usingManaged } from '../../src/Finalization'
 import { returnFrom } from '../../src/ReturnFrom'
 import { scope } from '../../src/Scope'
+import { emit, forEach, type Stream } from '../../src/Stream'
 
 const ImportCsv = 'examples/scope/ImportCsv' as const
 
@@ -14,6 +16,8 @@ type CsvFile = {
   readonly path: string
   readonly text: string
 }
+
+type CsvRow = string[]
 
 const stopImport = (reason: string) =>
   returnFrom(ImportCsv, { type: 'skipped', reason } satisfies ImportResult)
@@ -27,46 +31,61 @@ const openCsv = (path: string, text: string) => fx(function* () {
   )
 })
 
-const readCsv = (file: CsvFile) => fx(function* () {
-  yield* log(`reading ${file.path}`)
-
-  return file.text
+const parseCsvRows = (text: string): CsvRow[] =>
+  text
     .trim()
     .split('\n')
     .map(line => line.split(',').map(cell => cell.trim()))
+
+const readCsvRows = (file: CsvFile) => fx(function* () {
+  yield* log(`reading ${file.path}`)
+
+  for (const row of parseCsvRows(file.text)) {
+    yield* emit(row)
+  }
+})
+
+const withIndex = <E>(stream: Fx<E | Stream<CsvRow>, void>) => fx(function* () {
+  let index = 0
+
+  yield* forEach(stream, value => fx(function* () {
+    yield* emit({ index, value })
+    index += 1
+  }))
 })
 
 const validateHeader = (header: readonly string[] | undefined) => fx(function* () {
   if (header === undefined) {
-    yield* stopImport('CSV is empty')
+    return yield* stopImport('CSV is empty')
   }
 
   if (!header.includes('email')) {
-    yield* stopImport('CSV is missing email column')
+    return yield* stopImport('CSV is missing email column')
   }
 })
 
-const importRows = (rows: readonly (readonly string[])[]) => fx(function* () {
+const importRows = (file: CsvFile) => fx(function* () {
   let count = 0
 
-  for (const row of rows) {
+  yield* forEach(readCsvRows(file).pipe(withIndex), ({ index, value: row }) => fx(function* () {
+    if (index === 0) {
+      return yield* validateHeader(row)
+    }
+
     if (row.every(cell => cell === '')) {
-      yield* stopImport(`Encountered empty row after ${count} imports`)
+      return yield* stopImport(`Encountered empty row after ${count} imports`)
     }
 
     yield* log(`importing ${row.join(' | ')}`)
     count += 1
-  }
+  }))
 
   return count
 })
 
 const importCsv = (path: string, text: string) => fx(function* () {
   const file = yield* usingManaged(ImportCsv, openCsv(path, text))
-  const [header, ...rows] = yield* readCsv(file)
-
-  yield* validateHeader(header)
-  const count = yield* importRows(rows)
+  const count = yield* importRows(file)
 
   return { type: 'imported', count } satisfies ImportResult
 }).pipe(scope(ImportCsv))
@@ -92,4 +111,4 @@ const main = fx(function* () {
   }
 })
 
-run(main.pipe(defaultConsole))
+run(main.pipe(defaultConsole, assertNoFail))

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
       "types": "./dist/Ref.d.ts",
       "import": "./dist/Ref.js"
     },
+    "./ReturnFrom": {
+      "types": "./dist/ReturnFrom.d.ts",
+      "import": "./dist/ReturnFrom.js"
+    },
     "./Finalization": {
       "types": "./dist/Finalization.d.ts",
       "import": "./dist/Finalization.js"
@@ -76,6 +80,10 @@
     "./Sink": {
       "types": "./dist/Sink.d.ts",
       "import": "./dist/Sink.js"
+    },
+    "./Scope": {
+      "types": "./dist/Scope.d.ts",
+      "import": "./dist/Scope.js"
     },
     "./Stream": {
       "types": "./dist/Stream.d.ts",

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -1,22 +1,42 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { abort, orReturn } from './Abort.js'
-import { ok, run } from './Fx.js'
+import { abort, Abort, orReturn } from './Abort.js'
+import { fx, ok, run } from './Fx.js'
+import { scope } from './Scope.js'
 
 describe('Abort', () => {
-  describe('orReturn', () => {
-    it('given Abort, returns alternative', () => {
+  const TestScope = 'test/Abort' as const
+
+  describe('scope', () => {
+    it('given matching Abort with fallback, returns alternative', () => {
       const r = Math.random()
-      const a = abort.pipe(orReturn(r), run)
+      const a = abort(TestScope).pipe(scope(TestScope), orReturn(TestScope, r), run)
 
       assert.equal(a, r)
     })
 
     it('given success, returns original value', () => {
       const r = Math.random()
-      const a = ok(r).pipe(orReturn(r + 1), run)
+      const a = ok(r).pipe(scope(TestScope), orReturn(TestScope, r + 1), run)
 
       assert.equal(a, r)
+    })
+
+    it('leaves matching Abort unhandled when fallback is omitted', () => {
+      const f = abort(TestScope).pipe(scope(TestScope))
+      const _: typeof f extends import('./Fx.js').Fx<Abort<typeof TestScope>, never> ? true : false = true
+
+      assert.equal(Abort.is(f[Symbol.iterator]().next().value), true)
+    })
+
+    it('does not handle Abort from a different scope', () => {
+      const OtherScope = 'test/Abort/other' as const
+      const f = fx(function* () {
+        yield* abort(OtherScope)
+        return 'done'
+      }).pipe(scope(TestScope), orReturn(TestScope, 'aborted'))
+
+      assert.equal(Abort.is(f[Symbol.iterator]().next().value), true)
     })
   })
 })

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -1,17 +1,25 @@
 import { Effect } from './Effect.js'
-import { ok } from './Fx.js'
+import { Fx, ok } from './Fx.js'
 import { control } from './Handler.js'
 
 /**
- * Abort a computation without returning a result. Abort represents partial functions,
- * where a result is not defined for some inputs.
+ * Abort the named scope without returning a result.
  */
-export class Abort extends Effect('fx/Abort')<void, never> { }
+export class Abort<const Scope extends string> extends Effect('fx/Abort')<Scope, never> { }
 
-export const abort = new Abort()
+export const abort = <const Scope extends string>(scope: Scope): Fx<Abort<Scope>, never> =>
+  new Abort(scope)
 
 /**
- * Return a default value from a computation that aborts early.
+ * Return a default value from an abort of the named scope.
  */
-export const orReturn = <const R>(r: R) =>
-  control(Abort, _ => ok(r))
+export const orReturn = <const Scope extends string, const R>(
+  scope: Scope,
+  value: R
+) => <const E, const A>(
+  f: Fx<E, A>
+): Fx<Exclude<E, Abort<Scope>>, A | R> =>
+    f.pipe(
+      control(Abort, (_, abort) =>
+        (abort.arg === scope ? ok(value) : abort) as Fx<Exclude<E, Abort<Scope>>, A | R>)
+    ) as Fx<Exclude<E, Abort<Scope>>, A | R>

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -4,8 +4,10 @@ import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { RaceAllFailed, all, defaultAll, firstSettled, firstSuccess, fork, forkEach, race, unbounded } from './Concurrent.js'
+import { andFinally } from './Finalization.js'
 import { flatMap, fx, ok, runPromise } from './Fx.js'
 import { handle } from './Handler.js'
+import { scope } from './Scope.js'
 import { Task, wait } from './Task.js'
 import { getTrace, snapshotError } from './Trace.js'
 
@@ -253,6 +255,29 @@ describe('Fork', () => {
       )
 
       assert.deepEqual(result, ['handled'])
+    })
+
+    it('runs children with scopes between all and defaultAll', async () => {
+      const TestScope = 'test/Fork/AllScope' as const
+      const released = [] as string[]
+      const cause = new Error('all scope failed')
+
+      const result = await all([fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          released.push('child')
+        }))
+        yield* fail(cause)
+      })]).pipe(
+        scope(TestScope),
+        defaultAll,
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.deepEqual(released, ['child'])
     })
 
     it('types all as a value tuple rather than a Task', async () => {

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -1,21 +1,24 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
+import { abort, Abort, orReturn } from './Abort.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { fx, ok, run } from './Fx.js'
-import { andFinally, andFinallyExit, managed, using, usingExit, usingManaged, withFinalization } from './Finalization.js'
-import type { Exit } from './Finalization.js'
+import { andFinally, andFinallyExit, managed, using, usingExit, usingManaged } from './Finalization.js'
+import { returnFrom } from './ReturnFrom.js'
+import { scope, type Exit } from './Scope.js'
 
 describe('Finalization', () => {
+  const TestScope = 'test/Finalization' as const
   it('releases finalizers in reverse registration order after success', () => {
     const released = [] as string[]
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinally(record(released, 'A'))
-      yield* andFinally(record(released, 'B'))
-      yield* andFinally(record(released, 'C'))
+    const result = run(fx(function* () {
+      yield* andFinally(TestScope, record(released, 'A'))
+      yield* andFinally(TestScope, record(released, 'B'))
+      yield* andFinally(TestScope, record(released, 'C'))
       return 'done'
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.equal(result, 'done')
     assert.deepEqual(released, ['C', 'B', 'A'])
@@ -25,12 +28,12 @@ describe('Finalization', () => {
     const released = [] as string[]
     const programFailure = new Error('program failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinally(record(released, 'A'))
-      yield* andFinally(record(released, 'B'))
-      yield* andFinally(record(released, 'C'))
+    const result = run(fx(function* () {
+      yield* andFinally(TestScope, record(released, 'A'))
+      yield* andFinally(TestScope, record(released, 'B'))
+      yield* andFinally(TestScope, record(released, 'C'))
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -42,12 +45,12 @@ describe('Finalization', () => {
     const aFailure = new Error('A release failed')
     const cFailure = new Error('C release failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinally(record(released, 'A', aFailure))
-      yield* andFinally(record(released, 'B'))
-      yield* andFinally(record(released, 'C', cFailure))
+    const result = run(fx(function* () {
+      yield* andFinally(TestScope, record(released, 'A', aFailure))
+      yield* andFinally(TestScope, record(released, 'B'))
+      yield* andFinally(TestScope, record(released, 'C', cFailure))
       return 'done'
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
@@ -61,12 +64,12 @@ describe('Finalization', () => {
     const aFailure = new Error('A release failed')
     const cFailure = new Error('C release failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinally(record(released, 'A', aFailure))
-      yield* andFinally(record(released, 'B'))
-      yield* andFinally(record(released, 'C', cFailure))
+    const result = run(fx(function* () {
+      yield* andFinally(TestScope, record(released, 'A', aFailure))
+      yield* andFinally(TestScope, record(released, 'B'))
+      yield* andFinally(TestScope, record(released, 'C', cFailure))
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
@@ -77,12 +80,12 @@ describe('Finalization', () => {
   it('provides a success exit to exit-aware finalizers', () => {
     const exits = [] as Exit[]
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinallyExit(exit => fx(function* () {
+    const result = run(fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       return 'done'
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.equal(result, 'done')
     assert.deepEqual(exits, [{ type: 'success', value: 'done' }])
@@ -92,12 +95,12 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
     const programFailure = new Error('program failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinallyExit(exit => fx(function* () {
+    const result = run(fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -111,17 +114,17 @@ describe('Finalization', () => {
     const released = [] as string[]
     const exits = [] as Exit[]
 
-    const result = run(withFinalization(fx(function* () {
-      yield* andFinallyExit(exit => fx(function* () {
+    const result = run(fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
         released.push('A')
         exits.push(exit)
       }))
-      yield* andFinallyExit(exit => fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
         released.push('B')
         exits.push(exit)
       }))
       return 'done'
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.equal(result, 'done')
     assert.deepEqual(released, ['B', 'A'])
@@ -133,12 +136,11 @@ describe('Finalization', () => {
   it('using returns the initialized value and registers cleanup', () => {
     const released = [] as string[]
 
-    const result = run(withFinalization(fx(function* () {
-      return yield* using(
-        ok('resource'),
+    const result = run(fx(function* () {
+      return yield* using(TestScope, ok('resource'),
         resource => record(released, resource)
       )
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(released, ['resource'])
@@ -148,12 +150,11 @@ describe('Finalization', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
 
-    const result = run(withFinalization(fx(function* () {
-      return yield* using(
-        fail(initFailure),
+    const result = run(fx(function* () {
+      return yield* using(TestScope, fail(initFailure),
         resource => record(released, String(resource))
       )
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, initFailure)
@@ -164,13 +165,13 @@ describe('Finalization', () => {
     const released = [] as string[]
     const programFailure = new Error('program failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* using(
+    const result = run(fx(function* () {
+      yield* using(TestScope, 
         ok('resource'),
         resource => record(released, resource)
       )
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -181,15 +182,14 @@ describe('Finalization', () => {
     const released = [] as string[]
     const exits = [] as Exit[]
 
-    const result = run(withFinalization(fx(function* () {
-      return yield* usingExit(
-        ok('resource'),
+    const result = run(fx(function* () {
+      return yield* usingExit(TestScope, ok('resource'),
         (resource, exit) => fx(function* () {
           released.push(resource)
           exits.push(exit)
         })
       )
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(released, ['resource'])
@@ -201,8 +201,8 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
     const programFailure = new Error('program failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* usingExit(
+    const result = run(fx(function* () {
+      yield* usingExit(TestScope, 
         ok('resource'),
         (resource, exit) => fx(function* () {
           released.push(resource)
@@ -210,7 +210,7 @@ describe('Finalization', () => {
         })
       )
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -225,13 +225,13 @@ describe('Finalization', () => {
     const programFailure = new Error('program failed')
     const releaseFailure = new Error('release failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* usingExit(
+    const result = run(fx(function* () {
+      yield* usingExit(TestScope, 
         ok('resource'),
         () => fail(releaseFailure)
       )
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
@@ -252,12 +252,12 @@ describe('Finalization', () => {
   it('usingManaged returns the managed value and registers its finalizer', () => {
     const released = [] as string[]
 
-    const result = run(withFinalization(fx(function* () {
-      return yield* usingManaged(ok(managed(
+    const result = run(fx(function* () {
+      return yield* usingManaged(TestScope, ok(managed(
         'resource',
         () => record(released, 'resource')
       )))
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(released, ['resource'])
@@ -267,9 +267,9 @@ describe('Finalization', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
 
-    const result = run(withFinalization(fx(function* () {
-      return yield* usingManaged(fail(initFailure))
-    })).pipe(returnFail))
+    const result = run(fx(function* () {
+      return yield* usingManaged(TestScope, fail(initFailure))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, initFailure)
@@ -280,15 +280,15 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
     const programFailure = new Error('program failed')
 
-    const result = run(withFinalization(fx(function* () {
-      yield* usingManaged(ok(managed(
+    const result = run(fx(function* () {
+      yield* usingManaged(TestScope, ok(managed(
         'resource',
         exit => fx(function* () {
           exits.push(exit)
         })
       )))
       yield* fail(programFailure)
-    })).pipe(returnFail))
+    }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -296,6 +296,81 @@ describe('Finalization', () => {
     const [exit] = exits
     assert.equal(exit.type, 'failure')
     if (exit.type === 'failure') assert.equal(exit.failure.arg, programFailure)
+  })
+
+  it('runs scoped finalizers after returnFrom', () => {
+    const released = [] as string[]
+
+    const result = run(fx(function* () {
+      yield* andFinally(TestScope, record(released, 'A'))
+      yield* andFinally(TestScope, record(released, 'B'))
+      yield* returnFrom(TestScope, 'returned')
+    }).pipe(scope(TestScope), returnFail))
+
+    assert.equal(result, 'returned')
+    assert.deepEqual(released, ['B', 'A'])
+  })
+
+  it('provides returnFrom exit to exit-aware finalizers', () => {
+    const exits = [] as Exit[]
+
+    const result = run(fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
+        exits.push(exit)
+      }))
+      yield* returnFrom(TestScope, 'returned')
+    }).pipe(scope(TestScope), returnFail))
+
+    assert.equal(result, 'returned')
+    assert.deepEqual(exits, [{
+      type: 'returnFrom',
+      scope: TestScope,
+      value: 'returned'
+    }])
+  })
+
+  it('runs scoped finalizers after handled abort', () => {
+    const released = [] as string[]
+
+    const result = run(fx(function* () {
+      yield* andFinally(TestScope, record(released, 'A'))
+      yield* andFinally(TestScope, record(released, 'B'))
+      yield* abort(TestScope)
+    }).pipe(scope(TestScope), orReturn(TestScope, 'aborted'), returnFail))
+
+    assert.equal(result, 'aborted')
+    assert.deepEqual(released, ['B', 'A'])
+  })
+
+  it('provides abort exit to exit-aware finalizers before re-emitting unhandled abort', () => {
+    const exits = [] as Exit[]
+
+    const f = fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
+        exits.push(exit)
+      }))
+      yield* abort(TestScope)
+    }).pipe(scope(TestScope))
+
+    const next = f[Symbol.iterator]().next()
+
+    assert.equal(Abort.is(next.value), true)
+    assert.deepEqual(exits, [{ type: 'abort', scope: TestScope }])
+  })
+
+  it('does not run finalizers from a different scope', () => {
+    const OtherScope = 'test/Finalization/other' as const
+    const released = [] as string[]
+
+    const f = fx(function* () {
+      yield* andFinally(OtherScope, record(released, 'other'))
+      return 'done'
+    }).pipe(scope(TestScope))
+
+    const next = f[Symbol.iterator]().next()
+
+    assert.equal(next.done, false)
+    assert.deepEqual(released, [])
   })
 })
 

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -1,83 +1,76 @@
 import { Effect } from './Effect.js'
-import { Fx, fx, ok } from './Fx.js'
-import { Handle, handle } from './Handler.js'
-
-import { Fail, fail, returnFail } from './Fail.js'
+import { Fx, fx } from './Fx.js'
+import type { Exit } from './Scope.js'
 
 // ----------------------------------------------------------------------
-// Guaranteed finalization effects within a finalization boundary
-
-export type Exit<A = unknown, F extends Fail<unknown> = Fail<unknown>> =
-  | Success<A>
-  | Failure<F>
-
-export interface Success<A> {
-  readonly type: 'success'
-  readonly value: A
-}
-
-export interface Failure<F extends Fail<unknown>> {
-  readonly type: 'failure'
-  readonly failure: F
-}
+// Guaranteed finalization effects within a named scope
 
 /**
- * A value paired with cleanup for the enclosing finalization boundary.
+ * A value paired with cleanup for a named scope.
  *
- * The finalizer receives the boundary's exit, not the managed value.
+ * The finalizer receives the scope's exit, not the managed value.
  */
 export interface Managed<A, E = never> {
   readonly value: A
   readonly finalizer: (exit: Exit) => Fx<E, void>
 }
 
-type Finalizer = (exit: Exit) => Fx<unknown, void>
+export type Finalizer = (exit: Exit) => Fx<unknown, void>
 
 /**
- * Request that a cleanup operation be run when the enclosing finalization boundary exits.
+ * Request that a cleanup operation be run when the named scope exits.
  */
-export class Finally extends Effect('fx/Finally')<Finalizer, void> { }
+export class Finally<const Scope extends string> extends Effect('fx/Finally')<{
+  readonly scope: Scope
+  readonly finalizer: Finalizer
+}, void> { }
 
 /**
- * Register a cleanup operation to run when the enclosing finalization boundary exits.
+ * Register a cleanup operation to run when the named scope exits.
  */
-export const andFinally = <E>(f: Fx<E, void>): Fx<Finally, void> =>
-  new Finally(() => f)
+export const andFinally = <const Scope extends string, E>(
+  scope: Scope,
+  f: Fx<E, void>
+): Fx<Finally<Scope>, void> =>
+  new Finally({ scope, finalizer: () => f })
 
 /**
- * Register a cleanup operation that receives the enclosing finalization boundary's exit.
+ * Register a cleanup operation that receives the named scope's exit.
  */
-export const andFinallyExit = <E>(
+export const andFinallyExit = <const Scope extends string, E>(
+  scope: Scope,
   f: (exit: Exit) => Fx<E, void>
-): Fx<Finally, void> =>
-  new Finally(exit => f(exit))
+): Fx<Finally<Scope>, void> =>
+  new Finally({ scope, finalizer: exit => f(exit) })
 
 /**
  * Run an initial operation, register cleanup for its result, and return it.
  */
-export const using = <const IE, const FE, const R>(
+export const using = <const Scope extends string, const IE, const FE, const R>(
+  scope: Scope,
   initially: Fx<IE, R>,
   finally_: (r: R) => Fx<FE, void>
-): Fx<IE | Finally, R> => fx(function* () {
+): Fx<IE | Finally<Scope>, R> => fx(function* () {
   const r = yield* initially
-  yield* andFinally(finally_(r))
+  yield* andFinally(scope, finally_(r))
   return r
 })
 
 /**
  * Run an initial operation, register exit-aware cleanup for its result, and return it.
  */
-export const usingExit = <const IE, const FE, const R>(
+export const usingExit = <const Scope extends string, const IE, const FE, const R>(
+  scope: Scope,
   initially: Fx<IE, R>,
   finally_: (r: R, exit: Exit) => Fx<FE, void>
-): Fx<IE | Finally, R> => fx(function* () {
+): Fx<IE | Finally<Scope>, R> => fx(function* () {
   const r = yield* initially
-  yield* andFinallyExit(exit => finally_(r, exit))
+  yield* andFinallyExit(scope, exit => finally_(r, exit))
   return r
 })
 
 /**
- * Pair a value with cleanup for a finalization boundary.
+ * Pair a value with cleanup for a named scope.
  */
 export const managed = <const A, const E>(
   value: A,
@@ -90,43 +83,11 @@ export const managed = <const A, const E>(
 /**
  * Run an initial operation that returns a managed value, register its cleanup, and return its value.
  */
-export const usingManaged = <const IE, const FE, const A>(
+export const usingManaged = <const Scope extends string, const IE, const FE, const A>(
+  scope: Scope,
   initially: Fx<IE, Managed<A, FE>>
-): Fx<IE | Finally, A> => fx(function* () {
+): Fx<IE | Finally<Scope>, A> => fx(function* () {
   const m = yield* initially
-  yield* andFinallyExit(m.finalizer)
+  yield* andFinallyExit(scope, m.finalizer)
   return m.value
-})
-
-/**
- * Run a computation and then run its registered cleanup operations.
- */
-export const withFinalization = <const E, const A>(f: Fx<E, A>) => fx(function* () {
-  const finalizers = [] as Finalizer[]
-  const result = yield* f.pipe(
-    handle(Finally, finally_ => ok(void finalizers.push(finally_.arg))),
-    returnFail
-  )
-
-  const failed = Fail.is(result)
-  const exit = failed
-    ? { type: 'failure', failure: result as Fail<unknown> } satisfies Exit
-    : { type: 'success', value: result } satisfies Exit
-  const failures = yield* releaseSafely(finalizers, exit)
-  if (failures.length > 0)
-    return yield* fail(new AggregateError(
-      failed ? [result.arg, ...failures] : failures,
-      'Resource release failed'
-    ))
-
-  return failed ? yield* fail(result.arg) : result
-}) as Fx<Handle<E, Finally, Fail<AggregateError>>, A>
-
-const releaseSafely = (resources: readonly Finalizer[], exit: Exit) => fx(function* () {
-  const failures = [] as unknown[]
-  for (let i = resources.length - 1; i >= 0; --i) {
-    const r = yield* returnFail(resources[i](exit))
-    if (Fail.is(r)) failures.push(r.arg)
-  }
-  return failures
 })

--- a/src/ReturnFrom.test.ts
+++ b/src/ReturnFrom.test.ts
@@ -1,0 +1,65 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { fx, run } from './Fx.js'
+import { ReturnFrom, returnFrom } from './ReturnFrom.js'
+import { scope } from './Scope.js'
+
+describe('ReturnFrom', () => {
+  const TestScope = 'test/ReturnFrom' as const
+
+  it('returns early from the matching scope with a value', () => {
+    const result = fx(function* () {
+      yield* returnFrom(TestScope, 'early')
+      return 'late'
+    }).pipe(
+      scope(TestScope),
+      run
+    )
+
+    assert.equal(result, 'early')
+  })
+
+  it('does not run code after returnFrom', () => {
+    let ran = false
+
+    const result = fx(function* () {
+      yield* returnFrom(TestScope, 'early')
+      ran = true
+      return 'late'
+    }).pipe(
+      scope(TestScope),
+      run
+    )
+
+    assert.equal(result, 'early')
+    assert.equal(ran, false)
+  })
+
+  it('propagates returnFrom for non-matching scopes', () => {
+    const OtherScope = 'test/ReturnFrom/other' as const
+    const f = fx(function* () {
+      yield* returnFrom(OtherScope, 'other')
+      return 'late'
+    }).pipe(scope(TestScope))
+
+    const next = f[Symbol.iterator]().next()
+
+    assert.equal(ReturnFrom.is(next.value), true)
+  })
+
+  it('only catches the nearest matching scope name', () => {
+    const OtherScope = 'test/ReturnFrom/other' as const
+
+    const result = fx(function* () {
+      return yield* fx(function* () {
+        yield* returnFrom(TestScope, 'inner')
+        return 'late'
+      }).pipe(scope(OtherScope))
+    }).pipe(
+      scope(TestScope),
+      run
+    )
+
+    assert.equal(result, 'inner')
+  })
+})

--- a/src/ReturnFrom.ts
+++ b/src/ReturnFrom.ts
@@ -1,0 +1,16 @@
+import { Effect } from './Effect.js'
+import { Fx } from './Fx.js'
+
+/**
+ * Return early from the named scope with a value.
+ */
+export class ReturnFrom<const Scope extends string, const A> extends Effect('fx/ReturnFrom')<{
+  readonly scope: Scope
+  readonly value: A
+}, never> { }
+
+export const returnFrom = <const Scope extends string, const A>(
+  scope: Scope,
+  value: A
+): Fx<ReturnFrom<Scope, A>, never> =>
+  new ReturnFrom({ scope, value })

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -1,0 +1,133 @@
+import { Abort } from './Abort.js'
+import { isEffect } from './Effect.js'
+import { Fail, fail, returnFail } from './Fail.js'
+import { Finalizer, Finally } from './Finalization.js'
+import { Fx, fx } from './Fx.js'
+import { CapturedHandler, HandlerCapture } from './HandlerCapture.js'
+import { ReturnFrom } from './ReturnFrom.js'
+import { Pipeable, pipeThis } from './internal/pipe.js'
+
+export type Exit<
+  Scope extends string = string,
+  A = unknown,
+  F extends Fail<unknown> = Fail<unknown>,
+  R = unknown
+> =
+  | Success<A>
+  | Failure<F>
+  | ReturnedFrom<Scope, R>
+  | Aborted<Scope>
+
+export interface Success<A> {
+  readonly type: 'success'
+  readonly value: A
+}
+
+export interface Failure<F extends Fail<unknown>> {
+  readonly type: 'failure'
+  readonly failure: F
+}
+
+export interface ReturnedFrom<Scope extends string, A> {
+  readonly type: 'returnFrom'
+  readonly scope: Scope
+  readonly value: A
+}
+
+export interface Aborted<Scope extends string> {
+  readonly type: 'abort'
+  readonly scope: Scope
+}
+
+export function scope<const Scope extends string>(
+  name: Scope
+): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>> {
+  return <const E, const A>(f: Fx<E, A>) =>
+    new ScopeBoundary(f, name) as Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>>
+}
+
+export type ScopeEffects<E, Scope extends string> =
+  HandleScopeEffect<E, Scope> | CleanupFailure<E, Scope>
+
+type HandleScopeEffect<E, Scope extends string> =
+  E extends Finally<Scope> ? never
+  : E extends ReturnFrom<Scope, any> ? never
+  : E
+
+type CleanupFailure<E, Scope extends string> =
+  Extract<E, Finally<Scope>> extends never ? never : Fail<AggregateError>
+
+export type ReturnValue<E, Scope extends string> =
+  E extends ReturnFrom<Scope, infer A> ? A : never
+
+class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipeable, CapturedHandler {
+  public readonly pipe = pipeThis as Pipeable['pipe']
+
+  constructor(
+    public readonly fx: Fx<E, A>,
+    public readonly scopeName: Scope
+  ) { }
+
+  wrap(fx: Fx<unknown, unknown>): Fx<unknown, unknown> {
+    return new ScopeBoundary(fx, this.scopeName)
+  }
+
+  *[Symbol.iterator](): Iterator<unknown, A> {
+    const finalizers = [] as Finalizer[]
+    const i = this.fx[Symbol.iterator]()
+    try {
+      let ir = i.next()
+
+      while (!ir.done) {
+        if (isEffect(ir.value)) {
+          const effect = ir.value
+
+          if (Finally.is(effect) && effect.arg.scope === this.scopeName) {
+            finalizers.push(effect.arg.finalizer)
+            ir = i.next(undefined)
+          } else if (ReturnFrom.is(effect) && effect.arg.scope === this.scopeName) {
+            const exit = { type: 'returnFrom', scope: this.scopeName, value: effect.arg.value } satisfies Exit<Scope>
+            const failures = yield* releaseSafely(finalizers, exit)
+            if (failures.length > 0) return (yield* failCleanup(failures)) as A
+            return effect.arg.value as A
+          } else if (Abort.is(effect) && effect.arg === this.scopeName) {
+            const exit = { type: 'abort', scope: this.scopeName } satisfies Exit<Scope>
+            const failures = yield* releaseSafely(finalizers, exit)
+            if (failures.length > 0) return (yield* failCleanup(failures)) as A
+            return yield effect
+          } else if (Fail.is(effect)) {
+            const exit = { type: 'failure', failure: effect } satisfies Exit
+            const failures = yield* releaseSafely(finalizers, exit)
+            if (failures.length > 0) return (yield* failCleanup([effect.arg, ...failures])) as A
+            return yield effect
+          } else if (HandlerCapture.is(effect)) {
+            ir = i.next([this, ...(yield effect) as any])
+          } else {
+            ir = i.next(yield effect)
+          }
+        } else {
+          throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
+        }
+      }
+
+      const exit = { type: 'success', value: ir.value } satisfies Exit<Scope, A>
+      const failures = yield* releaseSafely(finalizers, exit)
+      if (failures.length > 0) return (yield* failCleanup(failures)) as A
+      return ir.value
+    } finally {
+      i.return?.()
+    }
+  }
+}
+
+const releaseSafely = (resources: readonly Finalizer[], exit: Exit) => fx(function* () {
+  const failures = [] as unknown[]
+  for (let i = resources.length - 1; i >= 0; --i) {
+    const r = yield* returnFail(resources[i](exit))
+    if (Fail.is(r)) failures.push(r.arg)
+  }
+  return failures
+})
+
+const failCleanup = (failures: readonly unknown[]) =>
+  fail(new AggregateError(failures, 'Resource release failed'))

--- a/src/Stream.test.ts
+++ b/src/Stream.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test'
 import { orReturn } from './Abort.js'
 import { unbounded } from './Concurrent.js'
 import { fx, map as mapFx, ok, run, runPromise, unit, type Fx } from './Fx.js'
+import { scope } from './Scope.js'
 import { next as nextSink } from './Sink.js'
 import {
   emit,
@@ -15,6 +16,7 @@ import {
   repeat,
   switchMap,
   take,
+  TakeScope,
   to,
   toAsyncIterable,
   withEnqueue,
@@ -46,7 +48,8 @@ describe('Stream', () => {
       const n = Math.floor(Math.random() * 100)
       const [r, events] = repeat(ok(x)).pipe(
         take(n),
-        orReturn(n),
+        scope(TakeScope),
+        orReturn(TakeScope, n),
         collectAll,
         run
       )
@@ -65,7 +68,8 @@ describe('Stream', () => {
         return 'done'
       }).pipe(
         take(n - 1),
-        orReturn('aborted'),
+        scope(TakeScope),
+        orReturn(TakeScope, 'aborted'),
         collectAll,
         run
       )
@@ -82,7 +86,8 @@ describe('Stream', () => {
         return 'done'
       }).pipe(
         take(n),
-        orReturn('aborted'),
+        scope(TakeScope),
+        orReturn(TakeScope, 'aborted'),
         collectAll,
         run
       )

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -17,6 +17,8 @@ import { IfAny } from './internal/type.js'
  */
 export class Stream<A> extends Effect('fx/Stream')<A, void> { }
 
+export const TakeScope = 'fx/Stream/take' as const
+
 export type Event<T> = T extends Stream<infer A> ? A : never
 
 export type ExcludeStream<E, E2 = never> = Handle<E, Stream<any>, E2>
@@ -49,9 +51,9 @@ export const take = (n: number) => <const E, const A, const R>(f: Fx<E | Stream<
       --i
       return resume(yield* emit(stream.arg))
     } else {
-      return yield* abort
+      return yield* abort(TakeScope)
     }
-  }))) as Fx<Handle<E, Stream<A>, Stream<A> | Abort>, A>
+  }))) as Fx<Handle<E, Stream<A>, Stream<A> | Abort<typeof TakeScope>>, A>
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export * from './Effect.js'
 export * from './Fx.js'
 export * from './Handler.js'
 export * from './HandlerCapture.js'
+export * from './ReturnFrom.js'
+export * from './Scope.js'
 export * from './Trace.js'
 
 export * from './runtime.js'


### PR DESCRIPTION
## Summary

Adds named `scope(name)(fx)` boundaries and scoped control effects for `ReturnFrom`, `Abort`, and `Finally`.

## Changes

- Adds `Scope` with a composite named boundary that handles matching `ReturnFrom`, scoped `Finally`, and observes/re-emits scoped `Abort` after finalization.
- Adds `ReturnFrom` and `returnFrom(scope, value)` for value-carrying early return.
- Updates `Abort` to require an explicit scope and adds scoped `orReturn(scope, value)` for abort recovery.
- Updates finalization helpers to register cleanup against explicit scopes.
- Updates `Stream.take` and existing examples to use explicit scopes and scope-aware abort recovery.
- Adds `examples/scope/read-csv.ts`, a focused CSV import example showing non-local `returnFrom` from nested helper code plus scoped finalization.
- Makes scope boundaries participate in handler capture so scoped finalization/control is preserved across `all/defaultAll` child tasks.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm tsx examples/resources.ts`
- `pnpm tsx examples/scope/read-csv.ts`

The resources example now reports the original failure site at `examples/resources.ts:26` with `Error: Simulated failure` as the cause.