### PR TITLE
[codex] Finalize scopes on task interruption

### DIFF
--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -3,15 +3,19 @@ import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { RaceAllFailed, all, defaultAll, firstSettled, firstSuccess, fork, forkEach, race, unbounded } from './Concurrent.js'
-import { andFinally } from './Finalization.js'
-import { flatMap, fx, ok, runPromise } from './Fx.js'
+import { RaceAllFailed, all, bounded, defaultAll, firstSettled, firstSuccess, fork, forkEach, race, unbounded } from './Concurrent.js'
+import { andFinally, andFinallyExit } from './Finalization.js'
+import { bracket, flatMap, fx, ok, runPromise } from './Fx.js'
 import { handle } from './Handler.js'
-import { scope } from './Scope.js'
+import { scope, type Exit } from './Scope.js'
 import { Task, wait } from './Task.js'
 import { getTrace, snapshotError } from './Trace.js'
 
 const asyncValue = <A>(a: A) => assertPromise(() => Promise.resolve(a))
+
+// @ts-expect-error markHandled is runtime-internal bookkeeping, not public API.
+const noPublicMarkHandled: typeof import('./Task.js').markHandled = undefined
+void noPublicMarkHandled
 
 describe('Fork', () => {
   describe('unbounded', () => {
@@ -58,6 +62,18 @@ describe('Fork', () => {
       const t = await f.pipe(fork, unbounded, runPromise)
       const r = await t.promise
       assert.deepEqual(r, x)
+    })
+
+    it('does not mark tasks handled until wait is run', async () => {
+      const task = await asyncValue('done').pipe(fork, unbounded, runPromise)
+
+      const constructed = wait(task)
+      assert.equal(task._handled, false)
+
+      const result = await constructed.pipe(runPromise)
+
+      assert.equal(result, 'done')
+      assert.equal(task._handled, true)
     })
 
     it('runs forked tasks with handlers outside the fork handler', async () => {
@@ -280,6 +296,96 @@ describe('Fork', () => {
       assert.deepEqual(released, ['child'])
     })
 
+    it('releases scoped finalizers when all cancels a sibling', async () => {
+      const TestScope = 'test/Fork/AllCancelScope' as const
+      const released = [] as string[]
+      const cause = new Error('all failed')
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          released.push('slow')
+        }))
+        yield* awaitAbort()
+      })
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow, bad]).pipe(
+        defaultAll,
+        scope(TestScope),
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.deepEqual(released, ['slow'])
+    })
+
+    it('surfaces cleanup failures when all cancels a sibling', async () => {
+      const TestScope = 'test/Fork/AllCancelCleanupFailure' as const
+      const cause = new Error('all failed')
+      const releaseFailure = new Error('release failed')
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* awaitAbort()
+      })
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow, bad]).pipe(
+        defaultAll,
+        scope(TestScope),
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof AggregateError)
+      assert.equal(result.arg.message, 'Resource release failed')
+      assert.equal(result.arg.errors.length, 2)
+      assert.equal((result.arg.errors[0] as Error).cause, cause)
+      assert.equal(result.arg.errors[1], releaseFailure)
+    })
+
+    it('reports every cleanup failure when all cancels siblings', async () => {
+      const TestScope = 'test/Fork/AllCancelMultipleCleanupFailures' as const
+      const cause = new Error('all failed')
+      const firstReleaseFailure = new Error('first release failed')
+      const secondReleaseFailure = new Error('second release failed')
+
+      const slow = (releaseFailure: Error) => fx(function* () {
+        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* awaitAbort()
+      })
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow(firstReleaseFailure), bad, slow(secondReleaseFailure)]).pipe(
+        defaultAll,
+        scope(TestScope),
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof AggregateError)
+      assert.equal(result.arg.message, 'Resource release failed')
+      assert.equal(result.arg.errors.length, 3)
+      assert.equal((result.arg.errors[0] as Error).cause, cause)
+      assert.deepEqual(result.arg.errors.slice(1), [firstReleaseFailure, secondReleaseFailure])
+    })
+
     it('types all as a value tuple rather than a Task', async () => {
       const result = await fx(function* () {
         const values = yield* all([ok(1), ok('two')])
@@ -326,6 +432,52 @@ describe('Fork', () => {
 
       assert.equal(result, 'winner')
       assert.equal(cancelled, true)
+    })
+
+    it('releases scoped finalizers when race cancels the loser', async () => {
+      const TestScope = 'test/Fork/RaceCancelScope' as const
+      const released = [] as string[]
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          released.push('slow')
+        }))
+        yield* awaitAbort()
+      })
+
+      const result = await race([ok('winner'), slow]).pipe(
+        firstSettled,
+        scope(TestScope),
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.equal(result, 'winner')
+      assert.deepEqual(released, ['slow'])
+    })
+
+    it('fails when a race loser cleanup fails after a successful winner', async () => {
+      const TestScope = 'test/Fork/RaceCancelCleanupFailure' as const
+      const releaseFailure = new Error('release failed')
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* awaitAbort()
+      })
+
+      const result = await race([ok('winner'), slow]).pipe(
+        firstSettled,
+        scope(TestScope),
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof AggregateError)
+      assert.equal(result.arg.message, 'Resource release failed')
+      assert.deepEqual(result.arg.errors, [releaseFailure])
     })
 
     it('runs children with handlers between race and firstSettled', async () => {
@@ -394,6 +546,29 @@ describe('Fork', () => {
       assert.equal(cancelled, true)
     })
 
+    it('fails when firstSuccess loser cleanup fails after a successful winner', async () => {
+      const TestScope = 'test/Fork/FirstSuccessCancelCleanupFailure' as const
+      const releaseFailure = new Error('release failed')
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* awaitAbort()
+      })
+
+      const result = await race([ok('winner'), slow]).pipe(
+        firstSuccess,
+        scope(TestScope),
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof AggregateError)
+      assert.equal(result.arg.message, 'Resource release failed')
+      assert.deepEqual(result.arg.errors, [releaseFailure])
+    })
+
     it('fails with input-ordered errors when every child fails', async () => {
       const first = new Error('first failed')
       const second = new Error('second failed')
@@ -460,6 +635,328 @@ describe('Fork', () => {
   })
 })
 
