### PR TITLE
[codex] Add active scope diagnostics

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -6,6 +6,7 @@ import { Fx, fx } from './Fx.js'
 import { CapturedHandler, HandlerCapture } from './HandlerCapture.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
+import { withActiveScope } from './internal/runtimeContext.js'
 
 export const brand = <Brand>() =>
   <const Name extends string>(name: Name): Name & Brand =>
@@ -78,7 +79,7 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
 
   *[Symbol.iterator](): Iterator<unknown, A> {
     const finalizers = [] as Finalizer[]
-    const i = this.fx[Symbol.iterator]()
+    const i = withActiveScope(this.scopeName, this.fx)[Symbol.iterator]()
     try {
       let ir = i.next()
 
@@ -91,18 +92,18 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
             ir = i.next(undefined)
           } else if (ReturnFrom.is(effect) && effect.arg.scope === this.scopeName) {
             const exit = { type: 'returnFrom', scope: this.scopeName, value: effect.arg.value } satisfies Exit<Scope>
-            const failures = yield* releaseSafely(finalizers, exit)
-            if (failures.length > 0) return (yield* failCleanup(failures)) as A
+            const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
+            if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup(failures))) as A
             return effect.arg.value as A
           } else if (Abort.is(effect) && effect.arg === this.scopeName) {
             const exit = { type: 'abort', scope: this.scopeName } satisfies Exit<Scope>
-            const failures = yield* releaseSafely(finalizers, exit)
-            if (failures.length > 0) return (yield* failCleanup(failures)) as A
+            const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
+            if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup(failures))) as A
             return yield effect
           } else if (Fail.is(effect)) {
             const exit = { type: 'failure', failure: effect } satisfies Exit
-            const failures = yield* releaseSafely(finalizers, exit)
-            if (failures.length > 0) return (yield* failCleanup([effect.arg, ...failures])) as A
+            const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
+            if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup([effect.arg, ...failures]))) as A
             return yield effect
           } else if (HandlerCapture.is(effect)) {
             ir = i.next([this, ...(yield effect) as any])
@@ -115,8 +116,8 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
       }
 
       const exit = { type: 'success', value: ir.value } satisfies Exit<Scope, A>
-      const failures = yield* releaseSafely(finalizers, exit)
-      if (failures.length > 0) return (yield* failCleanup(failures)) as A
+      const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
+      if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup(failures))) as A
       return ir.value
     } finally {
       i.return?.()
@@ -133,5 +134,6 @@ const releaseSafely = (resources: readonly Finalizer[], exit: Exit) => fx(functi
   return failures
 })
 
-const failCleanup = (failures: readonly unknown[]) =>
-  fail(new AggregateError(failures, 'Resource release failed'))
+const failCleanup = (failures: readonly unknown[]) => fx(function* () {
+  return yield* fail(new AggregateError(failures, 'Resource release failed'))
+})

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -4,8 +4,10 @@ import { assertPromise, tryPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
 import { all, defaultAll, firstSettled, fork, race, unbounded } from './Concurrent.js'
 import { Fail, fail, returnFail } from './Fail.js'
+import { andFinally } from './Finalization.js'
 import { fx, runPromise } from './Fx.js'
 import { defaultRetry, retry } from './Retry.js'
+import { scope } from './Scope.js'
 import { wait } from './Task.js'
 import { sleep, withClock } from './Time.js'
 import { TimeoutError, defaultTimeout, timeout } from './Timeout.js'
@@ -136,6 +138,64 @@ describe('Trace', () => {
     }
   })
 
