### PR TITLE
[codex] Trace abort call sites

### DIFF
--- a/examples/scope/abort-trace-origin.ts
+++ b/examples/scope/abort-trace-origin.ts
@@ -1,0 +1,44 @@
+import { Abort, abort } from '../../src/Abort.js'
+import { defaultConsole, error } from '../../src/Console.js'
+import { Fail, failFrom, returnFail } from '../../src/Fail.js'
+import { fx, run, type Fx } from '../../src/Fx.js'
+import { control } from '../../src/Handler.js'
+import { scope } from '../../src/Scope.js'
+import { formatDiagnostic, setTraceCapturePolicy } from '../../src/Trace.js'
+import { nodeSourceLookup } from '../../src/TraceNode.js'
+
+setTraceCapturePolicy('full')
+
+const RequestScope = 'examples/scope/abort-trace-origin' as const
+const sourceLookup = nodeSourceLookup()
+
+const program = fx(function* () {
+  return yield* validate()
+}).pipe(scope(RequestScope))
+
+reportAbort(program).pipe(
+  defaultConsole,
+  run
+)
+
+function validate() {
+  return fx(function* () {
+    yield* abort(RequestScope)
+    return 'valid'
+  })
+}
+
+function reportAbort<A>(program: Fx<Abort<typeof RequestScope>, A>) {
+  return fx(function* () {
+    const result = yield* program.pipe(
+      control(Abort, (_, abort) =>
+        failFrom(abort, new Error('unhandled request abort'))
+      ),
+      returnFail
+    )
+
+    if (!Fail.is(result)) return
+
+    yield* error(formatDiagnostic(result, { source: { lookup: sourceLookup } }))
+  })
+}

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -1,4 +1,6 @@
+import { at } from './Breadcrumb.js'
 import { Effect } from './Effect.js'
+import { withOrigin } from './Effect.js'
 import { Fx, ok } from './Fx.js'
 import { control } from './Handler.js'
 
@@ -8,7 +10,7 @@ import { control } from './Handler.js'
 export class Abort<const Scope extends string> extends Effect('fx/Abort')<Scope, never> { }
 
 export const abort = <const Scope extends string>(scope: Scope): Fx<Abort<Scope>, never> =>
-  new Abort(scope)
+  withOrigin(new Abort(scope), at('fx/Abort/abort', abort))
 
 /**
  * Return a default value from an abort of the named scope.

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -568,6 +568,19 @@ describe('Trace', () => {
     ].join('\n'))
   })
 
+  it('formats Fail values using the wrapped error and Fail trace', () => {
+    const failure = new Fail(new Error('boom'), {
+      origin: breadcrumb('failed here'),
+      trace: prependTrace(breadcrumb('failed here'))
+    })
+
+    assert.equal(formatDiagnostic(failure), [
+      'Error: boom',
+      'Fx trace:',
+      '  at failed here'
+    ].join('\n'))
+  })
+
   it('formats aggregate errors with compact indexed child summaries', () => {
     const child = new Error('wrapped child', { cause: new TypeError('root child') })
     const aggregate = new AggregateError([child, 'plain failure'], 'aggregate failed')

--- a/src/Trace.ts
+++ b/src/Trace.ts
@@ -392,6 +392,7 @@ const snapshotErrorValue = (error: unknown, seen: Set<unknown>): DiagnosticError
   }
 
   if (tracksCycles(error)) seen.add(error)
+  if (isFailEffect(error)) return snapshotFail(error, seen)
 
   const trace = getTrace(error)
   const base = error instanceof Error
@@ -411,6 +412,23 @@ const snapshotErrorValue = (error: unknown, seen: Set<unknown>): DiagnosticError
     ...(aggregate === undefined ? {} : { aggregate: { errors: aggregate.map(e => snapshotErrorValue(e, seen)) } })
   }
 }
+
+const snapshotFail = (failure: DiagnosticFail, seen: Set<unknown>): DiagnosticErrorSnapshot => ({
+  ...snapshotErrorValue(failure.arg, seen),
+  ...(failure.trace === undefined ? {} : { trace: snapshotTrace(failure.trace) })
+})
+
+// Avoid importing Fail here: Fail.ts depends on Trace.ts.
+interface DiagnosticFail {
+  readonly _fxEffectId: 'fx/Fail'
+  readonly arg: unknown
+  readonly trace?: Trace
+}
+
+const isFailEffect = (value: unknown): value is DiagnosticFail =>
+  typeof value === 'object'
+  && value !== null
+  && (value as Partial<DiagnosticFail>)._fxEffectId === 'fx/Fail'
 
 const snapshotErrorObject = (error: Error): DiagnosticErrorSnapshot => ({
   type: error.constructor.name,


### PR DESCRIPTION
## What changed

- Attach trace/origin metadata in the public `abort(scope)` constructor so diagnostics can point at the abort call site.
- Teach diagnostics to format returned `Fail` values by rendering the wrapped error with the `Fail` trace.
- Add a focused trace test for formatting `Fail` values.
- Add an example showing an abort converted to a diagnostic through built-in `Console` effects.

## Why

When an `Abort` is later converted with `failFrom`, the diagnostic previously fell back to the conversion site instead of the semantic abort site. Capturing origin metadata in `abort(scope)` gives users a more useful trace by default.

## Validation

- `pnpm exec tsx examples/scope/abort-trace-origin.ts`
- `pnpm exec tsc --noEmit --ignoreConfig --module NodeNext --moduleResolution NodeNext --target ESNext --lib ES2024 --types node --strict examples/scope/abort-trace-origin.ts`
- `pnpm typecheck`
- `pnpm test`