+describe('Task interruption finalization', () => {
+  it('explicit task disposal releases scoped finalizers', async () => {
+    const TestScope = 'test/Fork/DisposeScope' as const
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          released.push('task')
+        }))
+        yield* awaitAbort()
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['task'])
+  })
+
+  it('runs interrupted scoped finalizers once when task disposal is repeated', async () => {
+    const TestScope = 'test/Fork/DisposeOnceScope' as const
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          released.push('task')
+        }))
+        yield* awaitAbort()
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['task'])
+  })
+
+  it('provides interrupted exit to exit-aware finalizers', async () => {
+    const TestScope = 'test/Fork/InterruptedExitScope' as const
+    const exits = [] as Exit[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinallyExit(TestScope, exit => fx(function* () {
+          exits.push(exit)
+        }))
+        yield* awaitAbort()
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope }])
+  })
+
+  it('disposes queued bounded tasks before semaphore acquisition', async () => {
+    const events = [] as string[]
+    const child = (label: string) => fx(function* () {
+      events.push(`start ${label}`)
+      yield* awaitAbort()
+    })
+
+    const tasks = await fx(function* () {
+      const first = yield* fork(child('first'))
+      const second = yield* fork(child('second'))
+      const third = yield* fork(child('third'))
+      return [first, second, third] as const
+    }).pipe(
+      bounded(1),
+      runPromise
+    )
+
+    assert.deepEqual(events, ['start first'])
+    await withTimeout(tasks[1]._disposeAndWait(), 100)
+
+    await tasks[0]._disposeAndWait()
+    await eventually(() => events.includes('start third'))
+    assert.deepEqual(events, ['start first', 'start third'])
+
+    await tasks[2]._disposeAndWait()
+  })
+
+  it('runs async effects in interrupted finalizers before disposal completes', async () => {
+    const TestScope = 'test/Fork/InterruptedAsyncFinalizer' as const
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          yield* asyncValue(undefined)
+          released.push('task')
+        }))
+        yield* awaitAbort()
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['task'])
+  })
+
+  it('drains effects yielded from wrapped iterator return during interruption', async () => {
+    const TestScope = 'test/Fork/InterruptedInnerReturn' as const
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* bracket(
+          ok(undefined),
+          () => fx(function* () {
+            yield* asyncValue(undefined)
+            released.push('inner')
+          }),
+          () => awaitAbort()
+        )
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['inner'])
+  })
+
+  it('drains wrapped iterator return after interrupted scoped finalizer yields', async () => {
+    const TestScope = 'test/Fork/InterruptedScopeThenInnerReturn' as const
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          yield* asyncValue(undefined)
+          released.push('scope')
+        }))
+        yield* bracket(
+          ok(undefined),
+          () => fx(function* () {
+            yield* asyncValue(undefined)
+            released.push('inner')
+          }),
+          () => awaitAbort()
+        )
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['scope', 'inner'])
+  })
+
+  it('documents async cleanup rejection wrapper during interruption', async () => {
+    const TestScope = 'test/Fork/InterruptedAsyncCleanupRejection' as const
+    const releaseFailure = new Error('async release failed')
+
+    const slow = fx(function* () {
+      yield* andFinally(TestScope, assertPromise(() => Promise.reject(releaseFailure)))
+      yield* awaitAbort()
+    })
+
+    const result = await race([ok('winner'), slow]).pipe(
+      firstSettled,
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    )
+
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.equal(result.arg.message, 'Resource release failed')
+    assert.equal(result.arg.errors.length, 1)
+    const [cleanupFailure] = result.arg.errors
+    const snapshot = snapshotError(cleanupFailure)
+    assert.equal(snapshot.code, 'FX_AWAITED_ASYNC_FAILED')
+    assert.equal(snapshot.cause?.message, 'async release failed')
+  })
+
+  it('aggregates interrupted scoped and wrapped iterator cleanup failures', async () => {
+    const TestScope = 'test/Fork/InterruptedMultipleCleanupFailures' as const
+    const scopeFailure = new Error('scope release failed')
+    const innerFailure = new Error('inner release failed')
+
+    const slow = fx(function* () {
+      yield* andFinally(TestScope, fail(scopeFailure))
+      yield* bracket(
+        ok(undefined),
+        () => fail(innerFailure),
+        () => awaitAbort()
+      )
+    })
+
+    const result = await race([ok('winner'), slow]).pipe(
+      firstSettled,
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    )
+
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.equal(result.arg.message, 'Resource release failed')
+    assert.deepEqual(result.arg.errors, [scopeFailure, innerFailure])
+  })
+
+  it('aggregates interrupted scoped cleanup failure with synchronous iterator return throw', async () => {
+    const TestScope = 'test/Fork/InterruptedReturnThrow' as const
+    const scopeFailure = new Error('scope release failed')
+    const innerFailure = new Error('inner hard throw')
+    const throwsOnReturn = (): ReturnType<typeof awaitAbort> => ({
+      pipe: ok(undefined).pipe.bind(ok(undefined)),
+      [Symbol.iterator]() {
+        const iterator = awaitAbort()[Symbol.iterator]()
+        return {
+          next: iterator.next.bind(iterator),
+          return() {
+          throw innerFailure
+          }
+        } satisfies Iterator<unknown, void, unknown>
+      }
+    })
+
+    const slow = fx(function* () {
+      yield* andFinally(TestScope, fail(scopeFailure))
+      yield* throwsOnReturn()
+    })
+
+    const result = await race([ok('winner'), slow]).pipe(
+      firstSettled,
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      runPromise
+    )
+
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.equal(result.arg.message, 'Resource release failed')
+    assert.deepEqual(result.arg.errors, [scopeFailure, innerFailure])
+  })
+
+  it('runs interrupted finalizers through outer handlers', async () => {
+    const TestScope = 'test/Fork/InterruptedOuterHandler' as const
+    class Release extends Effect('test/Fork/InterruptedOuterHandler/Release')<void, void> { }
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinally(TestScope, new Release())
+        yield* awaitAbort()
+      }))
+    }).pipe(
+      scope(TestScope),
+      returnFail,
+      unbounded,
+      handle(Release, () => fx(function* () {
+        released.push('task')
+      })),
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['task'])
+  })
+
+  it('runs interrupted finalizers through captured handlers', async () => {
+    const TestScope = 'test/Fork/InterruptedCapturedHandler' as const
+    class Release extends Effect('test/Fork/InterruptedCapturedHandler/Release')<void, void> { }
+    const released = [] as string[]
+
+    const task = taskOrThrow(await fx(function* () {
+      return yield* fork(fx(function* () {
+        yield* andFinally(TestScope, new Release())
+        yield* awaitAbort()
+      }))
+    }).pipe(
+      scope(TestScope),
+      handle(Release, () => fx(function* () {
+        released.push('task')
+      })),
+      returnFail,
+      unbounded,
+      runPromise
+    ))
+
+    await task._disposeAndWait()
+
+    assert.deepEqual(released, ['task'])
+  })
+})
+
 const firstLine = (e: unknown): string =>
   e instanceof Error ? e.stack?.split('\n')[0] ?? '' : ''
 
