### PR TITLE
[codex] Add runtime loop benchmarks and local reductions

### DIFF
--- a/benchmarks/results/2026-05-14-control-lazy-resume-rejected.md
+++ b/benchmarks/results/2026-05-14-control-lazy-resume-rejected.md
@@ -1,0 +1,25 @@
+# Control Lazy Resume Candidate
+
+- Candidate: lazily allocate the `resume` closure in `Control.[Symbol.iterator]` only when a matching controlled effect is observed.
+- Files changed during candidate: `src/internal/Handler.ts`
+- Verification: `pnpm typecheck`, `pnpm lint`, and `pnpm test` passed.
+- Decision: reject and revert.
+
+## Summary
+
+The candidate improved non-matching control pass-through but regressed the matching `control resume` path enough to fail the guardrail.
+
+## Comparison
+
+Expanded coverage baseline:
+
+| Case | Baseline ns/op | Candidate ns/op |
+| --- | ---: | ---: |
+| control resume | 11,872 | 12,477 |
+| control short-circuit | 3,864 | 3,950 |
+| control pass-through depth 0 | 12,230 | 12,136 |
+| control pass-through depth 16 | 185,250 | 178,612 |
+
+## Interpretation
+
+This shows the same tradeoff at a smaller scale: avoiding setup work helps the non-matching path, but adding lazy initialization to the matched path makes `control resume` slower. Since matching `control` is a first-class hot path in the suite, this candidate should not be kept.

--- a/benchmarks/results/2026-05-14-expanded-runtime-loop-coverage-baseline.md
+++ b/benchmarks/results/2026-05-14-expanded-runtime-loop-coverage-baseline.md
@@ -1,0 +1,39 @@
+# Expanded Runtime Loop Coverage Baseline
+
+- Date: 2026-05-14T20:42:11.504Z
+- Git SHA: d72d784
+- Worktree: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:runtime-loops`
+- Runtime state: miss-path minimal `Handler` accepted point, before Scope/HandlerCaptureBoundary reductions.
+
+## Added Coverage
+
+This run adds benchmark coverage for:
+
+- non-matching `Control` pass-through depth
+- `ScopeBoundary` pass-through depth
+- scope finalizer registration
+- scope capture depth
+- `HandlerCaptureBoundary` pass-through depth
+- matching close depth through non-matching handler capture boundaries
+
+## New Baseline Cases
+
+| Case | ns/op |
+| --- | ---: |
+| control pass-through depth 0 | 12,230 |
+| control pass-through depth 16 | 185,250 |
+| scope pass-through depth 0 | 13,468 |
+| scope pass-through depth 16 | 359,625 |
+| scope finalizer registration depth 0 | 7,630 |
+| scope finalizer registration depth 16 | 47,485 |
+| scope capture depth 0 | 3,647 |
+| scope capture depth 16 | 97,416 |
+| handler capture boundary pass-through depth 0 | 14,306 |
+| handler capture boundary pass-through depth 16 | 191,650 |
+| handler capture boundary close depth 0 | 3,085 |
+| handler capture boundary close depth 16 | 28,146 |
+
+Use this file as the comparison point for subsequent Scope and HandlerCaptureBoundary candidates.

--- a/benchmarks/results/2026-05-14-flattened-handler-prototype-learnings.md
+++ b/benchmarks/results/2026-05-14-flattened-handler-prototype-learnings.md
@@ -1,0 +1,69 @@
+# Flattened Handler Prototype Learnings
+
+The flattened adjacent ordinary-handler prototype was correct but not performance-viable as implemented. It still produced useful information for deciding what to prototype next.
+
+## What we learned
+
+### Flattening can remove depth scaling
+
+The prototype made pass-through depth nearly flat:
+
+| Case | Prototype ns/op |
+| --- | ---: |
+| pass-through depth 0 | 183,510 |
+| pass-through depth 16 | 194,118 |
+
+That confirms the core idea is directionally valid: one dispatch frame plus local handler lookup avoids repeated generator pass-through through every non-matching handler.
+
+### Fixed overhead matters more than expected
+
+The same prototype badly regressed the single-handler hot path:
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| matched handler throughput | 10,902 | 181,725 |
+
+This makes the prototype unsuitable as-is. Any future handler-stack optimization must protect the single-handler and depth-0 paths before optimizing deep stacks.
+
+### Module shape and eager imports are performance-sensitive
+
+Several variations showed that adding stack machinery near the hot `handle` path could keep depth 0 slow, even when the original internal `Handler` logic was restored. This suggests V8/module-transform/JIT behavior is sensitive to import graph and class/generator shape.
+
+Future prototypes should keep `src/internal/Handler.ts` byte-for-byte close to the current implementation unless a change is intentionally being measured, and should avoid eager stack machinery in modules that every ordinary `handle` use imports.
+
+### The benchmark suite needs hot-path guardrails
+
+The original target was deep non-matching pass-through, but the prototype showed the benchmark suite also needs to guard:
+
+- `matched handler throughput`
+- `pass-through depth 0`
+- direct internal `Handler` behavior
+- prebuilt handler stack behavior separately from stack construction
+
+Depth-16 improvement is not meaningful if depth 0 regresses materially.
+
+### Captured handler replay needs separate care
+
+The prototype also made replay depth flat but very slow:
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| replay depth 0 | 14,564 | 186,772 |
+
+Captured/replayed handler contexts should not use a flattened shape that regresses the same single-handler path.
+
+## Decision for next prototype
+
+Approach 1 is not disproven, but the integration strategy was wrong. The next prototype should focus on lazy adjacent-handler coalescing:
+
+- keep first `handle(...)` exactly as today
+- coalesce only when applying a handler to an existing ordinary `Handler`
+- keep stack machinery out of the eager single-handler hot path if possible
+- require depth 0 and matched handler throughput to stay near baseline before evaluating depth-16 gains
+
+## Suggested acceptance gates
+
+- `matched handler throughput` and `pass-through depth 0` no worse than 10-15% from baseline
+- `pass-through depth 16` materially better than baseline
+- full correctness suite passes
+- captured handler replay does not regress depth 0 materially

--- a/benchmarks/results/2026-05-14-flattened-handler-prototype-negative.md
+++ b/benchmarks/results/2026-05-14-flattened-handler-prototype-negative.md
@@ -1,0 +1,50 @@
+# Fx Runtime Loop Benchmark Results
+
+- Date: 2026-05-14T19:30:47.620Z
+- Git SHA: d72d784
+- Worktree: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:runtime-loops`
+- Handler programs yield 100 effects per operation.
+- Prototype: flattened adjacent ordinary handlers in `src/Handler.ts`.
+- Outcome: negative. The prototype reduced depth scaling but regressed the single/matched handler hot path enough to make it unsuitable as-is.
+
+| Case | Iterations | Total ms | Ops/sec | ns/op | Relative |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| matched handler throughput | 20,000 | 3634.50 | 5503 | 181725 | 1.00x |
+| pass-through depth 0 | 20,000 | 3670.20 | 5449 | 183510 | 1.01x |
+| pass-through depth 1 | 20,000 | 3696.14 | 5411 | 184807 | 1.02x |
+| pass-through depth 4 | 20,000 | 3739.05 | 5349 | 186953 | 1.03x |
+| pass-through depth 8 | 20,000 | 3791.41 | 5275 | 189571 | 1.04x |
+| pass-through depth 16 | 20,000 | 3882.35 | 5152 | 194118 | 1.07x |
+| matched handler outermost | 20,000 | 6316.07 | 3167 | 315803 | 1.74x |
+| matched handler middle | 20,000 | 4626.84 | 4323 | 231342 | 1.27x |
+| matched handler innermost | 20,000 | 3713.56 | 5386 | 185678 | 1.02x |
+| control resume | 20,000 | 246.67 | 81079 | 12334 | 0.07x |
+| control short-circuit | 20,000 | 84.87 | 235666 | 4243 | 0.02x |
+| capture depth 0 | 20,000 | 79.19 | 252555 | 3960 | 1.00x |
+| capture depth 1 | 20,000 | 91.10 | 219530 | 4555 | 1.15x |
+| capture depth 4 | 20,000 | 126.21 | 158471 | 6310 | 1.59x |
+| capture depth 8 | 20,000 | 163.86 | 122055 | 8193 | 2.07x |
+| capture depth 16 | 20,000 | 248.28 | 80555 | 12414 | 3.14x |
+| replay depth 0 | 20,000 | 3735.44 | 5354 | 186772 | 47.17x |
+| replay depth 1 | 20,000 | 3715.69 | 5383 | 185785 | 46.92x |
+| replay depth 4 | 20,000 | 3733.15 | 5357 | 186658 | 47.14x |
+| replay depth 8 | 20,000 | 3719.36 | 5377 | 185968 | 46.97x |
+| replay depth 16 | 20,000 | 3715.79 | 5382 | 185789 | 46.92x |
+| mapCapturedHandlers fanout 1 | 20,000 | 89.17 | 224289 | 4459 | 1.13x |
+| mapCapturedHandlers fanout 4 | 20,000 | 87.01 | 229865 | 4350 | 1.10x |
+| mapCapturedHandlers fanout 16 | 20,000 | 102.54 | 195037 | 5127 | 1.29x |
+| mapCapturedHandlers fanout 64 | 20,000 | 171.60 | 116549 | 8580 | 2.17x |
+| pure runPromise | 2,000 | 25.05 | 79842 | 12525 | 1.00x |
+| sequential async x10 | 2,000 | 358.57 | 5578 | 179283 | 14.31x |
+| fork fanout 16 unbounded | 2,000 | 1369.12 | 1461 | 684559 | 54.66x |
+| fork fanout 16 bounded 1 | 2,000 | 1379.03 | 1450 | 689517 | 55.05x |
+| fork fanout 16 bounded 4 | 2,000 | 1360.65 | 1470 | 680326 | 54.32x |
+| fork fanout 16 bounded 16 | 2,000 | 1349.05 | 1483 | 674527 | 53.86x |
+| all fanout 16 | 2,000 | 477.42 | 4189 | 238710 | 19.06x |
+| race fanout 16 | 2,000 | 463.30 | 4317 | 231649 | 18.50x |
+| dispose blocked task | 1,000 | 22.53 | 44390 | 22528 | 1.00x |
+| dispose blocked scoped task | 1,000 | 40.67 | 24590 | 40668 | 1.81x |
+| dispose blocked fork | 1,000 | 66.95 | 14937 | 66949 | 2.97x |

