### PR TITLE
[codex] Add PR branch history guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@ Development guidance:
 - Add focused tests under `src/*.test.ts` for behavior and type-level expectations where relevant.
 - Do not edit `dist/` directly; build output is generated.
 - Keep examples practical and small.
+- Never force push to a remote PR branch or PR worktree unless specifically told to do so. Always maintain full history on PR branches and PR worktrees.


### PR DESCRIPTION
## Summary

- Add AGENTS.md guidance that agents must not force push remote PR branches or PR worktrees unless explicitly instructed.
- State that PR branches and PR worktrees should preserve full history.

## Validation

- Docs-only change; no tests run.