@@ -471,4 +968,31 @@ const traceMessages = (e: unknown) => {
     trace = trace.parent
   }
   return messages
+}
+
+const awaitAbort = () => assertPromise<void>(signal => new Promise(resolve => {
+  signal.addEventListener('abort', () => resolve(), { once: true })
+}))
+
+const withTimeout = async <A>(promise: Promise<A>, ms: number): Promise<A> =>
+  await Promise.race([
+    promise,
+    delay(ms).then(() => {
+      throw new Error(`Timed out after ${ms}ms`)
+    })
+  ])
+
+const eventually = async (f: () => boolean): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    if (f()) return
+    await delay(5)
+  }
+  assert.equal(f(), true)
+}
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+const taskOrThrow = <A, E>(task: Task<A, E> | Fail<unknown>): Task<A, E> => {
+  assert.ok(!Fail.is(task))
+  return task
 }

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -307,21 +307,57 @@ type TaskErrorsOf<Tasks extends readonly Task<unknown, unknown>[]> = {
 }
 
 const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
+  tasks.forEach(t => t._markHandled())
   const d = new DisposeAll(tasks)
-  const p = Promise.all(tasks.map(t => t.promise)).finally(() => { d[Symbol.dispose]() })
-  return new Task(p, d, currentRuntimeContext()) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
+  const p = Promise.all(tasks.map(t => t.promise)).then(
+    async value => {
+      const cleanupFailures = await d.disposeAndWait()
+      if (cleanupFailures.length > 0) throw resourceReleaseFailed(cleanupFailures)
+      return value
+    },
+    async failure => {
+      const cleanupFailures = await d.disposeAndWait()
+      if (cleanupFailures.length > 0) throw resourceReleaseFailed([failure, ...cleanupFailures])
+      throw failure
+    }
+  )
+  return new Task(p, d, currentRuntimeContext(), d.disposed) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
 }
 
 const taskRace = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
+  tasks.forEach(t => t._markHandled())
   const d = new DisposeAll(tasks)
-  const p = Promise.race(tasks.map(t => t.promise)).finally(() => { d[Symbol.dispose]() })
-  return new Task(p, d, currentRuntimeContext()) as Task<TaskResult<Tasks[number]>, TaskErrors<Tasks[number]>>
+  const p = Promise.race(tasks.map(t => t.promise)).then(
+    async value => {
+      const cleanupFailures = await d.disposeAndWait()
+      if (cleanupFailures.length > 0) throw resourceReleaseFailed(cleanupFailures)
+      return value as TaskResult<Tasks[number]>
+    },
+    async failure => {
+      const cleanupFailures = await d.disposeAndWait()
+      if (cleanupFailures.length > 0) throw resourceReleaseFailed([failure, ...cleanupFailures])
+      throw failure
+    }
+  )
+  return new Task(p, d, currentRuntimeContext(), d.disposed) as Task<TaskResult<Tasks[number]>, TaskErrors<Tasks[number]>>
 }
 
 const taskFirstSuccess = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
+  tasks.forEach(t => t._markHandled())
   const d = new DisposeAll(tasks)
-  const p = firstSuccessfulPromise(tasks).finally(() => { d[Symbol.dispose]() })
-  return new Task(p, d, currentRuntimeContext()) as Task<TaskResult<Tasks[number]>, RaceAllFailed<TaskErrorsOf<Tasks>>>
+  const p = firstSuccessfulPromise(tasks).then(
+    async value => {
+      const cleanupFailures = await d.disposeAndWait()
+      if (cleanupFailures.length > 0) throw resourceReleaseFailed(cleanupFailures)
+      return value
+    },
+    async failure => {
+      const cleanupFailures = await d.disposeAndWait()
+      if (cleanupFailures.length > 0) throw resourceReleaseFailed([failure, ...cleanupFailures])
+      throw failure
+    }
+  )
+  return new Task(p, d, currentRuntimeContext(), d.disposed) as Task<TaskResult<Tasks[number]>, RaceAllFailed<TaskErrorsOf<Tasks>>>
 }
 
 const firstSuccessfulPromise = async <Tasks extends readonly Task<unknown, unknown>[]>(
@@ -350,6 +386,47 @@ const firstSuccessfulPromise = async <Tasks extends readonly Task<unknown, unkno
 }
 
 class DisposeAll {
-  constructor(private readonly tasks: Iterable<Task<unknown, unknown>>) { }
-  [Symbol.dispose]() { for (const t of this.tasks) t[Symbol.dispose]() }
+  private readonly disposedResolver = Promise.withResolvers<void>()
+  readonly disposed = this.disposedResolver.promise
+  private disposedPromise?: Promise<readonly unknown[]>
+
+  constructor(private readonly tasks: Iterable<Task<unknown, unknown>>) {
+    this.disposed.catch(() => { })
+  }
+
+  [Symbol.dispose]() { void this.disposeAndWait() }
+
+  disposeAndWait() {
+    this.disposedPromise ??= Promise.allSettled([...this.tasks].map(t => t._disposeAndWait())).then(
+      results => {
+        const failures = results.flatMap(result =>
+          result.status === 'rejected' ? cleanupFailuresOf(result.reason) : []
+        )
+        if (failures.length > 0) this.disposedResolver.reject(resourceReleaseFailed(failures))
+        else this.disposedResolver.resolve()
+        return failures
+      }
+    )
+    return this.disposedPromise
+  }
 }