--- a/benchmarks/results/2026-05-14-handler-capture-boundary-direct-check.md
+++ b/benchmarks/results/2026-05-14-handler-capture-boundary-direct-check.md
@@ -1,0 +1,40 @@
+# HandlerCaptureBoundary Direct Check Candidate
+
+- Candidate: replace `HandlerCapture.is(ir.value)` with direct `_fxEffectId` comparison inside `HandlerCaptureBoundary`.
+- Files changed during candidate: `src/HandlerCapture.ts`
+- Verification: `pnpm typecheck`, `pnpm lint`, and `pnpm test` passed.
+- Decision: keep.
+
+## Summary
+
+This candidate is a small local reduction in an existing loop. It avoids a static `is` helper call after `isEffect` has already validated the yielded value as an effect.
+
+It did not change public APIs, class shape, constructor shape, imports, or module graph.
+
+## Primary Comparison
+
+Expanded coverage baseline:
+
+| Case | Baseline ns/op | Candidate ns/op |
+| --- | ---: | ---: |
+| handler capture boundary pass-through depth 0 | 14,306 | 14,054 |
+| handler capture boundary pass-through depth 16 | 191,650 | 186,965 |
+| handler capture boundary close depth 0 | 3,085 | 3,083 |
+| handler capture boundary close depth 4 | 9,613 | 8,957 |
+| handler capture boundary close depth 16 | 28,146 | 27,378 |
+
+## Guardrails
+
+Handler guardrails stayed in the expected range:
+
+| Case | Candidate ns/op |
+| --- | ---: |
+| matched handler throughput | 10,100 |
+| direct internal matched handler throughput | 10,070 |
+| pass-through depth 0 | 12,342 |
+| prebuilt pass-through depth 16 | 179,995 |
+| direct internal pass-through depth 16 | 181,742 |
+
+## Interpretation
+
+This is a small positive candidate. Like the Handler miss-path change, it suggests direct effect-id checks are preferable inside hot loops once `isEffect` has already established the effect shape.

--- a/benchmarks/results/2026-05-14-handler-pass-through-investigation.md
+++ b/benchmarks/results/2026-05-14-handler-pass-through-investigation.md
@@ -1,0 +1,89 @@
+# Deep Non-Matching Handler Pass-Through Investigation
+
+## Current signal
+
+The runtime-loop baseline shows steep growth as ordinary effects pass through non-matching handlers before reaching the matching handler:
+
+| Case | ns/op |
+| --- | ---: |
+| pass-through depth 0 | 13,156 |
+| pass-through depth 1 | 21,537 |
+| pass-through depth 4 | 46,733 |
+| pass-through depth 8 | 81,043 |
+| pass-through depth 16 | 190,649 |
+
+With 100 yielded effects per operation, the saved baseline implies roughly 1.1 microseconds for each additional non-matching handler per yielded effect at depth 16.
+
+## Focused measurement
+
+I compared rebuilding the handler stack per measured operation with prebuilding the stack once:
+
+| Case | ns/op |
+| --- | ---: |
+| prebuilt depth 0 | 10,887 |
+| rebuilt depth 0 | 9,787 |
+| prebuilt depth 1 | 19,221 |
+| rebuilt depth 1 | 18,212 |
+| prebuilt depth 4 | 42,345 |
+| rebuilt depth 4 | 42,846 |
+| prebuilt depth 8 | 76,492 |
+| rebuilt depth 8 | 77,219 |
+| prebuilt depth 16 | 187,919 |
+| rebuilt depth 16 | 188,575 |
+
+Conclusion: stack construction is not the primary cause. The steady-state iterator path dominates.
+
+## CPU profile
+
+A V8 CPU profile for a prebuilt depth-16 pass-through case attributes almost all samples to repeated `src/internal/Handler.ts` generator frames:
+
+| Samples | Location |
+| ---: | --- |
+| 24,455 | `src/internal/Handler.ts :: (anonymous)` |
+| 1,120 | garbage collector |
+| 972 | `src/Effect.ts :: (anonymous)` |
+| 427 | `src/Effect.ts :: is` |
+
+The profile shape matches the implementation: every non-matching handler wrapper resumes its own generator frame, checks the yielded effect, then yields it to the next outer frame.
+
+## Hot path
+
+The hot path is `Handler.[Symbol.iterator]` in `src/internal/Handler.ts`:
+
+- `isEffect(ir.value)`
+- `effectId === effect._fxEffectId`
+- `HandlerCapture.is(effect)`
+- `yield effect`
+- `i.next(...)`
+
+Each non-matching handler repeats that sequence for every yielded effect.
+
+## Semantic constraints for optimization
+
+Any optimization has to preserve:
+
+- Inner handlers get the first chance to handle effects from the original program.
+- Effects yielded by a handler implementation are handled only by handlers outside that handler, not by the same handler or handlers inside it.
+- `HandlerCapture` preserves captured handler order and does not capture handler boundaries.
+- Iterator `return()` cleanup still drains through the same interpretation path.
+- `Control` remains separate unless a later investigation proves it can share machinery safely.
+
+## Highest-value optimization direction
+
+The most promising direction is a flattened handler frame for adjacent ordinary `Handler` wrappers:
+
+- Store adjacent handlers in one object rather than nesting one generator wrapper per handler.
+- On each yielded effect, scan handler metadata in semantic order and dispatch to the first matching handler.
+- When a handler matches, run its handler-produced `Fx` under only the outer portion of the handler stack, preserving current scoping semantics.
+- On `HandlerCapture`, return captured handler entries in the same order as today.
+
+This targets the repeated generator frame bounce directly. A smaller micro-optimization, such as replacing `HandlerCapture.is(effect)` with a cached `_fxEffectId` comparison, may help but is unlikely to address the depth scaling.
+
+## Suggested next step
+
+Prototype an internal `HandlerStack` or equivalent inside `src/internal/Handler.ts`, initially only for adjacent ordinary `Handler` instances. Keep `Control` unchanged. Add focused tests for:
+
+- Matching order with multiple handlers for different effect types.
+- Handler-produced effects being handled only by outer handlers.
+- Handler capture order through flattened handlers.
+- Cleanup behavior when a flattened stack is closed early.

--- a/benchmarks/results/2026-05-14-incremental-local-runtime-loop-reductions-summary.md
+++ b/benchmarks/results/2026-05-14-incremental-local-runtime-loop-reductions-summary.md
@@ -1,0 +1,86 @@
+# Incremental Local Runtime Loop Reductions
+
+- Date: 2026-05-14T21:00:23.738Z
+- Git SHA: d72d784
+- Worktree: `/private/tmp/fx-runtime-loop-benchmarks`
+- Branch: `bench/runtime-loop-benchmarks`
+- Worktree state: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Final runtime-loop command: `pnpm benchmark:runtime-loops`
+- Final correctness checks: `pnpm typecheck`, `pnpm lint`, `pnpm test`
+
+## Final Kept Diff Summary
+
+```text
+package.json                   | 1 +
+src/HandlerCapture.ts          | 2 +-
+src/internal/Handler.ts        | 9 +++++----
+src/internal/runtimeContext.ts | 2 +-
+4 files changed, 8 insertions(+), 6 deletions(-)
+```
+
+Kept runtime changes:
+
+- `Handler`: lazy allocation of the captured handler wrapper and direct `HandlerCapture._fxEffectId` check on the ordinary miss path.
+- `HandlerCaptureBoundary`: direct `_fxEffectId` check after `isEffect` has already validated the yielded value.
+- `runtimeContext`: inline runtime-context presence check in `attachRuntimeContext` to avoid the helper call on an already guarded object.
+
+Kept benchmark changes:
+
+- Added `pnpm benchmark:runtime-loops`.
+- Added expanded runtime-loop coverage for handler execution/construction, direct internal handler execution, control pass-through, scope pass-through/finalizer/capture paths, handler capture boundary pass-through/close paths, and interrupt-mask loops.
+
+## Candidate Decisions
+
+| Candidate | Decision | Reason |
+| --- | --- | --- |
+| Miss-path minimal `Handler` | Keep | Correctness passed; repeated benchmarks showed useful handler miss-path and capture-depth improvements without the fixed-cost cliff seen in flattened/coalesced prototypes. |
+| Scope lazy capture/direct check | Revert | Correctness passed, but scope capture/finalizer signals were noisy and included regressions; not enough evidence to keep. |
+| `HandlerCaptureBoundary` direct check | Keep | Correctness passed; boundary pass-through improved modestly with no broad handler guardrail regression. |
+| `Control` lazy resume closure | Revert | Pass-through improved, but `control resume` regressed beyond the guardrail. |
+| Runtime-context attach inline check | Keep | Correctness passed; `benchmark:runtime-context` showed small regional context improvements without changing module shape. |
+| `run` interrupt-mask direct check | Revert | Correctness passed, but `run interrupt mask x100` regressed slightly, suggesting the existing checks are already well optimized. |
+
+## Final Runtime-Loop Benchmark Highlights
+
+The final cumulative benchmark includes only kept runtime changes.
+
+| Case | ns/op |
+| --- | ---: |
+| matched handler throughput | 10,250 |
+| prebuilt matched handler throughput | 10,080 |
+| direct internal matched handler throughput | 10,278 |
+| pass-through depth 0 | 11,887 |
+| prebuilt pass-through depth 0 | 11,645 |
+| direct internal pass-through depth 0 | 11,673 |
+| pass-through depth 16 | 181,419 |
+| prebuilt pass-through depth 16 | 190,968 |
+| direct internal pass-through depth 16 | 200,690 |
+| capture depth 0 | 3,452 |
+| capture depth 16 | 26,791 |
+| replay depth 0 | 13,718 |
+| control resume | 12,133 |
+| control short-circuit | 3,958 |
+| control pass-through depth 16 | 185,987 |
+| scope pass-through depth 16 | 369,737 |
+| scope finalizer registration depth 16 | 48,097 |
+| scope capture depth 16 | 99,273 |
+| handler capture boundary pass-through depth 16 | 185,875 |
+| handler capture boundary close depth 16 | 27,867 |
+| run interrupt mask x100 | 119,258 |
+
+## Interpretation
+
+The useful pattern is narrow and local: moving rare capture/context work behind a cheap check can help without changing the object/module shape that V8 currently optimizes. The accepted handler change suggests that avoiding wrapper allocation on ordinary misses is worthwhile, especially for deep pass-through and capture-heavy measurements.
+
+The rejected candidates are equally informative. Similar-looking reductions are not portable across loops: `Control` favored the existing eager resume closure on the resume path, `ScopeBoundary` showed unstable or negative results despite matching the same shape, and `run` did not benefit from direct interrupt-mask id checks. Each loop needs its own benchmark coverage and independent acceptance decision.
+
+## Next Prototype Direction
+
+The highest-value next work is not another structural handler representation. Instead, continue with isolated, per-loop micro-reductions only where benchmark coverage already identifies a cost center:
+
+- Scope pass-through remains very expensive at depth, but previous local capture changes were inconclusive. Any next scope prototype should target pass-through specifically, not capture/finalizer paths.
+- Handler capture boundary pass-through still scales with depth and may have more local miss-path opportunities.
+- Runtime-context attachment should be explored with `benchmark:runtime-context`, not handler-loop benchmarks.
+- `run` interrupt-mask changes should be left alone unless a different benchmark isolates a clearer repeated operation.

