### PR TITLE
Compact duplicate concurrency trace frames

### DIFF
--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -720,6 +720,48 @@ describe('Trace', () => {
     assert.match(formatDiagnostic(error, { colors: 'never' }), /at race trace \[race child #1\]/)
   })
 
+  it('compacts same-location all child and parent frames', () => {
+    const error = tracedError(
+      'all failed',
+      'fx/Fail/fail',
+      { kind: 'fail' },
+      concurrencyTrace('all', 0, 20, 21, 20, 21)
+    )
+
+    const formatted = formatDiagnostic(error, { colors: 'never' })
+
+    assert.match(formatted, /at fx\/Concurrent\/all\[0\] \[all child #0\]/)
+    assert.doesNotMatch(formatted, /at fx\/Concurrent\/all \[all\]/)
+  })
+
+  it('compacts same-location race child and parent frames', () => {
+    const error = tracedError(
+      'race failed',
+      'fx/Fail/fail',
+      { kind: 'fail' },
+      concurrencyTrace('race', 1, 20, 21, 20, 21)
+    )
+
+    const formatted = formatDiagnostic(error, { colors: 'never' })
+
+    assert.match(formatted, /at fx\/Concurrent\/race\[1\] \[race child #1\]/)
+    assert.doesNotMatch(formatted, /at fx\/Concurrent\/race \[race\]/)
+  })
+
+  it('keeps different-location concurrency child and parent frames', () => {
+    const error = tracedError(
+      'all failed',
+      'fx/Fail/fail',
+      { kind: 'fail' },
+      concurrencyTrace('all', 0, 20, 21, 22, 23)
+    )
+
+    const formatted = formatDiagnostic(error, { colors: 'never' })
+
+    assert.match(formatted, /at fx\/Concurrent\/all\[0\] \[all child #0\]/)
+    assert.match(formatted, /at fx\/Concurrent\/all \[all\]/)
+  })
+
   it('formats source snippets with default one-line context', () => {
     const error = tracedErrorAt('source failed', 'source trace', 10, 11, { kind: 'fail' })
     const formatted = formatDiagnostic(error, {
@@ -962,6 +1004,30 @@ const sharedRaceTrace = (index: number) =>
       { kind: 'race' }
     ),
     { kind: 'race', index }
+  )
+
+const concurrencyTrace = (
+  kind: 'all' | 'race',
+  index: number,
+  childLine: number,
+  childColumn: number,
+  parentLine: number,
+  parentColumn: number
+) =>
+  prependTrace(
+    stackBreadcrumb(
+      `fx/Concurrent/${kind}[${index}]`,
+      `Error: ${kind} child\n    at child (${import.meta.filename}:${childLine}:${childColumn})`
+    ),
+    prependTrace(
+      stackBreadcrumb(
+        `fx/Concurrent/${kind}`,
+        `Error: ${kind}\n    at ${kind} (${import.meta.filename}:${parentLine}:${parentColumn})`
+      ),
+      undefined,
+      { kind }
+    ),
+    { kind, index }
   )
 
 const raceAllFailed = (errors: readonly unknown[]) => {

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -602,7 +602,7 @@ const formatDiagnosticTrace = (
 
   if (frames.length > 0) {
     lines.push(`${prefix}${context.style.section('Fx trace:')}`)
-    for (const frame of frames) {
+    for (const frame of compactConcurrencyFrames(frames)) {
       lines.push(`${prefix}  at ${formatSnapshotFrame(frame, context)}`)
       if (frame.location !== undefined) {
         lines.push(`${prefix}     ${formatTraceLocation(frame.location, context)}`)
@@ -618,6 +618,27 @@ const formatDiagnosticTrace = (
     else if (trace.truncated) lines.push(`${prefix}  ${context.style.section('<trace truncated; older frames omitted>')}`)
   }
 }
+
+const compactConcurrencyFrames = (frames: readonly TraceSnapshotFrame[]): readonly TraceSnapshotFrame[] =>
+  frames.filter((frame, i) => !isSameLocationConcurrencyParent(frame, frames[i - 1]))
+
+const isSameLocationConcurrencyParent = (
+  frame: TraceSnapshotFrame,
+  previous: TraceSnapshotFrame | undefined
+): boolean =>
+  previous !== undefined
+  && (frame.kind === 'all' || frame.kind === 'race')
+  && frame.kind === previous.kind
+  && frame.index === undefined
+  && previous.index !== undefined
+  && sameTraceLocation(frame, previous)
+
+const sameTraceLocation = (a: TraceSnapshotFrame, b: TraceSnapshotFrame): boolean =>
+  a.location !== undefined
+  && b.location !== undefined
+  && a.location.file === b.location.file
+  && a.location.line === b.location.line
+  && a.location.column === b.location.column
 
 const formatSnapshotFrame = (frame: TraceSnapshotFrame, context: FormatContext): string => {
   const metadata = formatFrameMetadata(frame)


### PR DESCRIPTION
## Summary
- compact same-location all/race child + parent frames in formatted diagnostics
- keep underlying trace snapshots and aggregate suffix logic unchanged
- add formatter coverage for all, race, and different-location frames

## Tests
- pnpm test
- pnpm typecheck
- pnpm exec tsx examples/resources.ts