+
+const resourceReleaseFailed = (failures: readonly unknown[]) =>
+  new AggregateError(failures, 'Resource release failed')
+
+const cleanupFailuresOf = (failure: unknown): readonly unknown[] => {
+  // TODO: Investigate focused unwrapping for disposal-time ForkError wrappers
+  // around rejected Async cleanup, while preserving useful runtime traces.
+  const cleanupFailure = isResourceReleaseFailure(failure)
+    ? failure
+    : typeof failure === 'object' && failure !== null && 'cause' in failure && isResourceReleaseFailure(failure.cause)
+    ? failure.cause
+    : undefined
+
+  return cleanupFailure === undefined
+    ? [failure]
+    : cleanupFailure.errors.flatMap(cleanupFailuresOf)
+}
+
+const isResourceReleaseFailure = (failure: unknown): failure is AggregateError =>
+  failure instanceof AggregateError && failure.message === 'Resource release failed'

--- a/src/HandlerCapture.ts
+++ b/src/HandlerCapture.ts
@@ -1,6 +1,7 @@
 import { Effect, EffectType, isEffect } from './Effect.js'
 import { Fx, map } from './Fx.js'
 import { Answer, Handler } from './internal/Handler.js'
+import { isInterpretingReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 
 export interface CapturedHandler {
@@ -64,12 +65,11 @@ class HandlerCaptureBoundary<E, A> implements Fx<E, A>, Pipeable {
 
   *[Symbol.iterator](): Iterator<E, A> {
     const i = this.fx[Symbol.iterator]()
-    try {
-      let ir = i.next()
-
+    const { captureName } = this
+    const step = function* (ir: IteratorResult<E, A>): Generator<E, A, unknown> {
       while (!ir.done) {
         if (isEffect(ir.value)) {
-          if (HandlerCapture.is(ir.value) && ir.value.arg === this.captureName) {
+          if (HandlerCapture.is(ir.value) && ir.value.arg === captureName) {
             ir = i.next([])
           } else {
             ir = i.next(yield ir.value as any)
@@ -80,8 +80,18 @@ class HandlerCaptureBoundary<E, A> implements Fx<E, A>, Pipeable {
       }
 
       return ir.value
+    }
+
+    let completed = false
+    try {
+      const value = yield* step(i.next())
+      completed = true
+      return value
     } finally {
-      i.return?.()
+      if (!completed) {
+        const ir = i.return?.()
+        if (ir !== undefined && isInterpretingReturn()) yield* step(ir)
+      }
     }
   }
 }

--- a/src/HttpServerNode.ts
+++ b/src/HttpServerNode.ts
@@ -85,7 +85,7 @@ const runNodeServer = <E, OE>(
       server => closeNodeServer(server).pipe(
         flatMap(() => observe({ type: 'closed', timestamp: eventTimestamp() }))
       ),
-      server => drainNodeHttpEvents(events, server, observe)
+      () => drainNodeHttpEvents(events, observe)
     )
   ).pipe(
     flatMap(rethrowObservedFail)
@@ -164,10 +164,9 @@ const closeNodeServer = (
 
 const drainNodeHttpEvents = <E>(
   events: Queue.Dequeue<ServerInternalEvent>,
-  server: StartedNodeHttpServer,
   observe: (event: ServerEvent) => Fx<E, void>
 ): Fx<Exclude<E, Fail<any>> | Async | Fail<NodeHttpError>, void | Extract<E, Fail<any>>> => fx(function* () {
-    const dequeue = dequeueNodeHttpEvent(events, server)
+    const dequeue = dequeueNodeHttpEvent(events)
 
     while (!events.disposed) {
       const next = yield* dequeue
@@ -183,8 +182,7 @@ const drainNodeHttpEvents = <E>(
   })
 
 const dequeueNodeHttpEvent = (
-  events: Queue.Dequeue<ServerInternalEvent>,
-  started: StartedNodeHttpServer
+  events: Queue.Dequeue<ServerInternalEvent>
 ): Fx<Async | Fail<NodeHttpError>, Queue.Dequeued<ServerInternalEvent> | Queue.Disposed> =>
   tryPromise(signal => new Promise<Queue.Dequeued<ServerInternalEvent> | Queue.Disposed>((resolve, reject) => {
     let settled = false
@@ -198,11 +196,8 @@ const dequeueNodeHttpEvent = (
       if (settled) return
       settled = true
       signal.removeEventListener('abort', onAbort)
-      started.cleanup()
       events[Symbol.dispose]()
-      started.server.close(error =>
-        error ? reject(error) : resolve({ tag: 'fx/Queue/Disposed' } as Queue.Disposed)
-      )
+      resolve({ tag: 'fx/Queue/Disposed' } as Queue.Disposed)
     }
 
     signal.addEventListener('abort', onAbort)

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -5,6 +5,7 @@ import { Finalizer, Finally } from './Finalization.js'
 import { Fx, fx } from './Fx.js'
 import { CapturedHandler, HandlerCapture } from './HandlerCapture.js'
 import { ReturnFrom } from './ReturnFrom.js'
+import { isInterpretingReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { withActiveScope } from './internal/runtimeContext.js'
 
@@ -22,6 +23,7 @@ export type Exit<
   | Failure<F>
   | ReturnedFrom<Scope, R>
   | Aborted<Scope>
+  | Interrupted<Scope>
 
 export interface Success<A> {
   readonly type: 'success'
@@ -41,6 +43,11 @@ export interface ReturnedFrom<Scope extends string, A> {
 
 export interface Aborted<Scope extends string> {
   readonly type: 'abort'
+  readonly scope: Scope
+}
+
+export interface Interrupted<Scope extends string> {
+  readonly type: 'interrupted'
   readonly scope: Scope
 }
 
@@ -79,34 +86,42 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
 
   *[Symbol.iterator](): Iterator<unknown, A> {
     const finalizers = [] as Finalizer[]
-    const i = withActiveScope(this.scopeName, this.fx)[Symbol.iterator]()
-    try {
-      let ir = i.next()
-
+    const { scopeName } = this
+    const i = withActiveScope(scopeName, this.fx)[Symbol.iterator]()
+    const captured: CapturedHandler = {
+      wrap: fx => new ScopeBoundary(fx, scopeName)
+    }
+    let released = false
+    const release = function* (exit: Exit): Generator<unknown, readonly unknown[]> {
+      if (released) return []
+      released = true
+      return yield* withActiveScope(scopeName, releaseSafely(finalizers, exit))
+    }
+    const step = function* (ir: IteratorResult<unknown, A>): Generator<unknown, A, unknown> {
       while (!ir.done) {
         if (isEffect(ir.value)) {
           const effect = ir.value
 
-          if (Finally.is(effect) && effect.arg.scope === this.scopeName) {
+          if (Finally.is(effect) && effect.arg.scope === scopeName) {
             finalizers.push(effect.arg.finalizer)
             ir = i.next(undefined)
-          } else if (ReturnFrom.is(effect) && effect.arg.scope === this.scopeName) {
-            const exit = { type: 'returnFrom', scope: this.scopeName, value: effect.arg.value } satisfies Exit<Scope>
-            const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
-            if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup(failures))) as A
+          } else if (ReturnFrom.is(effect) && effect.arg.scope === scopeName) {
+            const exit = { type: 'returnFrom', scope: scopeName, value: effect.arg.value } satisfies Exit<Scope>
+            const failures = yield* release(exit)
+            if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A
             return effect.arg.value as A
-          } else if (Abort.is(effect) && effect.arg === this.scopeName) {
-            const exit = { type: 'abort', scope: this.scopeName } satisfies Exit<Scope>
-            const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
-            if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup(failures))) as A
-            return yield effect
+          } else if (Abort.is(effect) && effect.arg === scopeName) {
+            const exit = { type: 'abort', scope: scopeName } satisfies Exit<Scope>
+            const failures = yield* release(exit)
+            if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A
+            return (yield effect) as A
           } else if (Fail.is(effect)) {
             const exit = { type: 'failure', failure: effect } satisfies Exit
-            const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
-            if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup([effect.arg, ...failures]))) as A
-            return yield effect
+            const failures = yield* release(exit)
+            if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup([effect.arg, ...failures]))) as A
+            return (yield effect) as A
           } else if (HandlerCapture.is(effect)) {
-            ir = i.next([this, ...(yield effect) as any])
+            ir = i.next([captured, ...(yield effect) as any])
           } else {
             ir = i.next(yield effect)
           }
@@ -116,11 +131,40 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
       }
 
       const exit = { type: 'success', value: ir.value } satisfies Exit<Scope, A>
-      const failures = yield* withActiveScope(this.scopeName, releaseSafely(finalizers, exit))
-      if (failures.length > 0) return (yield* withActiveScope(this.scopeName, failCleanup(failures))) as A
+      const failures = yield* release(exit)
+      if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A
       return ir.value
+    }
+
+    let completed = false
+    try {
+      const value = yield* step(i.next())
+      completed = true
+      return value
     } finally {
-      i.return?.()
+      const interpretingReturn = isInterpretingReturn()
+      const cleanupFailures = [] as unknown[]
+      try {
+        const exit = { type: 'interrupted', scope: scopeName } satisfies Exit<Scope>
+        cleanupFailures.push(...yield* release(exit))
+      } catch (e) {
+        cleanupFailures.push(e)
+      } finally {
+        if (!completed) {
+          try {
+            const ir = i.return?.()
+            if (ir !== undefined && interpretingReturn) {
+              const result = yield* returnFail(fx(function* () {
+                return yield* step(ir)
+              }))
+              if (Fail.is(result)) cleanupFailures.push(result.arg)
+            }
+          } catch (e) {
+            cleanupFailures.push(e)
+          }
+        }
+      }
+      if (cleanupFailures.length > 0) yield* withActiveScope(scopeName, failCleanup(cleanupFailures))
     }
   }
 }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,5 +1,4 @@
 import { Async, assertPromise } from './Async.js'
-
 import { Fail, fail } from './Fail.js'
 import { Fx, flatten, ok } from './Fx.js'
 import type { RuntimeContext } from './internal/runtimeContext.js'
@@ -7,19 +6,44 @@ import { withActiveRuntimeContext } from './internal/runtimeContext.js'
 
 export class Task<A, E> {
   private disposed = false
+  private handled = false
   public readonly E!: E
 
   constructor(
     public readonly promise: Promise<A>,
     private readonly dispose: Disposable,
-    public readonly _runtimeContext?: RuntimeContext
+    public readonly _runtimeContext?: RuntimeContext,
+    private readonly disposedPromise: Promise<void> = Promise.resolve()
   ) {
+    this.disposedPromise.catch(() => { })
   }
 
   [Symbol.dispose]() {
     if (this.disposed) return
     this.disposed = true
+    this.promise.catch(() => { })
     this.dispose[Symbol.dispose]()
+  }
+
+  /** @internal Runtime-owned disposal helper. */
+  async _disposeAndWait() {
+    this[Symbol.dispose]()
+    await this.disposedPromise
+  }
+
+  /** @internal Runtime-owned unhandled fork diagnostic state. */
+  get _disposed() {
+    return this.disposed
+  }
+
+  /** @internal Runtime-owned unhandled fork diagnostic state. */
+  get _handled() {
+    return this.handled
+  }
+
+  /** @internal Runtime-owned unhandled fork diagnostic state. */
+  _markHandled() {
+    this.handled = true
   }
 }
 
@@ -29,6 +53,7 @@ export const dispose = <const A, const E>(t: Task<A, E>) =>
 export const wait = <const A, const E>(t: Task<A, E>) =>
   flatten(assertPromise<Fx<E | Fail<unknown>, A>>(
     s => {
+      t._markHandled()
       const dispose = () => t[Symbol.dispose]()
       s.addEventListener('abort', dispose)
 

--- a/src/internal/Handler.ts
+++ b/src/internal/Handler.ts
@@ -1,6 +1,7 @@
 import { EffectType, isEffect } from '../Effect.js'
 import { Fx } from '../Fx.js'
 import { HandlerCapture, type CapturedHandler } from '../HandlerCapture.js'
+import { isInterpretingReturn } from './iteratorClose.js'
 import { Pipeable, pipeThis } from './pipe.js'
 import { getRuntimeContext, withActiveRuntimeContext, withRuntimeContext } from './runtimeContext.js'
 
@@ -23,9 +24,10 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, CapturedHandler {
   *[Symbol.iterator](): Iterator<E, A> {
     const { effectId, handler, fx } = this
     const i = fx[Symbol.iterator]()
-    try {
-      let ir = i.next()
-
+    const captured: CapturedHandler = {
+      wrap: fx => new Handler(fx, effectId, handler)
+    }
+    const step = function* (ir: IteratorResult<E, A>): Generator<E, A, unknown> {
       while (!ir.done) {
         if (isEffect(ir.value)) {
           const effect = ir.value
@@ -36,7 +38,7 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, CapturedHandler {
               : withActiveRuntimeContext(context, () => handler(effect))
             ir = i.next(yield* withRuntimeContext(context, handled) as any)
           } else if (HandlerCapture.is(effect)) {
-            ir = i.next([this, ...(yield effect) as any])
+            ir = i.next([captured, ...(yield effect) as any])
           } else {
             ir = i.next(yield effect as any)
           }
@@ -46,8 +48,17 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, CapturedHandler {
       }
 
       return ir.value
+    }
+    let completed = false
+    try {
+      const value = yield* step(i.next())
+      completed = true
+      return value
     } finally {
-      i.return?.()
+      if (!completed) {
+        const ir = i.return?.()
+        if (ir !== undefined && isInterpretingReturn()) yield* step(ir)
+      }
     }
   }
 }
@@ -71,9 +82,7 @@ export class Control<E, A> implements Fx<E, A>, Pipeable {
 
     const { effectId, handler, fx } = this
     const i = fx[Symbol.iterator]()
-    try {
-      let ir = i.next()
-
+    const step = function* (ir: IteratorResult<E, A>): Generator<E, A, unknown> {
       while (!ir.done) {
         if (isEffect(ir.value)) {
           const effect = ir.value
@@ -95,8 +104,17 @@ export class Control<E, A> implements Fx<E, A>, Pipeable {
       }
 
       return ir.value
+    }
+    let completed = false
+    try {
+      const value = yield* step(i.next())
+      completed = true
+      return value
     } finally {
-      i.return?.()
+      if (!completed) {
+        const ir = i.return?.()
+        if (ir !== undefined && isInterpretingReturn()) yield* step(ir)
+      }
     }
   }
 }

--- a/src/internal/iteratorClose.ts
+++ b/src/internal/iteratorClose.ts
@@ -1,0 +1,18 @@
+let interpretingReturn = false
+
+export const withInterpretedReturn = <A>(f: () => A): A => {
+  // Runtime interruption closes generators by calling iterator.return(). A
+  // generator can yield cleanup effects from finally while return() is on the
+  // stack, so the flag is intentionally synchronous-only: wrappers may drain
+  // those yielded effects only for this runtime close path, not for ordinary
+  // user-level control flow or other iterator switching.
+  const previous = interpretingReturn
+  interpretingReturn = true
+  try {
+    return f()
+  } finally {
+    interpretingReturn = previous
+  }
+}
+
+export const isInterpretingReturn = () => interpretingReturn

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -9,6 +9,7 @@ import { attachTrace, captureAppendTrace, capturePrependTrace, captureTrace, get
 import type { Trace, TraceFrameMetadata, TraceOptions } from '../Trace.js'
 import { Semaphore } from './Semaphore.js'
 import { DisposableSet, dispose } from './disposable.js'
+import { withInterpretedReturn } from './iteratorClose.js'
 import type { RuntimeContext } from './runtimeContext.js'
 import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext } from './runtimeContext.js'
 
@@ -18,25 +19,33 @@ export type RunForkOptions = TraceOptions & {
 
 export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCapture<string>, const A>(f: Fx<E, A>, options: RunForkOptions = {}): Task<A, Extract<E, Fail<any>>> => {
   const disposables = new DisposableSet()
+  const disposed = Promise.withResolvers<void>()
   const runtimeContext = currentRuntimeContext()
   const origin = options.origin ?? at('fx/runFork', runFork)
   const trace = options.trace ?? captureTraceWithContext(runtimeContext, origin, undefined, { kind: 'run' })
   const maxConcurrency = options.maxConcurrency ?? Infinity
 
-  const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, origin, trace, runtimeContext)
-    .finally(() => dispose(disposables))
+  const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, disposed, origin, trace, runtimeContext)
+    .finally(() => {
+      dispose(disposables)
+      disposed.resolve()
+    })
 
-  return taskWithRuntimeContext(promise, disposables, runtimeContext)
+  return taskWithRuntimeContext(promise, disposables, runtimeContext, disposed.promise)
 }
 
 export const acquireAndRunFork = (f: ForkContext, s: Semaphore, context: readonly CapturedHandler[] = [], runtimeContext: RuntimeContext | undefined = currentRuntimeContext()): Task<unknown, unknown> => {
   const disposables = new DisposableSet()
+  const disposed = Promise.withResolvers<void>()
 
-  const promise = acquire(s, disposables,
-    () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, f.origin, f.trace, runtimeContext)
-      .finally(() => dispose(disposables)))
+  const promise = acquire(s, disposables, disposed,
+    () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, runtimeContext)
+      .finally(() => {
+        dispose(disposables)
+        disposed.resolve()
+      }))
 
-  return taskWithRuntimeContext(promise, disposables, runtimeContext)
+  return taskWithRuntimeContext(promise, disposables, runtimeContext, disposed.promise)
 }
 
 const runForkInternal = <const E, const A>(
@@ -44,6 +53,7 @@ const runForkInternal = <const E, const A>(
   context: readonly CapturedHandler[],
   semaphore: Semaphore,
   disposables: DisposableSet,
+  disposed: PromiseWithResolvers<void>,
   origin: Breadcrumb,
   trace: Trace | undefined,
   runtimeContext?: RuntimeContext
@@ -54,7 +64,7 @@ const runForkInternal = <const E, const A>(
   })
   unhandled.catch(() => { })
 
-  return runForkLoop(f, context, semaphore, disposables, origin, trace, unhandled, e => rejectUnhandled(new UnhandledForkError(e)), runtimeContext)
+  return runForkLoop(f, context, semaphore, disposables, disposed, origin, trace, unhandled, e => rejectUnhandled(new UnhandledForkError(e)), runtimeContext)
 }
 
 const runForkLoop = async <const E, const A>(
@@ -62,67 +72,126 @@ const runForkLoop = async <const E, const A>(
   context: readonly CapturedHandler[],
   semaphore: Semaphore,
   disposables: DisposableSet,
+  disposed: PromiseWithResolvers<void>,
   origin: Breadcrumb,
   trace: Trace | undefined,
   unhandled: Promise<never>,
   rejectUnhandled: (e: unknown) => void,
   runtimeContext?: RuntimeContext
 ): Promise<A> => {
+  let interrupting: Promise<void> | undefined
+
   try {
     const i = iteratorWithRuntimeContext(f, runtimeContext)
-    disposables.add(new IteratorDisposable(i))
-    let ir = nextWithRuntimeContext(i, runtimeContext)
-
-    while (!ir.done) {
-      if (Async.is(ir.value)) {
-        const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
-        const { run, origin } = ir.value.arg
-        const t = runTask(run, effectContext)
-        disposables.add(t)
-        const promise = t.promise.finally(() => disposables.remove(t))
-        let a
-        try {
-          a = await Promise.race([promise, unhandled])
-        } catch (e) {
-          if (e instanceof UnhandledForkError) throw e.error
-          const asyncTrace = capturePrependTraceWithContext(effectContext, origin, trace, { kind: 'async' })
-          throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext), effectContext, { cause: e })
-        }
-        // stop if the scope was disposed while we were waiting
-        if (disposables.disposed) return await never()
-        ir = resumeWithRuntimeContext(i, effectContext, a)
-      } else if (Fork.is(ir.value)) {
-        const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
-        const forkOrigin = ir.value.arg.origin
-        const forkTrace = capturePrependTraceWithContext(effectContext, forkOrigin, trace, forkFrameMetadata(ir.value.arg.trace))
-        const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext)
-        disposables.add(t)
-        t.promise
-          .finally(() => disposables.remove(t))
-          .catch(e => rejectUnhandled(
-            new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext), effectContext, { cause: e })
-          ))
-        ir = resumeWithRuntimeContext(i, effectContext, t)
-      } else if (HandlerCapture.is(ir.value)) {
-        ir = resumeWithRuntimeContext(i, runtimeContext, context)
-      } else if (Fail.is(ir.value)) {
-        const causeTrace = getTrace(ir.value.arg)
-        const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
-        const failTrace = traceUnhandledFail(ir.value, causeTrace, trace, effectContext)
-        const failOrigin = originOfUnhandledFail(ir.value, causeTrace)
-        throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, failOrigin, failTrace, effectContext, { cause: ir.value.arg })
+    const interrupt = async (): Promise<A> => {
+      if (interrupting === undefined) {
+        interrupting = interruptIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed)
+        interrupting.catch(() => { })
       }
-      else {
-        const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
-        throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, origin, traceWithCause(trace, ir.value, effectContext), effectContext, { cause: ir.value })
-      }
+      await interrupting
+      return await never()
     }
-    return ir.value as A
+    disposables.add({ [Symbol.dispose]: () => { void interrupt().catch(() => { }) } })
+    return await runIterator(nextWithRuntimeContext(i, runtimeContext), i, context, semaphore, disposables, origin, trace, unhandled, rejectUnhandled, runtimeContext, interrupt)
   } catch (e) {
-    if (e instanceof ForkError) throw e
+    if (e instanceof ForkError) {
+      if (disposables.disposed) disposed.reject(e)
+      throw e
+    }
     const errorContext = getRuntimeContext(e) ?? runtimeContext
-    throw new ForkError('FX_UNHANDLED_EXCEPTION', `Unhandled exception in forked task`, origin, traceWithCause(trace, e, errorContext), errorContext, { cause: e })
+    const error = new ForkError('FX_UNHANDLED_EXCEPTION', `Unhandled exception in forked task`, origin, traceWithCause(trace, e, errorContext), errorContext, { cause: e })
+    if (disposables.disposed) disposed.reject(error)
+    throw error
   }
+}
+
+const interruptIterator = async <const E, const A>(
+  i: Iterator<E, A, unknown>,
+  context: readonly CapturedHandler[],
+  semaphore: Semaphore,
+  origin: Breadcrumb,
+  trace: Trace | undefined,
+  unhandled: Promise<never>,
+  rejectUnhandled: (e: unknown) => void,
+  runtimeContext: RuntimeContext | undefined,
+  disposed: PromiseWithResolvers<void>
+): Promise<void> => {
+  const cleanup = new DisposableSet()
+  try {
+    const ir = returnWithRuntimeContext(i, runtimeContext)
+    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, runtimeContext)
+    disposed.resolve()
+  } catch (e) {
+    disposed.reject(e)
+    throw e
+  } finally {
+    dispose(cleanup)
+  }
+}
+
+const runIterator = async <const E, const A>(
+  ir: IteratorResult<E, A>,
+  i: Iterator<E, A, unknown>,
+  context: readonly CapturedHandler[],
+  semaphore: Semaphore,
+  disposables: DisposableSet,
+  origin: Breadcrumb,
+  trace: Trace | undefined,
+  unhandled: Promise<never>,
+  rejectUnhandled: (e: unknown) => void,
+  runtimeContext: RuntimeContext | undefined,
+  interrupt?: () => Promise<A>
+): Promise<A> => {
+  while (!ir.done) {
+    if (Async.is(ir.value)) {
+      const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
+      const { run, origin } = ir.value.arg
+      const t = runTask(run, effectContext)
+      disposables.add(t)
+      const promise = t.promise.finally(() => disposables.remove(t))
+      let a
+      try {
+        a = await Promise.race([promise, unhandled])
+      } catch (e) {
+        if (e instanceof UnhandledForkError) throw e.error
+        if (disposables.disposed && interrupt !== undefined) return await interrupt()
+        const asyncTrace = capturePrependTraceWithContext(effectContext, origin, trace, { kind: 'async' })
+        throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext), effectContext, { cause: e })
+      }
+      // stop if the scope was disposed while we were waiting
+      if (disposables.disposed && interrupt !== undefined) return await interrupt()
+      ir = resumeWithRuntimeContext(i, effectContext, a)
+    } else if (Fork.is(ir.value)) {
+      const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
+      const forkOrigin = ir.value.arg.origin
+      const forkTrace = capturePrependTraceWithContext(effectContext, forkOrigin, trace, forkFrameMetadata(ir.value.arg.trace))
+      const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext)
+      disposables.add(t)
+      t.promise
+        .finally(() => disposables.remove(t))
+        .catch(e => {
+          queueMicrotask(() => {
+            if (t._handled || t._disposed || disposables.disposed) return
+            rejectUnhandled(
+              new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext), effectContext, { cause: e })
+            )
+          })
+        })
+      ir = resumeWithRuntimeContext(i, effectContext, t)
+    } else if (HandlerCapture.is(ir.value)) {
+      ir = resumeWithRuntimeContext(i, runtimeContext, context)
+    } else if (Fail.is(ir.value)) {
+      const causeTrace = getTrace(ir.value.arg)
+      const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
+      const failTrace = traceUnhandledFail(ir.value, causeTrace, trace, effectContext)
+      const failOrigin = originOfUnhandledFail(ir.value, causeTrace)
+      throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, failOrigin, failTrace, effectContext, { cause: ir.value.arg })
+    } else {
+      const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
+      throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, origin, traceWithCause(trace, ir.value, effectContext), effectContext, { cause: ir.value })
+    }
+  }
+  return ir.value as A
 }
 
 class ForkError extends Error {
@@ -147,16 +216,46 @@ class UnhandledForkError extends Error {
   }
 }
 
-const acquire = async <A>(s: Semaphore, scope: DisposableSet, f: () => Promise<A>) => {
+const acquire = async <A>(s: Semaphore, scope: DisposableSet, disposed: PromiseWithResolvers<void>, f: () => Promise<A>) => {
   const a = s.acquire()
+  const cancelled = Promise.withResolvers<void>()
+  let acquired = false
+  let released = false
+  const releaseOnce = () => {
+    if (released) return
+    released = true
+    s.release()
+  }
+  const acquisition = {
+    [Symbol.dispose]() {
+      a[Symbol.dispose]()
+      cancelled.resolve()
+    }
+  }
+
+  scope.add(acquisition)
+  await Promise.race([
+    a.promise.then(() => {
+      acquired = true
+    }),
+    cancelled.promise
+  ])
+  scope.remove(acquisition)
+
+  if (!acquired) {
+    disposed.resolve()
+    return await never()
+  }
+
+  const interrupted = disposed.promise.then(() => {
+    releaseOnce()
+    return never<A>()
+  })
 
   try {
-    scope.add(a)
-    await a.promise
-    scope.remove(a)
-    return await f()
+    return await Promise.race([f(), interrupted])
   } finally {
-    s.release()
+    releaseOnce()
   }
 }
 
@@ -177,11 +276,12 @@ const runTask = <A>(run: (s: AbortSignal) => Promise<A>, runtimeContext?: Runtim
 const taskWithRuntimeContext = <A, E>(
   promise: Promise<A>,
   dispose: Disposable,
-  runtimeContext?: RuntimeContext
+  runtimeContext?: RuntimeContext,
+  disposed?: Promise<void>
 ): Task<A, E> =>
   runtimeContext === undefined
-    ? new Task<A, E>(promise, dispose, runtimeContext)
-    : withActiveRuntimeContext(runtimeContext, () => new Task<A, E>(promise, dispose, runtimeContext))
+    ? new Task<A, E>(promise, dispose, runtimeContext, disposed)
+    : withActiveRuntimeContext(runtimeContext, () => new Task<A, E>(promise, dispose, runtimeContext, disposed))
 
 const iteratorWithRuntimeContext = <E, A>(
   f: Fx<E, A>,
@@ -207,6 +307,15 @@ const resumeWithRuntimeContext = <E, A>(
   runtimeContext === undefined
     ? iterator.next(value)
     : withActiveRuntimeContext(runtimeContext, () => iterator.next(value))
+
+const returnWithRuntimeContext = <E, A>(
+  iterator: Iterator<E, A, unknown>,
+  runtimeContext?: RuntimeContext
+): IteratorResult<E, A> =>
+  runtimeContext === undefined
+    ? withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A })
+    : withActiveRuntimeContext(runtimeContext, () =>
+      withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A }))
 
 const never = <A>(): Promise<A> => new Promise(() => { })
 
@@ -277,9 +386,4 @@ const originFromTrace = (trace: Trace): Breadcrumb => ({
 
 class DisposableAbortController extends AbortController {
   [Symbol.dispose]() { this.abort() }
-}
-
-class IteratorDisposable {
-  constructor(private readonly iterator: Iterator<unknown>) { }
-  [Symbol.dispose]() { this.iterator.return?.() }
 }


### PR DESCRIPTION
## Summary

This fixes scoped resource release when structured concurrency interrupts a running child task. Previously, cancellation could close a generator with `iterator.return()` without interpreting cleanup effects yielded from scope boundaries, handlers, or inner `finally`/`bracket` paths. That meant scoped finalizers could be skipped when `all`, `race`, `firstSuccess`, or explicit task disposal cancelled a task.

## Changes

- Add first-class `Exit` modeling for runtime interruption via `type: 'interrupted'`.
- Interpret effects yielded during runtime `iterator.return()` so interrupted scopes and nested cleanup paths run.
- Await structured child cleanup in `all`, `race`, and `firstSuccess`, and surface cleanup failures as `AggregateError('Resource release failed')`.
- Fix bounded-concurrency disposal before semaphore acquisition so queued tasks do not hang disposal.
- Keep task disposal fire-and-forget publicly while using runtime-internal `_disposeAndWait`/handling bookkeeping.
- Simplify HTTP server bracketing so server close has a single owner.
- Add focused regression coverage for cancellation finalization, cleanup aggregation, bounded disposal, handler capture, async finalizers, and documented async rejection wrapper behavior.

## Validation

- `pnpm exec tsx --test src/Concurrent.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`