--- a/benchmarks/results/2026-05-14-isolated-handler-transpile-v8-comparison.md
+++ b/benchmarks/results/2026-05-14-isolated-handler-transpile-v8-comparison.md
@@ -1,0 +1,63 @@
+# Isolated Handler Transpile and V8 Comparison
+
+This comparison isolates ordinary handler execution from the full runtime-loop suite and compares:
+
+- clean baseline source through `tsx`
+- lazy adjacent-handler prototype source through `tsx`
+- clean baseline `tsc` output through `node`
+- lazy adjacent-handler prototype `tsc` output through `node`
+
+The baseline worktree was created detached at `main` in `/private/tmp/fx-runtime-loop-compare-baseline`. The prototype worktree was `/private/tmp/fx-runtime-loop-benchmarks`.
+
+## Source via `tsx`
+
+Command:
+
+```sh
+pnpm exec tsx /private/tmp/fx-isolated-handler-bench.ts <repo-root> src
+```
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| public matched construct+run | 12,130 | 195,006 |
+| public matched prebuilt | 13,615 | 183,184 |
+| direct internal matched prebuilt | 12,955 | 185,245 |
+| public pass-through depth 0 | 14,145 | 187,063 |
+| public pass-through depth 16 | 196,299 | 196,265 |
+| public prebuilt pass-through depth 16 | 193,284 | 211,646 |
+| direct internal prebuilt pass-through depth 16 | 192,703 | 194,263 |
+
+## Built JS via `tsc` + `node`
+
+Commands:
+
+```sh
+pnpm exec tsc --project /private/tmp/fx-runtime-loop-compare-baseline/tsconfig.build.json --typeRoots /private/tmp/fx-runtime-loop-benchmarks/node_modules/@types
+pnpm build
+node /private/tmp/fx-isolated-handler-bench.mjs <repo-root> dist
+```
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| public matched construct+run | 9,758 | 117,285 |
+| public matched prebuilt | 10,182 | 110,190 |
+| direct internal matched prebuilt | 10,588 | 111,662 |
+| public pass-through depth 0 | 11,655 | 115,777 |
+| public pass-through depth 16 | 179,428 | 121,797 |
+| public prebuilt pass-through depth 16 | 175,833 | 117,163 |
+| direct internal prebuilt pass-through depth 16 | 177,140 | 116,495 |
+
+## Interpretation
+
+This is not only a `tsx` or esbuild artifact. The `tsx` source path shows the largest optimization cliff, but built JS still regresses the single-handler path by about 10x.
+
+The prototype does prove that adjacent coalescing can reduce depth scaling in built JS: depth 16 improves from about 175-179k ns/op to about 116-122k ns/op. However, that win is not acceptable because depth 0 and matched handler throughput regress from about 10-12k ns/op to about 110-117k ns/op.
+
+The most likely explanation is V8 optimization sensitivity to module/class/generator shape. The key signal is that `direct internal matched prebuilt` regresses even though `src/internal/Handler.ts` has no diff in the prototype. Import graph and class identity shape are enough to perturb optimization of ordinary handler execution.
+
+Next investigation should use V8 optimization diagnostics on the isolated benchmark:
+
+- run a tiny matched-handler-only benchmark with `--trace-opt --trace-deopt`
+- compare baseline vs prototype built JS
+- inspect whether `Handler.[Symbol.iterator]`, `step`, `run`, or generator resume paths deopt or fail to optimize
+- test an integration that avoids changing public `Handler.ts` imports, such as an explicit opt-in coalescing constructor used only by benchmarks, before considering production integration

--- a/benchmarks/results/2026-05-14-lazy-adjacent-handler-coalescing-learnings.md
+++ b/benchmarks/results/2026-05-14-lazy-adjacent-handler-coalescing-learnings.md
@@ -1,0 +1,72 @@
+# Lazy Adjacent Handler Coalescing Learnings
+
+The lazy adjacent-handler coalescing prototype was correct, but it is not a viable production direction as implemented. It confirmed that flattening adjacent ordinary handlers can reduce deep pass-through scaling, but also exposed a large fixed-cost cliff that affects the ordinary single-handler path.
+
+## What we learned
+
+### Coalescing can reduce depth scaling
+
+The built-JS isolated benchmark showed the intended depth win:
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| public pass-through depth 16 | 179,428 | 121,797 |
+| public prebuilt pass-through depth 16 | 175,833 | 117,163 |
+| direct internal prebuilt pass-through depth 16 | 177,140 | 116,495 |
+
+This means a single dispatch frame over an adjacent handler stack is directionally useful for deep non-matching pass-through.
+
+### Fixed overhead still dominates
+
+The same prototype badly regressed the common path:
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| public matched prebuilt | 10,182 | 110,190 |
+| direct internal matched prebuilt | 10,588 | 111,662 |
+| public pass-through depth 0 | 11,655 | 115,777 |
+
+The deep-stack improvement does not compensate for a roughly 10x regression in matched and depth-0 handler execution.
+
+### This is not only a `tsx` artifact
+
+Running the same isolated benchmark through `tsx` made the cliff worse:
+
+| Case | Baseline `tsx` ns/op | Prototype `tsx` ns/op |
+| --- | ---: | ---: |
+| public matched prebuilt | 13,615 | 183,184 |
+| direct internal matched prebuilt | 12,955 | 185,245 |
+| public pass-through depth 0 | 14,145 | 187,063 |
+
+However, built `dist` output still regressed substantially. That rules out treating this purely as an esbuild/`tsx` development-runner issue.
+
+### V8 appears sensitive to module and class shape
+
+The most important signal is that `direct internal matched prebuilt` regressed even when `src/internal/Handler.ts` itself had no diff. Moving coalescing machinery into a separate internal module did not protect the hot path.
+
+That points to V8 optimization sensitivity around the broader ESM import graph, class identity/shape, generator code, or inlining decisions. The regression is too large to explain by the coalesced dispatch loop alone.
+
+### Production integration is too fragile right now
+
+Both flattened and lazy coalescing prototypes found the same failure mode: depth scaling improves only after moving the single-handler path into a much slower regime. Any handler-stack optimization must first prove that matched handler throughput and depth-0 pass-through stay near baseline.
+
+## Decision
+
+Do not continue with production-path adjacent-handler coalescing as the next optimization. Keep the benchmark improvements and negative results, but revert the lazy coalescing runtime changes before pursuing another runtime optimization.
+
+The next higher-value direction is to optimize within the existing `Handler` implementation without changing public handler module shape, adding alternate frame classes, or changing the ordinary handler import graph.
+
+Suggested next prototype: a minimal miss-path optimization inside the existing `Handler.[Symbol.iterator]`, preserving the current class/module structure and measuring:
+
+- matched handler throughput
+- public and direct internal depth-0 pass-through
+- prebuilt pass-through depth 16
+- capture and replay depth 0
+
+## Benchmark files
+
+Related results:
+
+- `2026-05-14-lazy-adjacent-handler-coalescing-negative.md`
+- `2026-05-14-isolated-handler-transpile-v8-comparison.md`
+- `2026-05-14-flattened-handler-prototype-learnings.md`