+  it('captures active scopes in trace snapshots ordered outer-to-inner', async () => {
+    const f = fx(function* () {
+      yield* fail(new Error('scoped failure'))
+    }).pipe(
+      scope('db/transaction'),
+      scope('http/request')
+    )
+
+    await assert.rejects(
+      runPromise(f as never),
+      e => {
+        assert.deepEqual(snapshotError(e).trace?.activeScopes, ['http/request', 'db/transaction'])
+        return true
+      }
+    )
+  })
+
+  it('omits active scope diagnostics for unscoped traced errors', () => {
+    const formatted = formatDiagnostic(tracedError('unscoped', 'plain trace'), { colors: 'never' })
+
+    assert.doesNotMatch(formatted, /Active scopes:/)
+  })
+
+  it('formats active scopes compactly on one line', async () => {
+    const f = fx(function* () {
+      yield* fail(new Error('scoped formatting'))
+    }).pipe(
+      scope('db/transaction'),
+      scope('http/request')
+    )
+
+    await assert.rejects(
+      runPromise(f as never),
+      e => {
+        assert.match(formatDiagnostic(e, { colors: 'never' }), /Active scopes: http\/request > db\/transaction/)
+        assert.match(formatError(e), /Active scopes: http\/request > db\/transaction/)
+        return true
+      }
+    )
+  })
+
+  it('compacts deep active scope stacks', async () => {
+    const scoped = ['a', 'b', 'c', 'd', 'e'].reduceRight(
+      (f, name) => f.pipe(scope(name)),
+      fx(function* () {
+        yield* fail(new Error('deep scopes'))
+      })
+    )
+
+    await assert.rejects(
+      runPromise(scoped as never),
+      e => {
+        assert.match(formatDiagnostic(e, { colors: 'never' }), /Active scopes: a > \.\.\. > c > d > e/)
+        return true
+      }
+    )
+  })
+
   it('does not rewrite traces captured before entering a region', async () => {
     const prebuilt = fail(new Error('prebuilt'))
 
@@ -201,6 +261,78 @@ describe('Trace', () => {
     } finally {
       setTraceCapturePolicy(previous)
     }
+  })
+
+  it('propagates active scopes to forked children', async () => {
+    const f = fx(function* () {
+      const task = yield* fork(fx(function* () {
+        yield* fail(new Error('fork scoped'))
+      }))
+      yield* wait(task)
+    }).pipe(scope('http/request'))
+
+    await assert.rejects(
+      runPromise(f.pipe(unbounded) as never),
+      e => {
+        assert.deepEqual(snapshotError(e).trace?.activeScopes, ['http/request'])
+        return true
+      }
+    )
+  })
+
+  it('propagates active scopes through structured concurrency handlers', async () => {
+    const allProgram = fx(function* () {
+      yield* all([fx(function* () { yield* fail(new Error('all scoped')) })]).pipe(defaultAll)
+    }).pipe(scope('http/request'))
+    const raceProgram = fx(function* () {
+      yield* race([fx(function* () { yield* fail(new Error('race scoped')) })]).pipe(firstSettled)
+    }).pipe(scope('http/request'))
+
+    await assert.rejects(
+      runPromise(allProgram.pipe(unbounded) as never),
+      e => {
+        assert.deepEqual(snapshotError(e).trace?.activeScopes, ['http/request'])
+        return true
+      }
+    )
+    await assert.rejects(
+      runPromise(raceProgram.pipe(unbounded) as never),
+      e => {
+        assert.deepEqual(snapshotError(e).trace?.activeScopes, ['http/request'])
+        return true
+      }
+    )
+  })
+
+  it('propagates active scopes to async failures', async () => {
+    const f = fx(function* () {
+      yield* tryPromise(() => Promise.reject(new Error('async scoped')))
+    }).pipe(scope('http/request'))
+
+    await assert.rejects(
+      runPromise(f as never),
+      e => {
+        assert.deepEqual(snapshotError(e).trace?.activeScopes, ['http/request'])
+        return true
+      }
+    )
+  })
+
+  it('captures active scopes for cleanup failures', async () => {
+    const f = fx(function* () {
+      yield* andFinally('db/transaction', fail(new Error('cleanup scoped')))
+    }).pipe(scope('db/transaction'))
+
+    await assert.rejects(
+      runPromise(f as never),
+      e => {
+        const formatted = formatDiagnostic(e, { colors: 'never' })
+        assert.deepEqual(snapshotError(e).trace?.activeScopes, ['db/transaction'])
+        assert.match(formatted, /AggregateError: Resource release failed/)
+        assert.match(formatted, /Active scopes: db\/transaction/)
+        return true
+      }
+    )
   })
 
   it('wait converts task failures using the task runtime context', async () => {

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -5,7 +5,7 @@ import {
 } from './internal/tracePolicy.js'
 import type { TraceCapturePolicy } from './internal/tracePolicy.js'
 import type { Fx } from './Fx.js'
-import { capturesTrace, withRuntimeContext } from './internal/runtimeContext.js'
+import { activeScopes, capturesTrace, withRuntimeContext } from './internal/runtimeContext.js'
 
 export type { TraceCapturePolicy }
 export { getTraceCapturePolicy, setTraceCapturePolicy }
@@ -35,6 +35,7 @@ export interface TraceFrame {
 export interface Trace {
   readonly frame: TraceFrame
   readonly parent?: Trace
+  readonly activeScopes?: readonly string[]
   readonly depth: number
   readonly truncated: boolean
   readonly acyclic?: true
@@ -66,6 +67,7 @@ export interface TraceSnapshotFrame {
 
 export interface TraceSnapshot {
   readonly frames: readonly TraceSnapshotFrame[]
+  readonly activeScopes?: readonly string[]
   readonly truncated: boolean
   readonly cycleDetected: boolean
 }
@@ -146,7 +148,7 @@ export const appendTrace = (trace: Trace, parent?: Trace): Trace => {
     }
   }
 
-  return fromFrames(frames, truncated)
+  return fromFrames(frames, truncated, trace.activeScopes)
 }
 
 export const captureAppendTrace = (trace: Trace | undefined, parent?: Trace): Trace | undefined =>
@@ -204,6 +206,7 @@ export const snapshotTrace = (trace: Trace): TraceSnapshot => {
 
   return {
     frames,
+    ...(trace.activeScopes === undefined || trace.activeScopes.length === 0 ? {} : { activeScopes: trace.activeScopes }),
     truncated: trace.truncated,
     cycleDetected: current !== undefined
   }
@@ -240,7 +243,11 @@ export const formatError = (error: unknown): string => {
   const trace = getTrace(error)
   if (trace === undefined) return formatErrorValue(error)
 
-  return `${formatErrorValue(rootCause(error))}\n${formatTrace(trace)}`
+  return [
+    formatErrorValue(rootCause(error)),
+    ...formatActiveScopes(trace.activeScopes),
+    formatTrace(trace)
+  ].join('\n')
 }
 
 export const formatDiagnostic = (error: unknown, options?: DiagnosticFormatOptions): string => {
@@ -250,11 +257,13 @@ export const formatDiagnostic = (error: unknown, options?: DiagnosticFormatOptio
 }
 
 const prependFrame = (frame: TraceFrame, parent?: Trace): Trace => {
-  if (parent === undefined) return { frame, depth: 1, truncated: false, acyclic: true }
+  const scopes = traceActiveScopes(parent)
+  if (parent === undefined) return { frame, ...scopes, depth: 1, truncated: false, acyclic: true }
   if (parent.depth < MaxTraceDepth) {
     return {
       frame,
       parent,
+      ...scopes,
       depth: parent.depth + 1,
       truncated: parent.truncated,
       acyclic: parent.acyclic
@@ -268,16 +277,17 @@ const prependFrame = (frame: TraceFrame, parent?: Trace): Trace => {
     current = current.parent
   }
 
-  return fromFrames(frames, true)
+  return fromFrames(frames, true, scopes.activeScopes)
 }
 
-const fromFrames = (frames: readonly TraceFrame[], truncated: boolean): Trace => {
+const fromFrames = (frames: readonly TraceFrame[], truncated: boolean, activeScopes?: readonly string[]): Trace => {
   let trace: Trace | undefined
 
   for (let i = frames.length - 1; i >= 0; i--) {
     trace = {
       frame: frames[i],
       parent: trace,
+      ...(i === 0 && activeScopes !== undefined && activeScopes.length > 0 ? { activeScopes } : {}),
       depth: (trace?.depth ?? 0) + 1,
       truncated,
       acyclic: true
@@ -302,7 +312,14 @@ const appendTraceFast = (trace: Trace, parent: Trace): Trace => {
     current = current.parent
   }
 
-  return fromFrames(frames, false)
+  return fromFrames(frames, false, trace.activeScopes)
+}
+
+const traceActiveScopes = (parent: Trace | undefined): Pick<Trace, 'activeScopes'> => {
+  const scopes = activeScopes()
+  if (scopes.length > 0) return { activeScopes: scopes }
+  if (parent?.activeScopes !== undefined && parent.activeScopes.length > 0) return { activeScopes: parent.activeScopes }
+  return {}
 }
 
 const firstStackLocation = (stack: string | undefined): TraceLocation | undefined => {
@@ -426,6 +443,15 @@ const aggregateErrors = (error: unknown): readonly unknown[] | undefined => {
   return undefined
 }
 
+const formatActiveScopes = (scopes: readonly string[] | undefined, context?: FormatContext): readonly string[] => {
+  if (scopes === undefined || scopes.length === 0) return []
+  const label = context?.style.section('Active scopes') ?? 'Active scopes'
+  return [`${label}: ${compactActiveScopes(scopes).join(' > ')}`]
+}
+
+const compactActiveScopes = (scopes: readonly string[]): readonly string[] =>
+  scopes.length <= 4 ? scopes : [scopes[0], '...', ...scopes.slice(-3)]
+
 interface FormatContext {
   readonly style: DiagnosticStyle
   readonly source?: SourceFormatContext
@@ -476,6 +502,7 @@ const formatDiagnosticError = (
   const prefix = ' '.repeat(indent)
   lines.push(`${prefix}${formatDiagnosticHeader(error, context)}`)
   formatDiagnosticFields(error.fields, lines, indent, context)
+  formatDiagnosticActiveScopes(error.trace?.activeScopes, lines, indent, context)
 
   if (error.trace !== undefined) {
     const omitTraceSuffix = options.omitTraceSuffix ?? 0
@@ -497,6 +524,18 @@ const formatDiagnosticError = (
   if (error.aggregate !== undefined) {
     formatDiagnosticAggregate(error, lines, indent, context)
   }
+}
+
+const formatDiagnosticActiveScopes = (
+  scopes: readonly string[] | undefined,
+  lines: string[],
+  indent: number,
+  context: FormatContext
+): void => {
+  const formatted = formatActiveScopes(scopes, context)
+  if (formatted.length === 0) return
+  const prefix = ' '.repeat(indent)
+  lines.push(`${prefix}${formatted[0]}`)
 }
 
 const formatDiagnosticHeader = (error: DiagnosticErrorSnapshot, context: FormatContext): string => {

--- a/src/internal/runtimeContext.ts
+++ b/src/internal/runtimeContext.ts
@@ -11,6 +11,7 @@ import { Pipeable, pipeThis } from './pipe.js'
  */
 export interface RuntimeContext {
   readonly traceCapturePolicy?: TraceCapturePolicy
+  readonly activeScopes?: readonly string[]
 }
 
 export const RuntimeContextTypeId = Symbol('fx/RuntimeContext')
@@ -67,6 +68,15 @@ export const capturesTrace = (context?: RuntimeContext): boolean =>
 
 export const capturesStack = (context?: RuntimeContext): boolean =>
   traceCapturePolicy(context) === 'full'
+
+export const activeScopes = (context: RuntimeContext | undefined = activeRuntimeContext): readonly string[] =>
+  context?.activeScopes ?? []
+
+export const withActiveScope = <E, A>(scope: string, fx: Fx<E, A>): Fx<E, A> => {
+  const scopes = activeScopes()
+  const nextScopes = scopes.at(-1) === scope ? scopes : [...scopes, scope]
+  return withRuntimeContext({ activeScopes: nextScopes }, fx)
+}
 
 const mergeRuntimeContext = (
   previous: RuntimeContext | undefined,


### PR DESCRIPTION
## Summary

Adds compact active-scope diagnostics to Fx traces so failures can show the named scope stack that was active when trace metadata was captured.

## Changes

- Carry active named scopes through the internal runtime context.
- Run named scope bodies and cleanup paths under the scope diagnostic context.
- Include active scopes in trace snapshots.
- Render compact scope output in `formatError` and `formatDiagnostic`, for example `Active scopes: http/request > db/transaction`.
- Add coverage for formatting, nested scopes, async/fork propagation, structured concurrency, cleanup failures, and trace capture policy regressions.

## Notes

While validating `examples/resources.ts`, I found a separate pre-existing cancellation/finalization bug where cancelled sibling tasks do not release scoped finalizers. That behavior reproduces on `main` and is intentionally not fixed in this PR.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`