### PR TITLE
Make ScopedEffects first class

### DIFF
--- a/examples/scope/read-csv.ts
+++ b/examples/scope/read-csv.ts
@@ -2,9 +2,10 @@ import { fx, run, type Fx } from '../../src'
 import { defaultConsole, log } from '../../src/Console'
 import { assert as assertNoFail } from '../../src/Fail'
 import { managed, usingManaged } from '../../src/Finalization'
+import { handleScoped } from '../../src/Handler'
 import { returnFrom } from '../../src/ReturnFrom'
 import { brand, scope } from '../../src/Scope'
-import { handleYieldFrom, yieldFrom, type YieldFrom, type Yielding } from '../../src/YieldFrom'
+import { yieldFrom, YieldFrom, type Yielding } from '../../src/YieldFrom'
 
 const ImportCsv = 'examples/scope/ImportCsv' as const
 
@@ -56,8 +57,8 @@ const readCsvRows = (file: CsvFile) => fx(function* () {
 const withIndex = <E>(rows: Fx<E | YieldFrom<typeof CsvRows>, void>) => fx(function* () {
   let index = 0
 
-  yield* rows.pipe(handleYieldFrom(CsvRows, row => fx(function* () {
-    yield* yieldFrom(IndexedCsvRows, { index, value: row })
+  yield* rows.pipe(handleScoped(YieldFrom<typeof CsvRows>, CsvRows, effect => fx(function* () {
+    yield* yieldFrom(IndexedCsvRows, { index, value: effect.arg })
     index += 1
   })))
 })
@@ -77,7 +78,9 @@ const importRows = (file: CsvFile) => fx(function* () {
 
   yield* readCsvRows(file).pipe(
     withIndex,
-    handleYieldFrom(IndexedCsvRows, ({ index, value: row }) => fx(function* () {
+    handleScoped(YieldFrom<typeof IndexedCsvRows>, IndexedCsvRows, effect => fx(function* () {
+      const { index, value: row } = effect.arg
+
       if (index === 0) {
         return yield* validateHeader(row)
       }

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -1,14 +1,14 @@
-import { Effect } from './Effect.js'
+import { ScopedEffect } from './Effect.js'
 import { Fx, ok } from './Fx.js'
 import { control } from './Handler.js'
 
 /**
  * Abort the named scope without returning a result.
  */
-export class Abort<const Scope extends string> extends Effect('fx/Abort')<Scope, never> { }
+export class Abort<const Scope extends string> extends ScopedEffect('fx/Abort')<Scope, void, never> { }
 
 export const abort = <const Scope extends string>(scope: Scope): Fx<Abort<Scope>, never> =>
-  new Abort(scope)
+  new Abort(scope, undefined)
 
 /**
  * Return a default value from an abort of the named scope.
@@ -21,5 +21,5 @@ export const orReturn = <const Scope extends string, const R>(
 ): Fx<Exclude<E, Abort<Scope>>, A | R> =>
     f.pipe(
       control(Abort, (_, abort) =>
-        (abort.arg === scope ? ok(value) : abort) as Fx<Exclude<E, Abort<Scope>>, A | R>)
+        (abort.scope === scope ? ok(value) : abort) as Fx<Exclude<E, Abort<Scope>>, A | R>)
     ) as Fx<Exclude<E, Abort<Scope>>, A | R>

--- a/src/Effect.test.ts
+++ b/src/Effect.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { at } from './Breadcrumb.js'
-import { Effect, EffectOriginTypeId, originOf, traceOriginOf, withOrigin, withTraceOrigin } from './Effect.js'
+import { Effect, EffectOriginTypeId, originOf, ScopedEffect, traceOriginOf, withOrigin, withTraceOrigin } from './Effect.js'
 import { captureTrace, setTraceCapturePolicy } from './Trace.js'
 
 describe('Effect', () => {
@@ -16,6 +16,31 @@ describe('Effect', () => {
       class U extends Effect('U')<void, void> { }
       assert.ok(!T.is(new U()))
       assert.ok(!U.is(new T()))
+    })
+  })
+
+  describe('ScopedEffect', () => {
+    it('uses a top-level scope field', () => {
+      class T extends ScopedEffect('T/Scoped')<'test/scope', { readonly value: number }, string> { }
+      const effect = new T('test/scope', { value: 1 })
+
+      assert.ok(T.is(effect))
+      assert.equal(effect.scope, 'test/scope')
+      assert.deepEqual(effect.arg, { value: 1 })
+    })
+
+    it('yields and resumes like an ordinary effect', () => {
+      class T extends ScopedEffect('T/ScopedIterator')<'test/scope', void, string> { }
+      const effect = new T('test/scope', undefined)
+      const iterator = effect[Symbol.iterator]()
+
+      const yielded = iterator.next()
+      assert.equal(yielded.done, false)
+      assert.equal(yielded.value, effect)
+
+      const done = iterator.next('done')
+      assert.equal(done.done, true)
+      assert.equal(done.value, 'done')
     })
   })
 

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -43,6 +43,16 @@ export const Effect = <const T extends string>(id: T) => class <A, R = unknown> 
   }
 }
 
+export const ScopedEffect = <const T extends string>(id: T) => class <
+  const Scope extends string,
+  A = void,
+  R = unknown
+> extends Effect(id)<A, R> {
+  constructor(public readonly scope: Scope, arg: A) {
+    super(arg)
+  }
+}
+
 export const isEffect = <E>(e: E): e is E & AnyEffect =>
   !!e && (e as any)._fxTypeId === EffectTypeId
 

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -1,4 +1,4 @@
-import { Effect } from './Effect.js'
+import { ScopedEffect } from './Effect.js'
 import { Fx, fx } from './Fx.js'
 import { uninterruptible } from './Interrupt.js'
 import type { Interrupt } from './Interrupt.js'
@@ -22,8 +22,7 @@ export type Finalizer = (exit: Exit) => Fx<unknown, void>
 /**
  * Request that a cleanup operation be run when the named scope exits.
  */
-export class Finally<const Scope extends string> extends Effect('fx/Finally')<{
-  readonly scope: Scope
+export class Finally<const Scope extends string> extends ScopedEffect('fx/Finally')<Scope, {
   readonly finalizer: Finalizer
 }, void> { }
 
@@ -34,7 +33,7 @@ export const andFinally = <const Scope extends string, E>(
   scope: Scope,
   f: Fx<E, void>
 ): Fx<Finally<Scope>, void> =>
-  new Finally({ scope, finalizer: () => f })
+  new Finally(scope, { finalizer: () => f })
 
 /**
  * Register a cleanup operation that receives the named scope's exit.
@@ -43,7 +42,7 @@ export const andFinallyExit = <const Scope extends string, E>(
   scope: Scope,
   f: (exit: Exit) => Fx<E, void>
 ): Fx<Finally<Scope>, void> =>
-  new Finally({ scope, finalizer: exit => f(exit) })
+  new Finally(scope, { finalizer: exit => f(exit) })
 
 /**
  * Run an initial operation, register cleanup for its result, and return it.

--- a/src/Handler.test.ts
+++ b/src/Handler.test.ts
@@ -20,7 +20,10 @@ describe('Handler', () => {
       const result = fx(function* () {
         return yield* request(TestScope, 1)
       }).pipe(
-        handleScoped(Request<typeof TestScope>, TestScope, effect => ok(`handled ${effect.arg.value}`)),
+        handleScoped(Request, TestScope, effect => {
+          const _: typeof TestScope = effect.scope
+          return ok(`handled ${effect.arg.value}`)
+        }),
         run
       )
 
@@ -50,6 +53,20 @@ describe('Handler', () => {
       }).pipe(handleScoped(Request<typeof TestScope>, TestScope, () => ok('handled')))
 
       const _: typeof f extends Fx<Request<typeof OtherScope>, 'done'> ? true : false = true
+    })
+
+    it('narrows residual union scopes', () => {
+      const scope = (true as boolean) ? TestScope : OtherScope
+      const f = fx(function* () {
+        yield* request(scope, 1)
+        return 'done'
+      }).pipe(handleScoped(Request<typeof TestScope | typeof OtherScope>, TestScope, () => ok('handled')))
+
+      type ResidualScope = typeof f extends Fx<infer E, 'done'>
+        ? E extends { readonly scope: infer Scope } ? Scope : never
+        : never
+
+      const _: ResidualScope extends typeof OtherScope ? true : false = true
     })
   })
 })

--- a/src/Handler.test.ts
+++ b/src/Handler.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { ScopedEffect } from './Effect.js'
+import { fx, ok, run, type Fx } from './Fx.js'
+import { handleScoped } from './Handler.js'
+
+describe('Handler', () => {
+  describe('handleScoped', () => {
+    const TestScope = 'test/Handler/handleScoped' as const
+    const OtherScope = 'test/Handler/handleScoped/other' as const
+
+    class Request<const Scope extends string> extends ScopedEffect('test/Handler/Request')<Scope, {
+      readonly value: number
+    }, string> { }
+
+    const request = <const Scope extends string>(scope: Scope, value: number): Request<Scope> =>
+      new Request(scope, { value })
+
+    it('handles effects from the matching scope', () => {
+      const result = fx(function* () {
+        return yield* request(TestScope, 1)
+      }).pipe(
+        handleScoped(Request<typeof TestScope>, TestScope, effect => ok(`handled ${effect.arg.value}`)),
+        run
+      )
+
+      assert.equal(result, 'handled 1')
+    })
+
+    it('propagates same-type effects from a different scope', () => {
+      const f = fx(function* () {
+        yield* request(OtherScope, 2)
+        return 'done'
+      }).pipe(handleScoped(Request<typeof TestScope>, TestScope, () => ok('handled')))
+
+      const _: typeof f extends Fx<Request<typeof OtherScope>, 'done'> ? true : false = true
+      const next = f[Symbol.iterator]().next()
+
+      assert.equal(Request.is(next.value), true)
+      const effect = next.value as Request<typeof OtherScope>
+      assert.equal(effect.scope, OtherScope)
+      assert.deepEqual(effect.arg, { value: 2 })
+    })
+
+    it('narrows only matching scoped effects', () => {
+      const f = fx(function* () {
+        yield* request(TestScope, 1)
+        yield* request(OtherScope, 2)
+        return 'done'
+      }).pipe(handleScoped(Request<typeof TestScope>, TestScope, () => ok('handled')))
+
+      const _: typeof f extends Fx<Request<typeof OtherScope>, 'done'> ? true : false = true
+    })
+  })
+})

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -7,9 +7,23 @@ export type Handle<E, A, B = never> = E extends A ? B : E
 
 export type HandleReturn<E, A, R> = E extends A ? R : never
 
+export type MatchedScopedEffect<A, Scope extends string> =
+  A & { readonly scope: Scope }
+
+export type ResidualScopedEffect<E, Scope extends string> =
+  E extends { readonly scope: infer EffectScope extends string }
+  ? Exclude<EffectScope, Scope> extends never
+    ? never
+    : E & { readonly scope: Exclude<EffectScope, Scope> }
+  : E
+
 export type HandleScoped<E, A, Scope extends string, B = never> =
   E extends A
-  ? E extends { readonly scope: Scope } ? B : E
+  ? E extends { readonly scope: infer EffectScope extends string }
+    ? Extract<EffectScope, Scope> extends never
+      ? E
+      : B | ResidualScopedEffect<E, Scope>
+    : E
   : E
 
 export type ScopedEffectType =
@@ -29,13 +43,13 @@ export const handle = <T extends EffectType, HandlerEffects>(
 export const handleScoped = <T extends ScopedEffectType, const Scope extends EffectScope<T>, HandlerEffects>(
   e: T,
   scope: Scope,
-  f: (effect: InstanceType<T>) => Fx<HandlerEffects, Answer<T>>
+  f: (effect: MatchedScopedEffect<InstanceType<T>, Scope>) => Fx<HandlerEffects, Answer<T>>
 ) => <const E, const A>(
   fx: Fx<E, A>
 ): Fx<HandleScoped<E, InstanceType<T>, Scope, HandlerEffects>, A> =>
     new Handler(fx, e._fxEffectId, effect => {
       if (effect.scope === scope) {
-        return f(effect as InstanceType<T>)
+        return f(effect as MatchedScopedEffect<InstanceType<T>, Scope>)
       }
 
       return effect as Fx<InstanceType<T>, Answer<T>>

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -7,6 +7,17 @@ export type Handle<E, A, B = never> = E extends A ? B : E
 
 export type HandleReturn<E, A, R> = E extends A ? R : never
 
+export type HandleScoped<E, A, Scope extends string, B = never> =
+  E extends A
+  ? E extends { readonly scope: Scope } ? B : E
+  : E
+
+export type ScopedEffectType =
+  EffectType & { new(...args: readonly any[]): { readonly scope: string } }
+
+export type EffectScope<T extends ScopedEffectType> =
+  InstanceType<T>['scope']
+
 export const handle = <T extends EffectType, HandlerEffects>(
   e: T,
   f: (effect: InstanceType<T>) => Fx<HandlerEffects, Answer<T>>
@@ -14,6 +25,21 @@ export const handle = <T extends EffectType, HandlerEffects>(
   fx: Fx<E, A>
 ): Fx<Handle<E, InstanceType<T>, HandlerEffects>, A> =>
     new Handler(fx, e._fxEffectId, f) as Fx<Handle<E, InstanceType<T>, HandlerEffects>, A>
+
+export const handleScoped = <T extends ScopedEffectType, const Scope extends EffectScope<T>, HandlerEffects>(
+  e: T,
+  scope: Scope,
+  f: (effect: InstanceType<T>) => Fx<HandlerEffects, Answer<T>>
+) => <const E, const A>(
+  fx: Fx<E, A>
+): Fx<HandleScoped<E, InstanceType<T>, Scope, HandlerEffects>, A> =>
+    new Handler(fx, e._fxEffectId, effect => {
+      if (effect.scope === scope) {
+        return f(effect as InstanceType<T>)
+      }
+
+      return effect as Fx<InstanceType<T>, Answer<T>>
+    }) as Fx<HandleScoped<E, InstanceType<T>, Scope, HandlerEffects>, A>
 
 export const control = <T extends EffectType, HandlerEffects = never, R = never>(
   e: T,

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -3,13 +3,25 @@ import { Fx } from './Fx.js'
 import { Answer, Arg, Control, Handler } from './internal/Handler.js'
 export type { Arg }
 
+/**
+ * Replace handled effects in `E` with effects produced by a handler.
+ */
 export type Handle<E, A, B = never> = E extends A ? B : E
 
+/**
+ * Return values produced by a control handler for matching effects.
+ */
 export type HandleReturn<E, A, R> = E extends A ? R : never
 
+/**
+ * A scoped effect narrowed to the scope currently being handled.
+ */
 export type MatchedScopedEffect<A, Scope extends string> =
   A & { readonly scope: Scope }
 
+/**
+ * A scoped effect with the handled scope removed from its remaining scope type.
+ */
 export type ResidualScopedEffect<E, Scope extends string> =
   E extends { readonly scope: infer EffectScope extends string }
   ? Exclude<EffectScope, Scope> extends never
@@ -17,6 +29,9 @@ export type ResidualScopedEffect<E, Scope extends string> =
     : E & { readonly scope: Exclude<EffectScope, Scope> }
   : E
 
+/**
+ * Replace matching scoped effects in `E` with effects produced by a handler.
+ */
 export type HandleScoped<E, A, Scope extends string, B = never> =
   E extends A
   ? E extends { readonly scope: infer EffectScope extends string }
@@ -26,12 +41,35 @@ export type HandleScoped<E, A, Scope extends string, B = never> =
     : E
   : E
 
+/**
+ * An effect constructor whose instances carry a top-level scope name.
+ */
 export type ScopedEffectType =
   EffectType & { new(...args: readonly any[]): { readonly scope: string } }
 
+/**
+ * The scope names produced by a scoped effect constructor.
+ */
 export type EffectScope<T extends ScopedEffectType> =
   InstanceType<T>['scope']
 
+/**
+ * Handle effects of the given type.
+ *
+ * @example
+ * ```ts
+ * class AskName extends Effect('app/AskName')<void, string> { }
+ *
+ * const program = fx(function* () {
+ *   return `hello ${yield* new AskName()}`
+ * })
+ *
+ * const result = program.pipe(
+ *   handle(AskName, () => ok('Ada')),
+ *   run
+ * )
+ * ```
+ */
 export const handle = <T extends EffectType, HandlerEffects>(
   e: T,
   f: (effect: InstanceType<T>) => Fx<HandlerEffects, Answer<T>>
@@ -40,6 +78,26 @@ export const handle = <T extends EffectType, HandlerEffects>(
 ): Fx<Handle<E, InstanceType<T>, HandlerEffects>, A> =>
     new Handler(fx, e._fxEffectId, f) as Fx<Handle<E, InstanceType<T>, HandlerEffects>, A>
 
+/**
+ * Handle scoped effects of the given type from one scope.
+ *
+ * Effects of the same type from other scopes are left unhandled.
+ *
+ * @example
+ * ```ts
+ * class Ask<const Scope extends string>
+ *   extends ScopedEffect('app/Ask')<Scope, void, string> { }
+ *
+ * const program = fx(function* () {
+ *   return yield* new Ask('user', undefined)
+ * })
+ *
+ * const result = program.pipe(
+ *   handleScoped(Ask, 'user', () => ok('Ada')),
+ *   run
+ * )
+ * ```
+ */
 export const handleScoped = <T extends ScopedEffectType, const Scope extends EffectScope<T>, HandlerEffects>(
   e: T,
   scope: Scope,
@@ -55,6 +113,23 @@ export const handleScoped = <T extends ScopedEffectType, const Scope extends Eff
       return effect as Fx<InstanceType<T>, Answer<T>>
     }) as Fx<HandleScoped<E, InstanceType<T>, Scope, HandlerEffects>, A>
 
+/**
+ * Handle effects of the given type with control over resuming the program.
+ *
+ * @example
+ * ```ts
+ * class Choose extends Effect('app/Choose')<void, boolean> { }
+ *
+ * const program = fx(function* () {
+ *   return yield* new Choose()
+ * })
+ *
+ * const result = program.pipe(
+ *   control(Choose, resume => ok(resume(true))),
+ *   run
+ * )
+ * ```
+ */
 export const control = <T extends EffectType, HandlerEffects = never, R = never>(
   e: T,
   f: <A>(resume: (a: Answer<T>) => A, effect: InstanceType<T>) => Fx<HandlerEffects, R>

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -13,16 +13,10 @@ export type Handle<E, A, B = never> = E extends A ? B : E
  */
 export type HandleReturn<E, A, R> = E extends A ? R : never
 
-/**
- * A scoped effect narrowed to the scope currently being handled.
- */
-export type MatchedScopedEffect<A, Scope extends string> =
+type MatchedScopedEffect<A, Scope extends string> =
   A & { readonly scope: Scope }
 
-/**
- * A scoped effect with the handled scope removed from its remaining scope type.
- */
-export type ResidualScopedEffect<E, Scope extends string> =
+type ResidualScopedEffect<E, Scope extends string> =
   E extends { readonly scope: infer EffectScope extends string }
   ? Exclude<EffectScope, Scope> extends never
     ? never
@@ -41,16 +35,10 @@ export type HandleScoped<E, A, Scope extends string, B = never> =
     : E
   : E
 
-/**
- * An effect constructor whose instances carry a top-level scope name.
- */
-export type ScopedEffectType =
+type ScopedEffectType =
   EffectType & { new(...args: readonly any[]): { readonly scope: string } }
 
-/**
- * The scope names produced by a scoped effect constructor.
- */
-export type EffectScope<T extends ScopedEffectType> =
+type EffectScope<T extends ScopedEffectType> =
   InstanceType<T>['scope']
 
 /**

--- a/src/ReturnFrom.test.ts
+++ b/src/ReturnFrom.test.ts
@@ -45,6 +45,9 @@ describe('ReturnFrom', () => {
     const next = f[Symbol.iterator]().next()
 
     assert.equal(ReturnFrom.is(next.value), true)
+    const effect = next.value as ReturnFrom<typeof OtherScope, 'other'>
+    assert.equal(effect.scope, OtherScope)
+    assert.equal(effect.arg, 'other')
   })
 
   it('only catches the nearest matching scope name', () => {

--- a/src/ReturnFrom.ts
+++ b/src/ReturnFrom.ts
@@ -1,16 +1,13 @@
-import { Effect } from './Effect.js'
+import { ScopedEffect } from './Effect.js'
 import { Fx } from './Fx.js'
 
 /**
  * Return early from the named scope with a value.
  */
-export class ReturnFrom<const Scope extends string, const A> extends Effect('fx/ReturnFrom')<{
-  readonly scope: Scope
-  readonly value: A
-}, never> { }
+export class ReturnFrom<const Scope extends string, const A> extends ScopedEffect('fx/ReturnFrom')<Scope, A, never> { }
 
 export const returnFrom = <const Scope extends string, const A>(
   scope: Scope,
   value: A
 ): Fx<ReturnFrom<Scope, A>, never> =>
-  new ReturnFrom({ scope, value })
+  new ReturnFrom(scope, value)

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -101,16 +101,17 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
       while (!ir.done) {
         if (isEffect(ir.value)) {
           const effect = ir.value
+          const sameScope = (effect as { readonly scope?: unknown }).scope === scopeName
 
-          if (Finally.is(effect) && effect.arg.scope === scopeName) {
+          if (sameScope && Finally.is(effect)) {
             finalizers.push(effect.arg.finalizer)
             ir = i.next(undefined)
-          } else if (ReturnFrom.is(effect) && effect.arg.scope === scopeName) {
-            const exit = { type: 'returnFrom', scope: scopeName, value: effect.arg.value } satisfies Exit<Scope>
+          } else if (sameScope && ReturnFrom.is(effect)) {
+            const exit = { type: 'returnFrom', scope: scopeName, value: effect.arg } satisfies Exit<Scope>
             const failures = yield* release(exit)
             if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A
-            return effect.arg.value as A
-          } else if (Abort.is(effect) && effect.arg === scopeName) {
+            return effect.arg as A
+          } else if (sameScope && Abort.is(effect)) {
             const exit = { type: 'abort', scope: scopeName } satisfies Exit<Scope>
             const failures = yield* release(exit)
             if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A

--- a/src/YieldFrom.test.ts
+++ b/src/YieldFrom.test.ts
@@ -2,9 +2,10 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { abort, orReturn } from './Abort.js'
 import { fx, ok, run, type Fx } from './Fx.js'
+import { handleScoped } from './Handler.js'
 import { returnFrom } from './ReturnFrom.js'
 import { brand, scope } from './Scope.js'
-import { collectFrom, handleYieldFrom, YieldFrom, yieldFrom } from './YieldFrom.js'
+import { collectFrom, YieldFrom, yieldFrom } from './YieldFrom.js'
 import type { Yielding } from './YieldFrom.js'
 
 describe('YieldFrom', () => {
@@ -43,14 +44,15 @@ describe('YieldFrom', () => {
     const f = fx(function* () {
       yield* yieldFrom(OtherScope, 'other')
       return 'done'
-    }).pipe(handleYieldFrom(NumberScope, () => ok(undefined)))
+    }).pipe(handleScoped(YieldFrom<typeof NumberScope>, NumberScope, () => ok(undefined)))
 
     const _: typeof f extends Fx<YieldFrom<typeof OtherScope>, string> ? true : false = true
     const next = f[Symbol.iterator]().next()
 
     assert.equal(YieldFrom.is(next.value), true)
     const effect = next.value as YieldFrom<typeof OtherScope>
-    assert.deepEqual(effect.arg, { scope: OtherScope, value: 'other' })
+    assert.equal(effect.scope, OtherScope)
+    assert.equal(effect.arg, 'other')
   })
 
   it('handles nested named yield scopes independently', () => {
@@ -63,8 +65,8 @@ describe('YieldFrom', () => {
       yield* yieldFrom(InnerScope, 'inner')
       return 'done'
     }).pipe(
-      handleYieldFrom(InnerScope, value => ok(void inner.push(value))),
-      handleYieldFrom(NumberScope, value => ok(void outer.push(value))),
+      handleScoped(YieldFrom<typeof InnerScope>, InnerScope, effect => ok(void inner.push(effect.arg))),
+      handleScoped(YieldFrom<typeof NumberScope>, NumberScope, effect => ok(void outer.push(effect.arg))),
       run
     )
 
@@ -77,7 +79,7 @@ describe('YieldFrom', () => {
     const f = fx(function* () {
       yield* yieldFrom(ItemScope, 'item')
       return true
-    }).pipe(handleYieldFrom(ItemScope, () => ok(undefined)))
+    }).pipe(handleScoped(YieldFrom<typeof ItemScope>, ItemScope, () => ok(undefined)))
 
     const _: typeof f extends Fx<never, boolean> ? true : false = true
 
@@ -89,7 +91,7 @@ describe('YieldFrom', () => {
       const accepted = yield* yieldFrom(DecisionScope, 'item')
       const _: boolean = accepted
       return accepted ? 'accepted' : 'rejected'
-    }).pipe(handleYieldFrom(DecisionScope, value => ok(value === 'item')))
+    }).pipe(handleScoped(YieldFrom<typeof DecisionScope>, DecisionScope, effect => ok(effect.arg === 'item')))
 
     const _: typeof f extends Fx<never, 'accepted' | 'rejected'> ? true : false = true
 
@@ -110,7 +112,7 @@ describe('YieldFrom', () => {
       yield* yieldFrom(ItemScope, 'item')
       return 'late'
     }).pipe(
-      handleYieldFrom(ItemScope, () => returnFrom(ReturnScope, 'early')),
+      handleScoped(YieldFrom<typeof ItemScope>, ItemScope, () => returnFrom(ReturnScope, 'early')),
       scope(ReturnScope),
       run
     )
@@ -125,7 +127,7 @@ describe('YieldFrom', () => {
       yield* yieldFrom(ItemScope, 'item')
       return 'late'
     }).pipe(
-      handleYieldFrom(ItemScope, () => abort(AbortScope)),
+      handleScoped(YieldFrom<typeof ItemScope>, ItemScope, () => abort(AbortScope)),
       scope(AbortScope),
       orReturn(AbortScope, 'aborted'),
       run

--- a/src/YieldFrom.ts
+++ b/src/YieldFrom.ts
@@ -1,6 +1,6 @@
-import { Effect } from './Effect.js'
+import { ScopedEffect } from './Effect.js'
 import { Fx, map, ok } from './Fx.js'
-import { handle } from './Handler.js'
+import { handleScoped } from './Handler.js'
 
 declare const YieldingTypeId: unique symbol
 
@@ -22,10 +22,7 @@ export type YieldInput<Scope> =
  */
 export class YieldFrom<
   const Scope extends string & Yielding<unknown, unknown>
-> extends Effect('fx/YieldFrom')<{
-  readonly scope: Scope
-  readonly value: YieldOutput<Scope>
-}, YieldInput<Scope>> { }
+> extends ScopedEffect('fx/YieldFrom')<Scope, YieldOutput<Scope>, YieldInput<Scope>> { }
 
 /**
  * Yield a value to the named scope.
@@ -34,33 +31,13 @@ export const yieldFrom = <const Scope extends string & Yielding<unknown, unknown
   scope: Scope,
   value: YieldOutput<Scope>
 ): YieldFrom<Scope> =>
-  new YieldFrom({ scope, value })
+  new YieldFrom(scope, value)
 
 export type YieldValue<E, Scope extends string & Yielding<unknown, unknown>> =
   E extends YieldFrom<Scope> ? YieldOutput<Scope> : never
 
 export type ExcludeYieldFrom<E, Scope extends string & Yielding<unknown, unknown>, E2 = never> =
   E extends YieldFrom<Scope> ? E2 : E
-
-/**
- * Handle yields from the named scope.
- */
-export const handleYieldFrom = <const Scope extends string & Yielding<unknown, unknown>, const E2>(
-  scope: Scope,
-  handler: (value: YieldOutput<Scope>, effect: YieldFrom<Scope>) => Fx<E2, YieldInput<Scope>>
-) => <const E, const A>(
-  f: Fx<E, A>
-): Fx<ExcludeYieldFrom<E, Scope, E2>, A> =>
-    f.pipe(handle<typeof YieldFrom, E2 | YieldFrom<string & Yielding<unknown, unknown>>>(YieldFrom, effect => {
-      if (effect.arg.scope === scope) {
-        return handler(
-          effect.arg.value as YieldOutput<Scope>,
-          effect as YieldFrom<Scope>
-        )
-      }
-
-      return effect as YieldFrom<string & Yielding<unknown, unknown>>
-    })) as Fx<ExcludeYieldFrom<E, Scope, E2>, A>
 
 /**
  * Collect all one-way yields from the named scope.
@@ -72,7 +49,8 @@ export const collectFrom = <const Scope extends string & Yielding<unknown, void>
     const values = [] as YieldValue<E, Scope>[]
 
     return f.pipe(
-      handleYieldFrom(scope, value => ok(void values.push(value as YieldValue<E, Scope>) as YieldInput<Scope>)),
+      handleScoped(YieldFrom<Scope>, scope, effect =>
+        ok(void values.push(effect.arg as YieldValue<E, Scope>) as YieldInput<Scope>)),
       map(result => [result, values] as const)
     ) as Fx<ExcludeYieldFrom<E, Scope>, readonly [A, readonly YieldValue<E, Scope>[]]>
   }


### PR DESCRIPTION
## Goal

Make scoped effects a first-class effect shape instead of encoding scope inside each effect's payload. This gives scope-aware effects a shared `scope` field, keeps their request payload in `arg`, and allows generic handling of effects that are distinguished by both effect type and scope name.

## Approach

- Add `ScopedEffect` in `src/Effect.ts` as a small specialization of `Effect` with a top-level `scope` field and ordinary `arg` payload/resume behavior.
- Add `handleScoped` in `src/Handler.ts` to handle only matching effect type + scope pairs while preserving same-type effects from other scopes in the remaining `E` union.
- Migrate `Abort`, `Finally`, `ReturnFrom`, and `YieldFrom` to extend `ScopedEffect`, updating `Scope` runtime handling to check `effect.scope` before consuming scoped control/finalization effects.
- Remove the YieldFrom-specific `handleYieldFrom` helper and express `collectFrom`, tests, and the CSV scope example in terms of `handleScoped`.
- Add focused runtime and type-level tests for `ScopedEffect` construction/iteration, `handleScoped` scope filtering, and migrated scoped effects.

## Reviewer Context

The main compatibility point is the shape of scoped effect instances: `scope` is now top-level and `arg` now contains only the effect-specific payload. That affects direct consumers of `YieldFrom`, `ReturnFrom`, `Finally`, or `Abort` instances, especially code that previously read `effect.arg.scope` or `effect.arg.value`.

The highest-value review areas are:

- `HandleScoped` type narrowing in `src/Handler.ts`, especially preserving unmatched same-type scoped effects.
- Runtime forwarding in `handleScoped`, where non-matching scopes must continue outward unchanged.
- `ScopeBoundary` checks in `src/Scope.ts`, which now guard by `sameScope` before consuming `Finally`, `ReturnFrom`, or `Abort`.
- Replacement of `handleYieldFrom` with the more general `handleScoped` API.

Validation run locally:

- `pnpm test`
- `pnpm typecheck`