--- a/benchmarks/results/2026-05-14-lazy-adjacent-handler-coalescing-negative.md
+++ b/benchmarks/results/2026-05-14-lazy-adjacent-handler-coalescing-negative.md
@@ -1,0 +1,81 @@
+# Lazy Adjacent Handler Coalescing Prototype Results
+
+- Date: 2026-05-14T19:56:21.204Z
+- Git SHA: d72d784
+- Worktree: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:runtime-loops`
+- Handler programs yield 100 effects per operation.
+- Result: correctness passed, but performance did not meet acceptance gates.
+
+## Summary
+
+The lazy adjacent-handler coalescing prototype was correct but performance-negative. Moving the coalescing machinery into a separate internal module still left the handler hot path in the same slow regime as the previous flattened prototype:
+
+| Case | Baseline ns/op | Prototype ns/op |
+| --- | ---: | ---: |
+| matched handler throughput | 10,902 | 183,515 |
+| pass-through depth 0 | 13,156 | 184,396 |
+| pass-through depth 16 | 190,649 | 197,629 |
+| replay depth 0 | 14,564 | 185,123 |
+
+This suggests the cost is not only the coalesced dispatch loop. The public handler import/module shape and added adjacent-frame machinery are enough to move ordinary `Handler` execution into the slow regime in this benchmark process, even when `src/internal/Handler.ts` is restored and direct internal `Handler` execution is measured separately.
+
+## Results
+
+| Case | Iterations | Total ms | Ops/sec | ns/op | Relative |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| matched handler throughput | 20,000 | 3670.30 | 5449 | 183515 | 1.00x |
+| prebuilt matched handler throughput | 20,000 | 3617.97 | 5528 | 180899 | 0.99x |
+| direct internal matched handler throughput | 20,000 | 3625.99 | 5516 | 181299 | 0.99x |
+| pass-through depth 0 | 20,000 | 3687.93 | 5423 | 184396 | 1.00x |
+| pass-through depth 1 | 20,000 | 3727.42 | 5366 | 186371 | 1.02x |
+| pass-through depth 4 | 20,000 | 3730.72 | 5361 | 186536 | 1.02x |
+| pass-through depth 8 | 20,000 | 3792.35 | 5274 | 189617 | 1.03x |
+| pass-through depth 16 | 20,000 | 3952.57 | 5060 | 197629 | 1.08x |
+| prebuilt pass-through depth 0 | 20,000 | 3693.97 | 5414 | 184699 | 1.01x |
+| prebuilt pass-through depth 1 | 20,000 | 3683.60 | 5429 | 184180 | 1.00x |
+| prebuilt pass-through depth 4 | 20,000 | 3723.28 | 5372 | 186164 | 1.01x |
+| prebuilt pass-through depth 8 | 20,000 | 3770.80 | 5304 | 188540 | 1.03x |
+| prebuilt pass-through depth 16 | 20,000 | 3901.84 | 5126 | 195092 | 1.06x |
+| direct internal pass-through depth 0 | 20,000 | 3681.52 | 5433 | 184076 | 1.00x |
+| direct internal pass-through depth 1 | 20,000 | 3679.51 | 5436 | 183975 | 1.00x |
+| direct internal pass-through depth 4 | 20,000 | 3708.90 | 5392 | 185445 | 1.01x |
+| direct internal pass-through depth 8 | 20,000 | 3765.36 | 5312 | 188268 | 1.03x |
+| direct internal pass-through depth 16 | 20,000 | 3886.28 | 5146 | 194314 | 1.06x |
+| construct handler stack depth 0 | 20,000 | 5.53 | 3613751 | 277 | 0.00x |
+| construct handler stack depth 1 | 20,000 | 8.66 | 2308802 | 433 | 0.00x |
+| construct handler stack depth 4 | 20,000 | 13.22 | 1513303 | 661 | 0.00x |
+| construct handler stack depth 8 | 20,000 | 23.75 | 842031 | 1188 | 0.01x |
+| construct handler stack depth 16 | 20,000 | 30.05 | 665461 | 1503 | 0.01x |
+| matched handler outermost | 20,000 | 6571.22 | 3044 | 328561 | 1.79x |
+| matched handler middle | 20,000 | 4932.03 | 4055 | 246602 | 1.34x |
+| matched handler innermost | 20,000 | 3700.06 | 5405 | 185003 | 1.01x |
+| control resume | 20,000 | 249.41 | 80189 | 12471 | 0.07x |
+| control short-circuit | 20,000 | 79.77 | 250707 | 3989 | 0.02x |
+| capture depth 0 | 20,000 | 74.72 | 267661 | 3736 | 1.00x |
+| capture depth 1 | 20,000 | 94.77 | 211042 | 4738 | 1.27x |
+| capture depth 4 | 20,000 | 121.98 | 163961 | 6099 | 1.63x |
+| capture depth 8 | 20,000 | 160.74 | 124423 | 8037 | 2.15x |
+| capture depth 16 | 20,000 | 236.66 | 84509 | 11833 | 3.17x |
+| replay depth 0 | 20,000 | 3702.46 | 5402 | 185123 | 49.55x |
+| replay depth 1 | 20,000 | 3736.16 | 5353 | 186808 | 50.00x |
+| replay depth 4 | 20,000 | 3692.73 | 5416 | 184636 | 49.42x |
+| replay depth 8 | 20,000 | 3695.01 | 5413 | 184750 | 49.45x |
+| replay depth 16 | 20,000 | 3698.74 | 5407 | 184937 | 49.50x |
+| mapCapturedHandlers fanout 1 | 20,000 | 87.29 | 229110 | 4365 | 1.17x |
+| mapCapturedHandlers fanout 4 | 20,000 | 88.09 | 227053 | 4404 | 1.18x |
+| mapCapturedHandlers fanout 16 | 20,000 | 127.30 | 157111 | 6365 | 1.70x |
+| mapCapturedHandlers fanout 64 | 20,000 | 173.61 | 115198 | 8681 | 2.32x |
+| pure runPromise | 2,000 | 24.97 | 80104 | 12484 | 1.00x |
+| sequential async x10 | 2,000 | 352.77 | 5669 | 176387 | 14.13x |
+| fork fanout 16 unbounded | 2,000 | 1362.47 | 1468 | 681234 | 54.57x |
+| fork fanout 16 bounded 1 | 2,000 | 1373.23 | 1456 | 686616 | 55.00x |
+| fork fanout 16 bounded 4 | 2,000 | 1361.25 | 1469 | 680623 | 54.52x |
+| fork fanout 16 bounded 16 | 2,000 | 1353.58 | 1478 | 676791 | 54.21x |
+| all fanout 16 | 2,000 | 473.68 | 4222 | 236840 | 18.97x |
+| race fanout 16 | 2,000 | 464.82 | 4303 | 232412 | 18.62x |
+| dispose blocked task | 1,000 | 26.09 | 38332 | 26088 | 1.00x |
+| dispose blocked scoped task | 1,000 | 36.89 | 27109 | 36888 | 1.41x |
+| dispose blocked fork | 1,000 | 66.55 | 15027 | 66547 | 2.55x |

--- a/benchmarks/results/2026-05-14-miss-path-minimal-handler-confirmed.md
+++ b/benchmarks/results/2026-05-14-miss-path-minimal-handler-confirmed.md
@@ -1,0 +1,27 @@
+# Miss-Path Minimal Handler Confirmation
+
+- Date: 2026-05-14T20:38:29.414Z
+- Git SHA: d72d784
+- Worktree: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:runtime-loops`
+- Result: repeated run confirms the miss-path minimal Handler change remains positive and does not trigger the V8/module-shape cliff.
+
+## Primary Guardrails
+
+| Case | Original baseline ns/op | Confirmation ns/op |
+| --- | ---: | ---: |
+| matched handler throughput | 10,902 | 10,194 |
+| prebuilt matched handler throughput | n/a | 9,858 |
+| direct internal matched handler throughput | n/a | 10,230 |
+| pass-through depth 0 | 13,156 | 12,632 |
+| pass-through depth 16 | 190,649 | 180,142 |
+| prebuilt pass-through depth 16 | n/a | 178,595 |
+| direct internal pass-through depth 16 | n/a | 178,671 |
+| capture depth 16 | 37,526 | 26,325 |
+| replay depth 0 | 14,564 | 12,749 |
+
+## Recommendation
+
+Keep the miss-path minimal `Handler` change as the current accepted point. It preserves matched/depth-0 hot paths and provides small but repeatable reductions in deep pass-through and capture depth.

--- a/benchmarks/results/2026-05-14-miss-path-minimal-handler.md
+++ b/benchmarks/results/2026-05-14-miss-path-minimal-handler.md
@@ -1,0 +1,98 @@
+# Miss-Path Minimal Handler Prototype Results
+
+- Date: 2026-05-14T20:23:22.907Z
+- Git SHA: d72d784
+- Worktree: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:runtime-loops`
+- Handler programs yield 100 effects per operation.
+- Result: correctness passed, and the prototype produced a small positive signal without the V8/module-shape cliff seen in handler coalescing prototypes.
+
+## Summary
+
+This prototype only changed `src/internal/Handler.ts`:
+
+- lazy allocate the captured-handler wrapper only when a `HandlerCapture` effect is observed
+- replace `HandlerCapture.is(effect)` on ordinary misses with a direct `_fxEffectId` comparison
+- leave public APIs, `src/Handler.ts`, imports, module graph, classes, and `Control` unchanged
+
+The result stayed within the intended V8-stable shape and improved several handler-path cases versus the original baseline:
+
+| Case | Baseline ns/op | Prototype ns/op | Change |
+| --- | ---: | ---: | ---: |
+| matched handler throughput | 10,902 | 9,961 | -8.6% |
+| pass-through depth 0 | 13,156 | 12,605 | -4.2% |
+| pass-through depth 16 | 190,649 | 183,286 | -3.9% |
+| prebuilt pass-through depth 16 | n/a | 178,843 | n/a |
+| direct internal pass-through depth 16 | n/a | 178,472 | n/a |
+| capture depth 16 | 37,526 | 26,062 | -30.5% |
+| replay depth 0 | 14,564 | 12,805 | -12.1% |
+
+Unlike the flattened and lazy coalescing prototypes, this did not move single-handler execution into a slow regime. The improvement is modest for ordinary pass-through, but the risk profile is much better.
+
+## Results
+
+| Case | Iterations | Total ms | Ops/sec | ns/op | Relative |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| matched handler throughput | 20,000 | 199.21 | 100395 | 9961 | 1.00x |
+| prebuilt matched handler throughput | 20,000 | 196.19 | 101940 | 9810 | 0.98x |
+| direct internal matched handler throughput | 20,000 | 198.16 | 100929 | 9908 | 0.99x |
+| pass-through depth 0 | 20,000 | 252.10 | 79335 | 12605 | 1.27x |
+| pass-through depth 1 | 20,000 | 409.53 | 48837 | 20476 | 2.06x |
+| pass-through depth 4 | 20,000 | 889.87 | 22475 | 44493 | 4.47x |
+| pass-through depth 8 | 20,000 | 1550.98 | 12895 | 77549 | 7.79x |
+| pass-through depth 16 | 20,000 | 3665.72 | 5456 | 183286 | 18.40x |
+| prebuilt pass-through depth 0 | 20,000 | 235.34 | 84984 | 11767 | 1.18x |
+| prebuilt pass-through depth 1 | 20,000 | 408.75 | 48930 | 20437 | 2.05x |
+| prebuilt pass-through depth 4 | 20,000 | 874.60 | 22868 | 43730 | 4.39x |
+| prebuilt pass-through depth 8 | 20,000 | 1511.37 | 13233 | 75568 | 7.59x |
+| prebuilt pass-through depth 16 | 20,000 | 3576.86 | 5591 | 178843 | 17.95x |
+| direct internal pass-through depth 0 | 20,000 | 233.68 | 85586 | 11684 | 1.17x |
+| direct internal pass-through depth 1 | 20,000 | 399.07 | 50116 | 19954 | 2.00x |
+| direct internal pass-through depth 4 | 20,000 | 863.63 | 23158 | 43181 | 4.34x |
+| direct internal pass-through depth 8 | 20,000 | 1512.41 | 13224 | 75621 | 7.59x |
+| direct internal pass-through depth 16 | 20,000 | 3569.44 | 5603 | 178472 | 17.92x |
+| construct handler stack depth 0 | 20,000 | 5.56 | 3594644 | 278 | 0.03x |
+| construct handler stack depth 1 | 20,000 | 10.49 | 1906108 | 525 | 0.05x |
+| construct handler stack depth 4 | 20,000 | 12.65 | 1580970 | 633 | 0.06x |
+| construct handler stack depth 8 | 20,000 | 18.94 | 1055869 | 947 | 0.10x |
+| construct handler stack depth 16 | 20,000 | 28.51 | 701434 | 1426 | 0.14x |
+| matched handler outermost | 20,000 | 325.66 | 61414 | 16283 | 1.63x |
+| matched handler middle | 20,000 | 590.71 | 33857 | 29536 | 2.97x |
+| matched handler innermost | 20,000 | 720.65 | 27753 | 36033 | 3.62x |
+| control resume | 20,000 | 238.16 | 83977 | 11908 | 1.20x |
+| control short-circuit | 20,000 | 74.65 | 267904 | 3733 | 0.37x |
+| capture depth 0 | 20,000 | 83.50 | 239530 | 4175 | 1.00x |
+| capture depth 1 | 20,000 | 98.24 | 203574 | 4912 | 1.18x |
+| capture depth 4 | 20,000 | 187.19 | 106841 | 9360 | 2.24x |
+| capture depth 8 | 20,000 | 306.22 | 65313 | 15311 | 3.67x |
+| capture depth 16 | 20,000 | 521.25 | 38370 | 26062 | 6.24x |
+| replay depth 0 | 20,000 | 256.11 | 78092 | 12805 | 3.07x |
+| replay depth 1 | 20,000 | 255.30 | 78340 | 12765 | 3.06x |
+| replay depth 4 | 20,000 | 252.32 | 79264 | 12616 | 3.02x |
+| replay depth 8 | 20,000 | 250.61 | 79806 | 12530 | 3.00x |
+| replay depth 16 | 20,000 | 253.76 | 78816 | 12688 | 3.04x |
+| mapCapturedHandlers fanout 1 | 20,000 | 73.39 | 272507 | 3670 | 0.88x |
+| mapCapturedHandlers fanout 4 | 20,000 | 86.60 | 230938 | 4330 | 1.04x |
+| mapCapturedHandlers fanout 16 | 20,000 | 99.49 | 201033 | 4974 | 1.19x |
+| mapCapturedHandlers fanout 64 | 20,000 | 157.20 | 127228 | 7860 | 1.88x |
+| pure runPromise | 2,000 | 24.48 | 81684 | 12242 | 1.00x |
+| sequential async x10 | 2,000 | 359.10 | 5569 | 179551 | 14.67x |
+| fork fanout 16 unbounded | 2,000 | 1322.16 | 1513 | 661079 | 54.00x |
+| fork fanout 16 bounded 1 | 2,000 | 1333.31 | 1500 | 666654 | 54.45x |
+| fork fanout 16 bounded 4 | 2,000 | 1306.17 | 1531 | 653087 | 53.35x |
+| fork fanout 16 bounded 16 | 2,000 | 1308.89 | 1528 | 654443 | 53.46x |
+| all fanout 16 | 2,000 | 435.42 | 4593 | 217709 | 17.78x |
+| race fanout 16 | 2,000 | 433.79 | 4611 | 216893 | 17.72x |
+| dispose blocked task | 1,000 | 21.70 | 46090 | 21697 | 1.00x |
+| dispose blocked scoped task | 1,000 | 36.39 | 27478 | 36393 | 1.68x |
+| dispose blocked fork | 1,000 | 66.30 | 15083 | 66300 | 3.06x |
+
+## Interpretation
+
+This is a small but useful win. It does not change the O(depth) pass-through shape, but it trims the ordinary miss path without triggering the severe V8 sensitivity seen when changing handler module/class shape.
+
+The larger capture-depth improvement is consistent with avoiding eager captured-wrapper allocation in each ordinary handler frame. Capture itself still scales with handler depth, but the per-frame cost is lower.
+
+This prototype is a better candidate to keep than either flattened/coalesced handler-stack approach because it preserves the existing optimized structure and improves the common-path guardrails.

--- a/benchmarks/results/2026-05-14-run-interrupt-mask-direct-check-rejected.md
+++ b/benchmarks/results/2026-05-14-run-interrupt-mask-direct-check-rejected.md
@@ -1,0 +1,18 @@
+# Run Interrupt Mask Direct Check Candidate
+
+- Candidate: cache `ir.value` and compare `_fxEffectId` directly for `InterruptMaskBegin`/`InterruptMaskEnd` in `run`.
+- Files changed during candidate: `src/Fx.ts`
+- Verification: `pnpm typecheck`, `pnpm lint`, and `pnpm test` passed.
+- Decision: reject and revert.
+
+## Summary
+
+The candidate did not improve the new `run interrupt mask x100` benchmark.
+
+| Case | Baseline ns/op | Candidate ns/op |
+| --- | ---: | ---: |
+| run interrupt mask x100 | 119,748 | 120,717 |
+
+## Interpretation
+
+The current `InterruptMaskBegin.is` / `InterruptMaskEnd.is` checks in `run` are already competitive for this path. The direct-check rewrite added no measurable value and should not be kept.

--- a/benchmarks/results/2026-05-14-runtime-context-attach-inline-check.md
+++ b/benchmarks/results/2026-05-14-runtime-context-attach-inline-check.md
@@ -1,0 +1,27 @@
+# Runtime Context Attach Inline Check Candidate
+
+- Candidate: inline the existing runtime-context presence check inside `attachRuntimeContext`.
+- Files changed during candidate: `src/internal/runtimeContext.ts`
+- Verification: `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm benchmark:runtime-context` passed.
+- Decision: keep.
+
+## Summary
+
+This candidate removes an internal `getRuntimeContext(...)` call from `attachRuntimeContext` after `attachRuntimeContext` has already checked that the target is an object. It preserves public API and module shape.
+
+## Benchmark Comparison
+
+Runtime-context baseline before candidate:
+
+| Case | Baseline ns/op | Candidate ns/op |
+| --- | ---: | ---: |
+| handled effects baseline | 10,197 | 9,785 |
+| handled effects global off | 9,525 | 9,193 |
+| handled effects ambient active off | 9,531 | 9,272 |
+| handled effects regional off | 33,836 | 32,813 |
+| handled effects regional labels | 33,448 | 32,786 |
+| handled effects regional full | 33,047 | 32,572 |
+
+## Interpretation
+
+This is a small local win in the runtime-context path. It avoids duplicate object/null checks and an extra function call in a path that runs for every yielded effect inside a regional runtime context.

--- a/benchmarks/results/2026-05-14-runtime-loop-performance-analysis.md
+++ b/benchmarks/results/2026-05-14-runtime-loop-performance-analysis.md
@@ -1,0 +1,91 @@
+# Runtime Loop Performance Analysis
+
+Based on the initial runtime-loop benchmark baseline, the highest-value performance areas are:
+
+## 1. Handler stack pass-through
+
+The clearest signal is pass-through depth:
+
+| Case | ns/op |
+| --- | ---: |
+| pass-through depth 0 | 13,156 |
+| pass-through depth 4 | 46,733 |
+| pass-through depth 8 | 81,043 |
+| pass-through depth 16 | 190,649 |
+
+That is almost linear-to-worse growth as non-matching handlers wrap the same yielded effect. This points at `src/internal/Handler.ts`: every non-matching handler adds another generator boundary, `isEffect` check, effect-id comparison, `yield`, and `i.next(...)` bounce.
+
+Highest-value questions:
+
+- Can adjacent handlers be represented in a flatter handler frame at construction time?
+- Can handler lookup avoid walking nested generator wrappers for non-matches?
+- Can captured/replayed handlers preserve simple dispatch without rebuilding deep wrapper chains?
+
+## 2. Fork fan-out
+
+Forking 16 pure children is expensive:
+
+| Case | ns/op |
+| --- | ---: |
+| pure runPromise | 12,720 |
+| fork fanout 16 unbounded | 677,707 |
+| fork fanout 16 bounded 1 | 678,424 |
+| fork fanout 16 bounded 4 | 670,646 |
+| fork fanout 16 bounded 16 | 668,490 |
+
+Bounded vs unbounded is nearly the same, suggesting semaphore contention is not the dominant cost. The likely cost is task/runtime setup: `runForkInternal`, `Promise.withResolvers`, `InterruptState`, `Task`, trace/fork origin handling, handler capture/replay, disposable bookkeeping, and child promise coordination.
+
+Highest-value places:
+
+- `src/internal/runFork.ts`: `runFork`, `acquireAndRunFork`, `runForkInternal`
+- `src/Concurrent.ts`: `fork`, `forkEach`, `bounded`
+- Trace capture in fork construction, especially for already-pure children
+
+## 3. Sequential Async stepping
+
+`sequential async x10` is roughly 14x pure `runPromise` in the saved baseline. That path pays per async effect:
+
+- `Async.is`
+- `runTask`
+- `AbortController`
+- `Task`
+- disposable add/remove
+- `Promise.race([promise, unhandled])`
+- runtime-context resume
+
+The biggest likely win is reducing fixed per-`Async` overhead, especially for already-resolved promises.
+
+## 4. Handler capture depth
+
+Capture depth scales sharply:
+
+| Case | ns/op |
+| --- | ---: |
+| capture depth 0 | 4,148 |
+| capture depth 16 | 37,526 |
+
+This matters because `fork`, `all`, `race`, timeout, and server boundaries all rely on capture/replay. Capture replay itself did not grow much by depth in this benchmark, but capture construction did.
+
+Look at:
+
+- `HandlerCapture` interception in `Handler`
+- `withHandlerContext` replay shape
+- Whether common captures can avoid array spreading or nested wrapper reconstruction
+
+## 5. Structured concurrency overhead
+
+`all fanout 16` and `race fanout 16` are much cheaper than explicit fork/wait fanout, but still around 230k ns/op. This is worth investigating after fork setup is better understood. Improvements here may come from fork setup and handler capture improvements.
+
+## Lower-priority signals
+
+- `control resume` is only modestly slower than `handle`.
+- `control short-circuit` is faster in this benchmark because it exits after the first effect, so it is not comparable to full 100-effect throughput.
+- Interrupt cleanup has measurable overhead, but the absolute numbers are much smaller than fork fan-out and deep handler pass-through.
+
+## Recommended investigation order
+
+1. Deep non-matching handler pass-through.
+2. Fork child setup overhead for pure child programs.
+3. Per-`Async` fixed overhead.
+4. Handler capture construction at runtime boundaries.
+5. Structured `all`/`race` after fork/capture findings.

--- a/benchmarks/results/2026-05-14-runtime-loops-baseline.md
+++ b/benchmarks/results/2026-05-14-runtime-loops-baseline.md
@@ -1,0 +1,48 @@
+# Fx Runtime Loop Benchmark Results
+
+- Date: 2026-05-14T17:46:20.932Z
+- Git SHA: d72d784
+- Worktree: dirty
+- Node: v25.9.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:runtime-loops`
+- Handler programs yield 100 effects per operation.
+
+| Case | Iterations | Total ms | Ops/sec | ns/op | Relative |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| matched handler throughput | 20,000 | 218.04 | 91727 | 10902 | 1.00x |
+| pass-through depth 0 | 20,000 | 263.12 | 76010 | 13156 | 1.21x |
+| pass-through depth 1 | 20,000 | 430.74 | 46432 | 21537 | 1.98x |
+| pass-through depth 4 | 20,000 | 934.66 | 21398 | 46733 | 4.29x |
+| pass-through depth 8 | 20,000 | 1620.86 | 12339 | 81043 | 7.43x |
+| pass-through depth 16 | 20,000 | 3812.98 | 5245 | 190649 | 17.49x |
+| matched handler outermost | 20,000 | 352.75 | 56697 | 17638 | 1.62x |
+| matched handler middle | 20,000 | 620.86 | 32213 | 31043 | 2.85x |
+| matched handler innermost | 20,000 | 755.28 | 26480 | 37764 | 3.46x |
+| control resume | 20,000 | 255.38 | 78314 | 12769 | 1.17x |
+| control short-circuit | 20,000 | 81.03 | 246833 | 4051 | 0.37x |
+| capture depth 0 | 20,000 | 82.97 | 241056 | 4148 | 1.00x |
+| capture depth 1 | 20,000 | 120.37 | 166152 | 6019 | 1.45x |
+| capture depth 4 | 20,000 | 217.06 | 92142 | 10853 | 2.62x |
+| capture depth 8 | 20,000 | 374.15 | 53455 | 18707 | 4.51x |
+| capture depth 16 | 20,000 | 750.52 | 26648 | 37526 | 9.05x |
+| replay depth 0 | 20,000 | 291.29 | 68661 | 14564 | 3.51x |
+| replay depth 1 | 20,000 | 260.49 | 76777 | 13025 | 3.14x |
+| replay depth 4 | 20,000 | 270.01 | 74072 | 13500 | 3.25x |
+| replay depth 8 | 20,000 | 260.78 | 76693 | 13039 | 3.14x |
+| replay depth 16 | 20,000 | 278.94 | 71699 | 13947 | 3.36x |
+| mapCapturedHandlers fanout 1 | 20,000 | 82.58 | 242179 | 4129 | 1.00x |
+| mapCapturedHandlers fanout 4 | 20,000 | 97.93 | 204229 | 4896 | 1.18x |
+| mapCapturedHandlers fanout 16 | 20,000 | 98.68 | 202675 | 4934 | 1.19x |
+| mapCapturedHandlers fanout 64 | 20,000 | 176.12 | 113556 | 8806 | 2.12x |
+| pure runPromise | 2,000 | 25.44 | 78616 | 12720 | 1.00x |
+| sequential async x10 | 2,000 | 362.49 | 5517 | 181244 | 14.25x |
+| fork fanout 16 unbounded | 2,000 | 1355.41 | 1476 | 677707 | 53.28x |
+| fork fanout 16 bounded 1 | 2,000 | 1356.85 | 1474 | 678424 | 53.33x |
+| fork fanout 16 bounded 4 | 2,000 | 1341.29 | 1491 | 670646 | 52.72x |
+| fork fanout 16 bounded 16 | 2,000 | 1336.98 | 1496 | 668490 | 52.55x |
+| all fanout 16 | 2,000 | 468.34 | 4270 | 234169 | 18.41x |
+| race fanout 16 | 2,000 | 458.59 | 4361 | 229296 | 18.03x |
+| dispose blocked task | 1,000 | 22.48 | 44475 | 22484 | 1.00x |
+| dispose blocked scoped task | 1,000 | 41.01 | 24387 | 41006 | 1.82x |
+| dispose blocked fork | 1,000 | 61.50 | 16260 | 61499 | 2.74x |

--- a/benchmarks/results/2026-05-14-scope-local-capture-reduction-inconclusive.md
+++ b/benchmarks/results/2026-05-14-scope-local-capture-reduction-inconclusive.md
@@ -1,0 +1,51 @@
+# Scope Local Capture Reduction Candidate
+
+- Candidate: lazy `CapturedHandler` allocation plus direct `HandlerCapture._fxEffectId` check in `ScopeBoundary`.
+- Files changed during candidate: `src/Scope.ts`
+- Verification: `pnpm typecheck`, `pnpm lint`, and `pnpm test` passed.
+- Decision: do not keep. Revert this candidate before continuing.
+
+## Summary
+
+The Scope candidate was correct but not stable enough to accept. It showed some pass-through improvement, but scope finalizer and scope capture measurements were noisy and included regressions larger than the 5% guardrail.
+
+## Comparison
+
+Expanded coverage baseline:
+
+| Case | Baseline ns/op |
+| --- | ---: |
+| scope pass-through depth 0 | 13,468 |
+| scope pass-through depth 16 | 359,625 |
+| scope finalizer registration depth 16 | 47,485 |
+| scope capture depth 0 | 3,647 |
+| scope capture depth 8 | 50,384 |
+| scope capture depth 16 | 97,416 |
+
+Candidate run 1:
+
+| Case | Candidate ns/op |
+| --- | ---: |
+| scope pass-through depth 0 | 13,182 |
+| scope pass-through depth 16 | 353,317 |
+| scope finalizer registration depth 16 | 47,509 |
+| scope capture depth 0 | 3,768 |
+| scope capture depth 8 | 53,322 |
+| scope capture depth 16 | 99,997 |
+
+Candidate run 2:
+
+| Case | Candidate ns/op |
+| --- | ---: |
+| scope pass-through depth 0 | 12,520 |
+| scope pass-through depth 16 | 353,823 |
+| scope finalizer registration depth 16 | 54,013 |
+| scope capture depth 0 | 5,028 |
+| scope capture depth 8 | 49,702 |
+| scope capture depth 16 | 95,154 |
+
+## Interpretation
+
+The direct miss-path reduction may help scope pass-through slightly, but the broader scope benchmarks did not remain within the acceptance guardrails. Since Scope has more cleanup/runtime-context work than ordinary Handler, this candidate needs a more focused investigation before being kept.
+
+The safest next step is to revert the Scope change and continue with smaller independent candidates.

--- a/benchmarks/runtime-loops.ts
+++ b/benchmarks/runtime-loops.ts
@@ -1,0 +1,437 @@
+import { execFileSync } from 'node:child_process'
+import { arch, platform, release } from 'node:os'
+import { performance } from 'node:perf_hooks'
+
+import { assertPromise } from '../src/Async.js'
+import { all, bounded, defaultAll, firstSettled, fork, race, unbounded } from '../src/Concurrent.js'
+import { Effect } from '../src/Effect.js'
+import { andFinally } from '../src/Finalization.js'
+import { fx, ok, run, runPromise, runTask } from '../src/Fx.js'
+import { control, handle } from '../src/Handler.js'
+import { captureHandlers, closeHandlerCapture, mapCapturedHandlers, withHandlerContext } from '../src/HandlerCapture.js'
+import { uninterruptible } from '../src/Interrupt.js'
+import { scope } from '../src/Scope.js'
+import { wait } from '../src/Task.js'
+import { setTraceCapturePolicy } from '../src/Trace.js'
+import { Handler as InternalHandler } from '../src/internal/Handler.js'
+import type { TraceCapturePolicy } from '../src/Trace.js'
+import type { Fx } from '../src/Fx.js'
+
+interface BenchmarkCase {
+  readonly name: string
+  readonly group: string
+  readonly iterations: number
+  readonly warmup: number
+  readonly policy?: TraceCapturePolicy
+  readonly run: () => void | Promise<void>
+}
+
+interface Result {
+  readonly name: string
+  readonly group: string
+  readonly iterations: number
+  readonly totalMs: number
+  readonly opsPerSecond: number
+  readonly nsPerOp: number
+  readonly relativeToGroupBaseline: number
+}
+
+class Ping extends Effect('benchmark/runtime-loops/Ping')<number, number> { }
+class Target extends Effect('benchmark/runtime-loops/Target')<number, number> { }
+class Miss extends Effect('benchmark/runtime-loops/Miss')<number, number> { }
+
+const HandlerIterations = 20_000
+const CaptureIterations = 20_000
+const RunForkIterations = 2_000
+const InterruptIterations = 1_000
+const EffectsPerProgram = 100
+
+const pingHandler = handle(Ping, ping => ok(ping.arg + 1))
+const targetHandler = handle(Target, target => ok(target.arg + 1))
+const missHandler = handle(Miss, miss => ok(miss.arg + 1))
+const controlResume = control(Ping, (resume, ping) => ok(resume(ping.arg + 1)))
+const controlShortCircuit = control(Ping, (_, ping) => ok(ping.arg + 1))
+const controlMiss = control(Miss, (resume, miss) => ok(resume(miss.arg + 1)))
+const directPingHandler = internalHandler(Ping, ping => ok(ping.arg + 1))
+const directTargetHandler = internalHandler(Target, target => ok(target.arg + 1))
+const directMissHandler = internalHandler(Miss, miss => ok(miss.arg + 1))
+
+const pingProgram = effectProgram(Ping, EffectsPerProgram)
+const targetProgram = effectProgram(Target, EffectsPerProgram)
+const prebuiltMatchedHandlerProgram = pingProgram.pipe(pingHandler)
+const directMatchedHandlerProgram = pingProgram.pipe(directPingHandler)
+const pureRunPromise = ok(1)
+const sequentialAsync10 = asyncProgram(10)
+const forkFanout16 = forkFanout(16)
+const allFanout16 = all(fanoutValues(16))
+const raceFanout16 = race(fanoutValues(16))
+const blocked = assertPromise<void>(() => new Promise(() => { }))
+const blockedWithFinalizer = fx(function* () {
+  yield* andFinally('benchmark/runtime-loops/Interrupt', ok(undefined))
+  return yield* blocked
+}).pipe(scope('benchmark/runtime-loops/Interrupt'))
+
+const handlerContextDepths = [0, 1, 4, 8, 16] as const
+const captureFanouts = [1, 4, 16, 64] as const
+const forkBounds = [1, 4, 16] as const
+const scopePassThroughPrograms = new Map<number, Fx<any, any>>(
+  handlerContextDepths.map(depth => [depth, applyScopes(targetProgram, depth).pipe(targetHandler)])
+)
+const handlerCaptureBoundaryPassThroughPrograms = new Map<number, Fx<any, any>>(
+  handlerContextDepths.map(depth => [depth, applyHandlerCaptureBoundaries(targetProgram, 'other', depth).pipe(targetHandler)])
+)
+const controlPassThroughPrograms = new Map<number, Fx<any, any>>(
+  handlerContextDepths.map(depth => [depth, applyControls(targetProgram, depth).pipe(targetHandler)])
+)
+
+const capturedContexts = new Map<number, ReturnType<typeof captureContext>>(
+  handlerContextDepths.map(depth => [depth, captureContext(depth)])
+)
+const replayProgram = effectProgram(Ping, EffectsPerProgram).pipe(pingHandler)
+const interruptMaskProgram = maskProgram(EffectsPerProgram)
+const prebuiltPassThroughPrograms = new Map<number, Fx<any, any>>(
+  handlerContextDepths.map(depth => [depth, applyHandlers(targetProgram, handlerStack(depth))])
+)
+const directPassThroughPrograms = new Map<number, Fx<any, any>>(
+  handlerContextDepths.map(depth => [depth, applyHandlers(targetProgram, directHandlerStack(depth))])
+)
+let constructionSink: Fx<any, any> | undefined
+
+const cases: readonly BenchmarkCase[] = [
+  benchmark('matched handler throughput', 'handler', HandlerIterations, 500, () => {
+    pingProgram.pipe(pingHandler, run)
+  }),
+  benchmark('prebuilt matched handler throughput', 'handler', HandlerIterations, 500, () => {
+    prebuiltMatchedHandlerProgram.pipe(run)
+  }),
+  benchmark('direct internal matched handler throughput', 'handler', HandlerIterations, 500, () => {
+    directMatchedHandlerProgram.pipe(run)
+  }),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`pass-through depth ${depth}`, 'handler', HandlerIterations, 500, () => {
+      applyHandlers(targetProgram, handlerStack(depth)).pipe(run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`prebuilt pass-through depth ${depth}`, 'handler', HandlerIterations, 500, () => {
+      prebuiltPassThroughPrograms.get(depth)!.pipe(run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`direct internal pass-through depth ${depth}`, 'handler', HandlerIterations, 500, () => {
+      directPassThroughPrograms.get(depth)!.pipe(run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`construct handler stack depth ${depth}`, 'handler', HandlerIterations, 500, () => {
+      constructionSink = applyHandlers(targetProgram, handlerStack(depth))
+    })
+  ),
+  benchmark('matched handler outermost', 'handler', HandlerIterations, 500, () => {
+    applyHandlers(targetProgram, [targetHandler, missHandler, missHandler, missHandler]).pipe(run)
+  }),
+  benchmark('matched handler middle', 'handler', HandlerIterations, 500, () => {
+    applyHandlers(targetProgram, [missHandler, missHandler, targetHandler, missHandler]).pipe(run)
+  }),
+  benchmark('matched handler innermost', 'handler', HandlerIterations, 500, () => {
+    applyHandlers(targetProgram, [missHandler, missHandler, missHandler, targetHandler]).pipe(run)
+  }),
+  benchmark('control resume', 'handler', HandlerIterations, 500, () => {
+    pingProgram.pipe(controlResume, run)
+  }),
+  benchmark('control short-circuit', 'handler', HandlerIterations, 500, () => {
+    pingProgram.pipe(controlShortCircuit, run)
+  }),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`control pass-through depth ${depth}`, 'handler', HandlerIterations, 500, () => {
+      controlPassThroughPrograms.get(depth)!.pipe(run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`capture depth ${depth}`, 'capture', CaptureIterations, 500, () => {
+      captureContext(depth)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`replay depth ${depth}`, 'capture', CaptureIterations, 500, () => {
+      withHandlerContext(capturedContexts.get(depth)!, replayProgram).pipe(run)
+    })
+  ),
+  ...captureFanouts.map(fanout =>
+    benchmark(`mapCapturedHandlers fanout ${fanout}`, 'capture', CaptureIterations, 500, () => {
+      mapCapturedHandlers('benchmark/runtime-loops/Capture', fanoutValues(fanout)).pipe(
+        closeHandlerCapture('benchmark/runtime-loops/Capture'),
+        run
+      )
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`scope pass-through depth ${depth}`, 'scope', HandlerIterations, 500, () => {
+      scopePassThroughPrograms.get(depth)!.pipe(run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`scope finalizer registration depth ${depth}`, 'scope', CaptureIterations, 500, () => {
+      finalizerProgram(depth).pipe(scope('benchmark/runtime-loops/ScopeFinalizer'), run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`scope capture depth ${depth}`, 'scope', CaptureIterations, 500, () => {
+      captureHandlers('benchmark/runtime-loops/ScopeCapture').pipe(
+        f => applyScopes(f, depth),
+        closeHandlerCapture('benchmark/runtime-loops/ScopeCapture'),
+        run
+      )
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`handler capture boundary pass-through depth ${depth}`, 'captureBoundary', HandlerIterations, 500, () => {
+      handlerCaptureBoundaryPassThroughPrograms.get(depth)!.pipe(run)
+    })
+  ),
+  ...handlerContextDepths.map(depth =>
+    benchmark(`handler capture boundary close depth ${depth}`, 'captureBoundary', CaptureIterations, 500, () => {
+      captureHandlers('benchmark/runtime-loops/BoundaryCapture').pipe(
+        f => applyHandlerCaptureBoundaries(f, 'other', depth),
+        closeHandlerCapture('benchmark/runtime-loops/BoundaryCapture'),
+        run
+      )
+    })
+  ),
+  benchmark('run interrupt mask x100', 'run', HandlerIterations, 500, () => {
+    interruptMaskProgram.pipe(run)
+  }),
+  benchmark('pure runPromise', 'runFork', RunForkIterations, 100, async () => {
+    await runPromise(pureRunPromise)
+  }),
+  benchmark('sequential async x10', 'runFork', RunForkIterations, 100, async () => {
+    await runPromise(sequentialAsync10)
+  }),
+  benchmark('fork fanout 16 unbounded', 'runFork', RunForkIterations, 100, async () => {
+    await forkFanout16.pipe(unbounded, runPromise)
+  }),
+  ...forkBounds.map(limit =>
+    benchmark(`fork fanout 16 bounded ${limit}`, 'runFork', RunForkIterations, 100, async () => {
+      await forkFanout16.pipe(bounded(limit), runPromise)
+    })
+  ),
+  benchmark('all fanout 16', 'runFork', RunForkIterations, 100, async () => {
+    await allFanout16.pipe(defaultAll, unbounded, runPromise)
+  }),
+  benchmark('race fanout 16', 'runFork', RunForkIterations, 100, async () => {
+    await raceFanout16.pipe(firstSettled, unbounded, runPromise)
+  }),
+  benchmark('dispose blocked task', 'interrupt', InterruptIterations, 100, async () => {
+    await disposeTask(blocked)
+  }),
+  benchmark('dispose blocked scoped task', 'interrupt', InterruptIterations, 100, async () => {
+    await disposeTask(blockedWithFinalizer)
+  }),
+  benchmark('dispose blocked fork', 'interrupt', InterruptIterations, 100, async () => {
+    await fx(function* () {
+      const task = yield* fork(blocked)
+      task[Symbol.dispose]()
+      yield* assertPromise(() => task._disposeAndWait())
+    }).pipe(unbounded, runPromise)
+  })
+]
+
+const results = await runBenchmarks(cases)
+void constructionSink
+console.log(formatMarkdown(results))
+
+function benchmark(
+  name: string,
+  group: string,
+  iterations: number,
+  warmup: number,
+  run: () => void | Promise<void>,
+  policy?: TraceCapturePolicy
+): BenchmarkCase {
+  return { name, group, iterations, warmup, policy, run }
+}
+
+async function runBenchmarks(benchmarks: readonly BenchmarkCase[]): Promise<readonly Result[]> {
+  const rawResults: Omit<Result, 'relativeToGroupBaseline'>[] = []
+
+  for (const b of benchmarks) {
+    const previous = b.policy === undefined ? undefined : setTraceCapturePolicy(b.policy)
+    try {
+      for (let i = 0; i < b.warmup; i++) await b.run()
+
+      const start = performance.now()
+      for (let i = 0; i < b.iterations; i++) await b.run()
+      const totalMs = performance.now() - start
+      const opsPerSecond = b.iterations / (totalMs / 1_000)
+      const nsPerOp = (totalMs * 1_000_000) / b.iterations
+
+      rawResults.push({
+        name: b.name,
+        group: b.group,
+        iterations: b.iterations,
+        totalMs,
+        opsPerSecond,
+        nsPerOp
+      })
+    } finally {
+      if (previous !== undefined) setTraceCapturePolicy(previous)
+    }
+  }
+
+  const baselines = new Map<string, number>()
+  for (const result of rawResults) {
+    if (!baselines.has(result.group)) baselines.set(result.group, result.nsPerOp)
+  }
+
+  return rawResults.map(result => ({
+    ...result,
+    relativeToGroupBaseline: result.nsPerOp / (baselines.get(result.group) ?? result.nsPerOp)
+  }))
+}
+
+function formatMarkdown(results: readonly Result[]): string {
+  return [
+    '# Fx Runtime Loop Benchmark Results',
+    '',
+    `- Date: ${new Date().toISOString()}`,
+    `- Git SHA: ${gitSha()}`,
+    `- Worktree: ${worktreeState()}`,
+    `- Node: ${process.version}`,
+    `- Platform: ${platform()} ${release()} ${arch()}`,
+    '- Command: `pnpm benchmark:runtime-loops`',
+    `- Handler programs yield ${EffectsPerProgram.toLocaleString()} effects per operation.`,
+    '',
+    '| Case | Iterations | Total ms | Ops/sec | ns/op | Relative |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+    ...results.map(result => [
+      `| ${result.name}`,
+      result.iterations.toLocaleString(),
+      result.totalMs.toFixed(2),
+      result.opsPerSecond.toFixed(0),
+      result.nsPerOp.toFixed(0),
+      `${result.relativeToGroupBaseline.toFixed(2)}x |`
+    ].join(' | '))
+  ].join('\n')
+}
+
+function effectProgram<const T extends typeof Ping | typeof Target>(
+  EffectType: T,
+  count: number
+) {
+  return fx(function* () {
+    let n = 0
+    for (let i = 0; i < count; i++) {
+      n = yield* new EffectType(n)
+    }
+    return n
+  })
+}
+
+function asyncProgram(count: number) {
+  return fx(function* () {
+    let n = 0
+    for (let i = 0; i < count; i++) {
+      n = yield* assertPromise(() => Promise.resolve(n + 1))
+    }
+    return n
+  })
+}
+
+function maskProgram(count: number) {
+  return fx(function* () {
+    for (let i = 0; i < count; i++) {
+      yield* uninterruptible(ok(i))
+    }
+  })
+}
+
+function fanoutValues(count: number): readonly Fx<never, number>[] {
+  return Array.from({ length: count }, (_, i) => ok(i))
+}
+
+function handlerStack(depth: number) {
+  return [...Array.from({ length: depth }, () => missHandler), targetHandler]
+}
+
+function directHandlerStack(depth: number) {
+  return [...Array.from({ length: depth }, () => directMissHandler), directTargetHandler]
+}
+
+function applyScopes(f: Fx<unknown, unknown>, depth: number) {
+  let current = f as Fx<any, any>
+  for (let i = 0; i < depth; i++) current = current.pipe(scope(`benchmark/runtime-loops/Scope/${i}`))
+  return current as Fx<any, any>
+}
+
+function finalizerProgram(count: number) {
+  return fx(function* () {
+    for (let i = 0; i < count; i++) {
+      yield* andFinally('benchmark/runtime-loops/ScopeFinalizer', ok(undefined))
+    }
+  })
+}
+
+function applyHandlerCaptureBoundaries(f: Fx<unknown, unknown>, name: string, depth: number) {
+  let current = f as Fx<any, any>
+  for (let i = 0; i < depth; i++) current = current.pipe(closeHandlerCapture(`${name}/${i}`))
+  return current as Fx<any, any>
+}
+
+function applyControls(f: Fx<unknown, unknown>, depth: number) {
+  let current = f as Fx<any, any>
+  for (let i = 0; i < depth; i++) current = current.pipe(controlMiss)
+  return current as Fx<any, any>
+}
+
+function internalHandler<T extends typeof Ping | typeof Target | typeof Miss>(
+  EffectType: T,
+  handler: (effect: InstanceType<T>) => Fx<unknown, InstanceType<T>['R']>
+) {
+  return <E, A>(fx: Fx<E, A>) => new InternalHandler(fx, EffectType._fxEffectId, handler)
+}
+
+function forkFanout(count: number) {
+  const values = fanoutValues(count)
+  return fx(function* () {
+    const tasks = []
+    for (const value of values) tasks.push(yield* fork(value))
+    for (const task of tasks) yield* wait(task)
+  })
+}
+
+function captureContext(depth: number) {
+  return applyHandlers(
+    captureHandlers('benchmark/runtime-loops/Capture').pipe(closeHandlerCapture('benchmark/runtime-loops/Capture')),
+    Array.from({ length: depth }, () => pingHandler)
+  ).pipe(run)
+}
+
+function applyHandlers(f: Fx<unknown, unknown>, handlers: readonly ((fx: Fx<any, any>) => Fx<any, any>)[]) {
+  let current = f as Fx<any, any>
+  for (const handler of handlers) current = current.pipe(handler)
+  return current as Fx<any, any>
+}
+
+async function disposeTask(f: Fx<any, unknown>) {
+  const task = runTask(f)
+  task[Symbol.dispose]()
+  await task._disposeAndWait()
+}
+
+function gitSha(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+function worktreeState(): string {
+  try {
+    execFileSync('git', ['diff', '--quiet'])
+    execFileSync('git', ['diff', '--cached', '--quiet'])
+    return 'clean'
+  } catch {
+    return 'dirty'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "build": "tsc --project ./tsconfig.build.json",
     "benchmark:trace": "tsx benchmarks/trace.ts",
     "benchmark:runtime-context": "tsx benchmarks/runtime-context.ts",
+    "benchmark:runtime-loops": "tsx benchmarks/runtime-loops.ts",
     "lint": "oxlint --type-aware",
     "test": "node --import tsx --test 'src/**/*.test.ts'",
     "test:watch": "node --import tsx --test --test-reporter=dot --watch './src/**/*.test.ts'",

--- a/src/HandlerCapture.ts
+++ b/src/HandlerCapture.ts
@@ -69,7 +69,7 @@ class HandlerCaptureBoundary<E, A> implements Fx<E, A>, Pipeable {
     const step = function* (ir: IteratorResult<E, A>): Generator<E, A, unknown> {
       while (!ir.done) {
         if (isEffect(ir.value)) {
-          if (HandlerCapture.is(ir.value) && ir.value.arg === captureName) {
+          if (ir.value._fxEffectId === HandlerCapture._fxEffectId && ir.value.arg === captureName) {
             ir = i.next([])
           } else {
             ir = i.next(yield ir.value as any)

--- a/src/internal/Handler.ts
+++ b/src/internal/Handler.ts
@@ -24,9 +24,7 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, CapturedHandler {
   *[Symbol.iterator](): Iterator<E, A> {
     const { effectId, handler, fx } = this
     const i = fx[Symbol.iterator]()
-    const captured: CapturedHandler = {
-      wrap: fx => new Handler(fx, effectId, handler)
-    }
+    let captured: CapturedHandler | undefined
     const step = function* (ir: IteratorResult<E, A>): Generator<E, A, unknown> {
       while (!ir.done) {
         if (isEffect(ir.value)) {
@@ -37,7 +35,10 @@ export class Handler<E, A> implements Fx<E, A>, Pipeable, CapturedHandler {
               ? handler(effect)
               : withActiveRuntimeContext(context, () => handler(effect))
             ir = i.next(yield* withRuntimeContext(context, handled) as any)
-          } else if (HandlerCapture.is(effect)) {
+          } else if (effect._fxEffectId === HandlerCapture._fxEffectId) {
+            captured ??= {
+              wrap: fx => new Handler(fx, effectId, handler)
+            }
             ir = i.next([captured, ...(yield effect) as any])
           } else {
             ir = i.next(yield effect as any)

--- a/src/internal/runtimeContext.ts
+++ b/src/internal/runtimeContext.ts
@@ -41,7 +41,7 @@ export const withRuntimeContext = <E, A>(
 
 export const attachRuntimeContext = (target: unknown, context: RuntimeContext | undefined = activeRuntimeContext): void => {
   if (context === undefined || typeof target !== 'object' || target === null) return
-  if (getRuntimeContext(target) !== undefined) return
+  if ((target as Partial<Record<typeof RuntimeContextTypeId, RuntimeContext>>)[RuntimeContextTypeId] !== undefined) return
 
   try {
     Object.defineProperty(target, RuntimeContextTypeId, {


### PR DESCRIPTION
## Summary

Adds a focused runtime-loop benchmark suite and records the investigation results for handler, capture, control, scope, runtime context, and interrupt-mask paths.

Kept the low-risk local runtime reductions that benchmarked well:

- Lazy captured-wrapper allocation and direct `HandlerCapture` id check in `Handler` miss-path handling.
- Direct `HandlerCapture` id check in `HandlerCaptureBoundary` after `isEffect` validation.
- Inline runtime-context presence check in `attachRuntimeContext`.

The PR also includes saved benchmark/analysis markdown for accepted and rejected prototypes, including flattened handler frames, lazy adjacent-handler coalescing, scope reductions, control lazy resume, and interrupt-mask checks.

## Validation

Run in `/private/tmp/fx-runtime-loop-benchmarks`:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm benchmark:runtime-loops`
- `pnpm benchmark:runtime-context`

## Notes

This preserves public APIs, module graph shape, class shapes, and constructor signatures. The runtime changes are intentionally narrow and local; larger structural handler prototypes were benchmarked and recorded as negative results.