### PR TITLE
Add SQLite persistence for bookmarks example

### DIFF
--- a/examples/bookmarks/design.md
+++ b/examples/bookmarks/design.md
@@ -346,6 +346,112 @@ the same regardless of client.
 If a browser-side `fx` client is added later, it should demonstrate a distinct
 point, such as interpreting `HttpClient` differently in browser and CLI.
 
+## Browser-local IndexedDB Client
+
+An optional later browser mode can run without the Node API server by interpreting
+the same domain programs directly in the browser and storing bookmarks in
+IndexedDB.
+
+Purpose:
+
+- demonstrate a browser platform interpretation of `BookmarkStore`,
+- make the browser demo usable across refreshes without running the server,
+- keep the no-server mode honest by reusing `addBookmark`, `listBookmarks`,
+  `markRead`, `archiveBookmark`, and `refreshMetadata`,
+- avoid introducing a service container, client framework, or domain-specific
+  transport abstraction before there are multiple concrete uses.
+
+The IndexedDB client should be browser-only and should not change the domain
+module, HTTP routes, CLI, or server storage handlers.
+
+Suggested files:
+
+```text
+examples/bookmarks/browser/
+  store-indexeddb.ts
+  local-client.ts
+```
+
+`store-indexeddb.ts` should export an `indexedDbBookmarkStore` handler for the
+existing `BookmarkStore` effect. Keep the storage shape boring:
+
+- database name: `fx-bookmarks`,
+- object store: `bookmarks`,
+- key path: `id`,
+- index: `url`,
+- stored value: a plain structured-cloneable record,
+- dates stored as ISO strings and decoded back to `Date`,
+- `tags` and `metadataStatus` stored as plain values that match the domain
+  shape.
+
+The handler should implement:
+
+- `FindBookmarkById` with `objectStore.get(id)`,
+- `FindBookmarkByUrl` with the `url` index,
+- `SaveBookmark` with `objectStore.put(serializedBookmark)`,
+- `ListBookmarks` by loading all bookmarks, decoding them, applying the same
+  filter semantics as the in-memory and SQLite handlers, and sorting by
+  `createdAt` then `id`.
+
+Loading all bookmarks is acceptable for this example. It keeps the IndexedDB
+code small and makes the handler easier to compare with the in-memory handler.
+Do not add indexed query planning unless the example grows enough to justify it.
+
+`local-client.ts` should expose the same operation names as the HTTP client, but
+without a `baseUrl` argument:
+
+```ts
+createLocalBookmark(input)
+listLocalBookmarks(query)
+markLocalBookmarkRead(id)
+archiveLocalBookmark(id)
+refreshLocalBookmarkMetadata(id)
+```
+
+Each function should call the corresponding domain program and apply browser
+handlers:
+
+- `indexedDbBookmarkStore`,
+- a browser id handler based on `crypto.randomUUID()` when available, with a
+  small timestamp/random fallback for older browsers,
+- `defaultTime` if it is browser-compatible, otherwise a tiny browser time
+  handler local to the browser example,
+- `demoPageMetadata` or a browser-safe metadata handler.
+
+Do not attempt real arbitrary URL metadata fetching in the browser for this
+mode. Browser CORS rules will make many pages unavailable, and that would
+distract from the storage example. A deterministic demo metadata handler is
+enough, or metadata failures can be recorded recoverably on the bookmark.
+
+Mode selection should be explicit. Prefer a URL query parameter:
+
+```text
+/bookmarks/?store=api
+/bookmarks/?store=indexeddb
+```
+
+Default to `api` so the existing server-backed example remains unchanged. Do
+not silently fall back from API mode to IndexedDB mode when requests fail; that
+would make user-visible behavior harder to explain.
+
+The UI should not fork into two copies. Instead, adapt `browser/app.ts` so the
+event handlers call a small `BookmarkBrowserClient` value selected once at
+startup:
+
+```ts
+type BookmarkBrowserClient<E> = {
+  readonly create: (input: AddBookmarkInput) => Fx<E, Bookmark>
+  readonly list: (query: BookmarkQuery) => Fx<E, readonly Bookmark[]>
+  readonly markRead: (id: BookmarkId) => Fx<E, Bookmark>
+  readonly archive: (id: BookmarkId) => Fx<E, Bookmark>
+  readonly refreshMetadata: (id: BookmarkId) => Fx<E, Bookmark>
+}
+```
+
+The HTTP implementation can wrap the existing `client.ts` functions. The
+IndexedDB implementation can wrap the new local client functions. Keep this type
+local to the browser example; do not promote it into a library abstraction.
+
 ## Testing Strategy
 
 Focused tests should cover:
@@ -386,10 +492,12 @@ Optional later additions:
 
 ```text
 examples/bookmarks/
-  store-json.ts
+  store-sqlite.ts
   browser/
     index.html
     app.js
+    local-client.ts
+    store-indexeddb.ts
   package.json
 ```
 
@@ -425,13 +533,34 @@ Status: implemented.
 
 ### Phase 4: Browser client
 
+Status: implemented.
+
 - Add a static page that calls the API.
 - Keep UI minimal: add, list, mark read, archive, refresh metadata.
 
-### Phase 5: Optional persistence
+### Phase 5: SQLite persistence
 
-- Add JSON file storage if persistence improves the example.
+Status: implemented.
+
+- Add SQLite storage for bookmarks.
 - Keep it as a handler swap, not a domain change.
+- Use `BOOKMARKS_DB` to choose the database file.
+
+### Phase 6: Browser-local IndexedDB mode
+
+Status: proposed.
+
+- Add a browser-only IndexedDB `BookmarkStore` handler.
+- Add a browser-local client that calls domain programs directly.
+- Add explicit browser mode selection with `?store=api` and
+  `?store=indexeddb`.
+- Keep API mode as the default.
+- Use demo or recoverable-failure metadata in IndexedDB mode; do not fetch
+  arbitrary page metadata from the browser.
+- Reuse the existing browser UI and select a small client adapter at startup.
+- Add focused tests for IndexedDB serialization, persistence across reload-like
+  client instances, filtering, updates, and direct domain workflow execution.
+
 
 ## Open Questions
 
@@ -447,7 +576,13 @@ Status: implemented.
   later handler swap.
 - Should the browser client stay plain JavaScript, or should it also demonstrate
   `fx` on the client side?
-  Answer: deferred until the browser phase.
+  Answer: the implemented browser client uses `fx` for UI flow and HTTP client
+  effects. A browser-local IndexedDB mode is deferred to phase 6 to demonstrate
+  direct browser interpretation of domain effects.
+- Should the browser app silently fall back to local storage when the API server
+  is unavailable?
+  Answer: no. Storage mode should be explicit with `?store=api` or
+  `?store=indexeddb` so users can tell which persistence backend they are using.
 
 ## Recommended First Cut
 

--- a/examples/bookmarks/domain.test.ts
+++ b/examples/bookmarks/domain.test.ts
@@ -66,6 +66,23 @@ describe('bookmarks example domain', () => {
     })
   })
 
+  it('fails duplicate active URLs after re-adding an archived URL', async () => {
+    const store = memoryBookmarkStore()
+    const ids = deterministicBookmarkIds(['bookmark-1', 'bookmark-2', 'bookmark-3'])
+    const archived = await runDomain(addBookmark({ url: 'https://example.com/read' }), { store, ids })
+    assertBookmark(archived)
+
+    await runDomain(archiveBookmark(archived.id), { store })
+    const active = await runDomain(addBookmark({ url: 'https://example.com/read' }), { store, ids })
+    assertBookmark(active)
+
+    assert.deepEqual(await runDomain(addBookmark({ url: 'https://example.com/read' }), { store, ids }), {
+      tag: 'DuplicateBookmark',
+      url: 'https://example.com/read',
+      id: active.id
+    })
+  })
+
   it('keeps bookmark creation successful when metadata fetch fails', async () => {
     const result = await runDomain(addBookmark({ url: 'https://example.com/offline' }), {
       metadata: {

--- a/examples/bookmarks/domain.ts
+++ b/examples/bookmarks/domain.ts
@@ -268,7 +268,9 @@ const pageMetadataFields = (result: MetadataResult): Pick<Bookmark, 'title' | 'd
     : {}
 
 const findByUrl = (bookmarks: Map<BookmarkId, Bookmark>, url: string): Bookmark | undefined =>
-  [...bookmarks.values()].find(bookmark => bookmark.url === url)
+  [...bookmarks.values()]
+    .filter(bookmark => bookmark.url === url)
+    .sort(compareDuplicateCandidates)[0]
 
 const filterBookmarks = (bookmarks: Map<BookmarkId, Bookmark>, query: BookmarkQuery): readonly Bookmark[] => {
   const normalized = normalizeQuery(query)
@@ -286,6 +288,11 @@ const bookmarkMatchesText = (bookmark: Bookmark, text: string): boolean =>
   bookmark.url.toLocaleLowerCase().includes(text) ||
     bookmark.title?.toLocaleLowerCase().includes(text) === true ||
     bookmark.description?.toLocaleLowerCase().includes(text) === true
+
+const compareDuplicateCandidates = (a: Bookmark, b: Bookmark): number =>
+  Number(a.status === 'archived') - Number(b.status === 'archived') ||
+  a.createdAt.getTime() - b.createdAt.getTime() ||
+  a.id.localeCompare(b.id)
 
 const isMetadataResult = (value: MetadataResult | PageMetadata): value is MetadataResult =>
   'tag' in value && (value.tag === 'available' || value.tag === 'failed')

--- a/examples/bookmarks/server.ts
+++ b/examples/bookmarks/server.ts
@@ -19,7 +19,6 @@ import {
   demoPageMetadata,
   listBookmarks,
   markRead,
-  memoryBookmarkStore,
   randomBookmarkIds,
   refreshMetadata,
   type AddBookmarkInput,
@@ -30,6 +29,7 @@ import {
   type FetchPageMetadata,
   type NextBookmarkId
 } from './domain.js'
+import { sqliteBookmarkStore } from './store-sqlite.js'
 
 type ServerConfig = {
   readonly host: string
@@ -275,7 +275,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 await server.pipe(
   nodeHttp(),
   f => forEachStream(f, logHttpServerEvent),
-  memoryBookmarkStore(),
+  sqliteBookmarkStore(process.env.BOOKMARKS_DB ?? 'bookmarks.sqlite'),
   demoPageMetadata,
   randomBookmarkIds,
   logConsole,

--- a/examples/bookmarks/store-sqlite.test.ts
+++ b/examples/bookmarks/store-sqlite.test.ts
@@ -1,0 +1,225 @@
+import * as assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import { returnAll } from '../../src/Fail.js'
+import { runPromise, type Fx } from '../../src/Fx.js'
+import { collect } from '../../src/Log.js'
+import { withClock, type Time } from '../../src/Time.js'
+import { VirtualClock } from '../../src/internal/time.js'
+import {
+  addBookmark,
+  deterministicBookmarkIds,
+  findBookmarkById,
+  findBookmarkByUrl,
+  listBookmarks,
+  markRead,
+  saveBookmark,
+  stubPageMetadata,
+  type Bookmark,
+  type BookmarkEffects,
+  type BookmarkError,
+  type FetchPageMetadata,
+  type MetadataResult
+} from './domain.js'
+import { sqliteBookmarkStore } from './store-sqlite.js'
+
+describe('sqlite bookmark store', () => {
+  it('saves and loads bookmarks by id', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const bookmark = bookmarkFixture({ id: 'bookmark-1' })
+      const saved = await runStore(path, saveBookmark(bookmark))
+      const found = await runStore(path, findBookmarkById(bookmark.id))
+
+      assert.deepEqual(saved, bookmark)
+      assert.deepEqual(found, bookmark)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('finds bookmarks by URL', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const bookmark = bookmarkFixture({ url: 'https://example.com/read' })
+
+      await runStore(path, saveBookmark(bookmark))
+
+      assert.deepEqual(await runStore(path, findBookmarkByUrl(bookmark.url)), bookmark)
+      assert.equal(await runStore(path, findBookmarkByUrl('https://example.com/missing')), undefined)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('lists bookmarks by status, tag, and text', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const first = bookmarkFixture({
+        id: 'bookmark-1',
+        url: 'https://example.com/typescript',
+        tags: ['typescript'],
+        title: 'TypeScript effects'
+      })
+      const second = bookmarkFixture({
+        id: 'bookmark-2',
+        url: 'https://example.com/archive',
+        tags: ['effects'],
+        status: 'read',
+        title: 'Reading queue'
+      })
+
+      await runStore(path, saveBookmark(second))
+      await runStore(path, saveBookmark(first))
+
+      assert.deepEqual(ids(await runStore(path, listBookmarks({ status: 'unread' }))), [first.id])
+      assert.deepEqual(ids(await runStore(path, listBookmarks({ tag: 'effects' }))), [second.id])
+      assert.deepEqual(ids(await runStore(path, listBookmarks({ text: 'typescript' }))), [first.id])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('persists bookmarks across handler instances', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const bookmark = bookmarkFixture({ id: 'bookmark-1' })
+
+      await runStore(path, saveBookmark(bookmark))
+
+      assert.deepEqual(await runStore(path, findBookmarkById(bookmark.id)), bookmark)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('updates existing bookmark rows', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const bookmark = bookmarkFixture({ id: 'bookmark-1', title: 'Old title' })
+      const updated = {
+        ...bookmark,
+        title: 'New title',
+        status: 'read' as const,
+        updatedAt: new Date('2024-01-01T00:01:00.000Z')
+      }
+
+      await runStore(path, saveBookmark(bookmark))
+      await runStore(path, saveBookmark(updated))
+
+      assert.deepEqual(await runStore(path, findBookmarkById(bookmark.id)), updated)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('runs domain workflows with sqlite persistence', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const first = await runDomain(path, addBookmark({
+        url: 'https://example.com/read#section',
+        tags: ['typescript', 'effects']
+      }), {
+        metadata: {
+          'https://example.com/read': {
+            title: 'SQLite-backed bookmarks',
+            description: 'Persisted reading queue'
+          }
+        }
+      })
+      assertBookmark(first)
+
+      const read = await runDomain(path, markRead(first.id))
+      assertBookmark(read)
+      assert.equal(read.status, 'read')
+
+      const listed = await runStore(path, listBookmarks({ status: 'read', tag: 'effects', text: 'sqlite' }))
+      assert.deepEqual(ids(listed), [first.id])
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+type BookmarkFixtureOptions = {
+  readonly id?: string
+  readonly url?: string
+  readonly title?: string
+  readonly description?: string
+  readonly tags?: readonly string[]
+  readonly status?: Bookmark['status']
+}
+
+type TestOptions = {
+  readonly clock?: VirtualClock
+  readonly ids?: ReturnType<typeof deterministicBookmarkIds>
+  readonly metadata?: Readonly<Record<string, MetadataResult | { readonly title?: string; readonly description?: string }>>
+}
+
+const runStore = async <A>(path: string, program: Fx<BookmarkEffects, A>): Promise<A | BookmarkError> =>
+  await program.pipe(
+    sqliteBookmarkStore(path),
+    stubPageMetadata({}),
+    deterministicBookmarkIds(['bookmark-1', 'bookmark-2', 'bookmark-3']),
+    withClock(new VirtualClock(Date.parse('2024-01-01T00:00:00.000Z'))),
+    collect,
+    returnAll,
+    runPromise
+  ).then(result => Array.isArray(result) ? result[0] : result)
+
+const runDomain = async <A>(
+  path: string,
+  program: Fx<BookmarkEffects | FetchPageMetadata | Time, A>,
+  options: TestOptions = {}
+): Promise<A | BookmarkError> => {
+  const clock = options.clock ?? new VirtualClock(Date.parse('2024-01-01T00:00:00.000Z'))
+  const ids = options.ids ?? deterministicBookmarkIds(['bookmark-1', 'bookmark-2', 'bookmark-3'])
+  const metadata = options.metadata ?? {}
+
+  return await program.pipe(
+    sqliteBookmarkStore(path),
+    stubPageMetadata(metadata),
+    ids,
+    withClock(clock),
+    collect,
+    returnAll,
+    runPromise
+  ).then(result => Array.isArray(result) ? result[0] : result)
+}
+
+const bookmarkFixture = (options: BookmarkFixtureOptions = {}): Bookmark => ({
+  id: options.id ?? 'bookmark-1',
+  url: options.url ?? 'https://example.com/read',
+  title: options.title ?? 'Example article',
+  description: options.description ?? 'An article to read later',
+  tags: options.tags ?? ['typescript'],
+  status: options.status ?? 'unread',
+  metadataStatus: { tag: 'available' },
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-01T00:00:00.000Z')
+})
+
+const tempDatabase = () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fx-bookmarks-sqlite-'))
+  return {
+    path: join(dir, 'bookmarks.sqlite'),
+    cleanup: () => rm(dir, { recursive: true, force: true })
+  }
+}
+
+const assertBookmark: (value: Bookmark | BookmarkError | readonly Bookmark[] | undefined) => asserts value is Bookmark =
+  (value): asserts value is Bookmark => {
+  assert.equal(typeof value, 'object')
+  assert.notEqual(value, null)
+  assert.ok(value !== undefined)
+  assert.ok(!Array.isArray(value))
+  assert.ok(!('tag' in value))
+}
+
+const ids = (bookmarks: Bookmark | BookmarkError | readonly Bookmark[] | undefined): readonly string[] => {
+  assert.ok(Array.isArray(bookmarks))
+  return bookmarks.map(bookmark => bookmark.id)
+}

--- a/examples/bookmarks/store-sqlite.test.ts
+++ b/examples/bookmarks/store-sqlite.test.ts
@@ -142,6 +142,13 @@ describe('sqlite bookmark store', () => {
     }
   })
 
+  it('closes the database after each store run', async () => {
+    const { path, cleanup } = tempDatabase()
+
+    await runStore(path, saveBookmark(bookmarkFixture()))
+    await assert.doesNotReject(cleanup)
+  })
+
   it('runs domain workflows with sqlite persistence', async () => {
     const { path, cleanup } = tempDatabase()
     try {

--- a/examples/bookmarks/store-sqlite.test.ts
+++ b/examples/bookmarks/store-sqlite.test.ts
@@ -11,6 +11,7 @@ import { withClock, type Time } from '../../src/Time.js'
 import { VirtualClock } from '../../src/internal/time.js'
 import {
   addBookmark,
+  archiveBookmark,
   deterministicBookmarkIds,
   findBookmarkById,
   findBookmarkByUrl,
@@ -50,6 +51,31 @@ describe('sqlite bookmark store', () => {
 
       assert.deepEqual(await runStore(path, findBookmarkByUrl(bookmark.url)), bookmark)
       assert.equal(await runStore(path, findBookmarkByUrl('https://example.com/missing')), undefined)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('finds active bookmarks before archived bookmarks by URL', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const archived = bookmarkFixture({
+        id: 'bookmark-1',
+        url: 'https://example.com/read',
+        status: 'archived'
+      })
+      const active = bookmarkFixture({
+        id: 'bookmark-2',
+        url: 'https://example.com/read',
+        status: 'unread',
+        title: 'Active bookmark',
+        createdAt: new Date('2024-01-01T00:01:00.000Z')
+      })
+
+      await runStore(path, saveBookmark(archived))
+      await runStore(path, saveBookmark(active))
+
+      assert.deepEqual(await runStore(path, findBookmarkByUrl(active.url)), active)
     } finally {
       await cleanup()
     }
@@ -142,6 +168,27 @@ describe('sqlite bookmark store', () => {
       await cleanup()
     }
   })
+
+  it('fails duplicate active URLs after re-adding an archived URL', async () => {
+    const { path, cleanup } = tempDatabase()
+    try {
+      const ids = deterministicBookmarkIds(['bookmark-1', 'bookmark-2', 'bookmark-3'])
+      const archived = await runDomain(path, addBookmark({ url: 'https://example.com/read' }), { ids })
+      assertBookmark(archived)
+
+      await runDomain(path, archiveBookmark(archived.id), { ids })
+      const active = await runDomain(path, addBookmark({ url: 'https://example.com/read' }), { ids })
+      assertBookmark(active)
+
+      assert.deepEqual(await runDomain(path, addBookmark({ url: 'https://example.com/read' }), { ids }), {
+        tag: 'DuplicateBookmark',
+        url: 'https://example.com/read',
+        id: active.id
+      })
+    } finally {
+      await cleanup()
+    }
+  })
 })
 
 type BookmarkFixtureOptions = {
@@ -151,6 +198,7 @@ type BookmarkFixtureOptions = {
   readonly description?: string
   readonly tags?: readonly string[]
   readonly status?: Bookmark['status']
+  readonly createdAt?: Date
 }
 
 type TestOptions = {
@@ -198,7 +246,7 @@ const bookmarkFixture = (options: BookmarkFixtureOptions = {}): Bookmark => ({
   tags: options.tags ?? ['typescript'],
   status: options.status ?? 'unread',
   metadataStatus: { tag: 'available' },
-  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  createdAt: options.createdAt ?? new Date('2024-01-01T00:00:00.000Z'),
   updatedAt: new Date('2024-01-01T00:00:00.000Z')
 })
 

--- a/examples/bookmarks/store-sqlite.ts
+++ b/examples/bookmarks/store-sqlite.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from 'node:sqlite'
-import { ok, type Fx } from '../../src/Fx.js'
+import { assertSync, bracket, ok, type Fx } from '../../src/Fx.js'
 import { handle } from '../../src/Handler.js'
 import {
   FindBookmarkById,
@@ -24,10 +24,20 @@ type BookmarkRow = {
   readonly updated_at: string
 }
 
-export const sqliteBookmarkStore = (path: string) => {
+export const sqliteBookmarkStore = (path: string) => <E, A>(program: Fx<E, A>) =>
+  bracket(
+    assertSync(() => openDatabase(path)),
+    db => assertSync(() => db.close()),
+    db => interpretBookmarkStore(db, program)
+  )
+
+const openDatabase = (path: string): DatabaseSync => {
   const db = new DatabaseSync(path)
   initialize(db)
+  return db
+}
 
+const interpretBookmarkStore = <E, A>(db: DatabaseSync, program: Fx<E, A>) => {
   const selectById = db.prepare('select * from bookmarks where id = ?')
   const selectByUrl = db.prepare(`
     select * from bookmarks
@@ -60,7 +70,7 @@ export const sqliteBookmarkStore = (path: string) => {
       updated_at = excluded.updated_at
   `)
 
-  const handleBookmarkStore = <E, A>(program: Fx<E, A>) => program.pipe(
+  return program.pipe(
     handle(FindBookmarkById, effect => ok(bookmarkFromRow(selectById.get(effect.arg)))),
     handle(FindBookmarkByUrl, effect => ok(bookmarkFromRow(selectByUrl.get(effect.arg)))),
     handle(ListBookmarks, effect => ok(listBookmarks(selectAll, selectByStatus, effect.arg))),
@@ -79,8 +89,6 @@ export const sqliteBookmarkStore = (path: string) => {
       return ok(effect.arg)
     })
   )
-
-  return handleBookmarkStore
 }
 
 const initialize = (db: DatabaseSync): void => {

--- a/examples/bookmarks/store-sqlite.ts
+++ b/examples/bookmarks/store-sqlite.ts
@@ -29,7 +29,12 @@ export const sqliteBookmarkStore = (path: string) => {
   initialize(db)
 
   const selectById = db.prepare('select * from bookmarks where id = ?')
-  const selectByUrl = db.prepare('select * from bookmarks where url = ? order by created_at, id limit 1')
+  const selectByUrl = db.prepare(`
+    select * from bookmarks
+    where url = ?
+    order by status = 'archived', created_at, id
+    limit 1
+  `)
   const selectAll = db.prepare('select * from bookmarks order by created_at, id')
   const selectByStatus = db.prepare('select * from bookmarks where status = ? order by created_at, id')
   const save = db.prepare(`

--- a/examples/bookmarks/store-sqlite.ts
+++ b/examples/bookmarks/store-sqlite.ts
@@ -1,0 +1,204 @@
+import { DatabaseSync } from 'node:sqlite'
+import { ok, type Fx } from '../../src/Fx.js'
+import { handle } from '../../src/Handler.js'
+import {
+  FindBookmarkById,
+  FindBookmarkByUrl,
+  ListBookmarks,
+  SaveBookmark,
+  type Bookmark,
+  type BookmarkQuery,
+  type BookmarkStatus,
+  type MetadataStatus
+} from './domain.js'
+
+type BookmarkRow = {
+  readonly id: string
+  readonly url: string
+  readonly title: string | null
+  readonly description: string | null
+  readonly tags: string
+  readonly status: string
+  readonly metadata_status: string
+  readonly created_at: string
+  readonly updated_at: string
+}
+
+export const sqliteBookmarkStore = (path: string) => {
+  const db = new DatabaseSync(path)
+  initialize(db)
+
+  const selectById = db.prepare('select * from bookmarks where id = ?')
+  const selectByUrl = db.prepare('select * from bookmarks where url = ? order by created_at, id limit 1')
+  const selectAll = db.prepare('select * from bookmarks order by created_at, id')
+  const selectByStatus = db.prepare('select * from bookmarks where status = ? order by created_at, id')
+  const save = db.prepare(`
+    insert into bookmarks (
+      id,
+      url,
+      title,
+      description,
+      tags,
+      status,
+      metadata_status,
+      created_at,
+      updated_at
+    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    on conflict(id) do update set
+      url = excluded.url,
+      title = excluded.title,
+      description = excluded.description,
+      tags = excluded.tags,
+      status = excluded.status,
+      metadata_status = excluded.metadata_status,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+  `)
+
+  const handleBookmarkStore = <E, A>(program: Fx<E, A>) => program.pipe(
+    handle(FindBookmarkById, effect => ok(bookmarkFromRow(selectById.get(effect.arg)))),
+    handle(FindBookmarkByUrl, effect => ok(bookmarkFromRow(selectByUrl.get(effect.arg)))),
+    handle(ListBookmarks, effect => ok(listBookmarks(selectAll, selectByStatus, effect.arg))),
+    handle(SaveBookmark, effect => {
+      save.run(
+        effect.arg.id,
+        effect.arg.url,
+        effect.arg.title ?? null,
+        effect.arg.description ?? null,
+        JSON.stringify(effect.arg.tags),
+        effect.arg.status,
+        JSON.stringify(effect.arg.metadataStatus),
+        effect.arg.createdAt.toISOString(),
+        effect.arg.updatedAt.toISOString()
+      )
+      return ok(effect.arg)
+    })
+  )
+
+  return handleBookmarkStore
+}
+
+const initialize = (db: DatabaseSync): void => {
+  db.exec(`
+    create table if not exists bookmarks (
+      id text primary key,
+      url text not null,
+      title text,
+      description text,
+      tags text not null,
+      status text not null,
+      metadata_status text not null,
+      created_at text not null,
+      updated_at text not null
+    )
+  `)
+}
+
+const listBookmarks = (
+  selectAll: ReturnType<DatabaseSync['prepare']>,
+  selectByStatus: ReturnType<DatabaseSync['prepare']>,
+  query: BookmarkQuery
+): readonly Bookmark[] => {
+  const status = query.status === 'all' ? undefined : query.status
+  const rows = status === undefined
+    ? selectAll.all()
+    : selectByStatus.all(status)
+  const tag = query.tag?.trim() || undefined
+  const text = query.text?.trim().toLocaleLowerCase() || undefined
+
+  return rows
+    .map(row => bookmarkFromRow(row))
+    .filter(bookmark => bookmark !== undefined)
+    .filter(bookmark => tag === undefined || bookmark.tags.includes(tag))
+    .filter(bookmark => text === undefined || bookmarkMatchesText(bookmark, text))
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id))
+}
+
+const bookmarkFromRow = (row: unknown): Bookmark | undefined => {
+  if (row === undefined) return undefined
+  if (!isBookmarkRow(row)) throw new Error('Malformed bookmark row')
+
+  const tags = parseTags(row.tags)
+  const metadataStatus = parseMetadataStatus(row.metadata_status)
+  const status = parseBookmarkStatus(row.status)
+  const createdAt = parseDate(row.created_at)
+  const updatedAt = parseDate(row.updated_at)
+
+  if (
+    tags === undefined ||
+    metadataStatus === undefined ||
+    status === undefined ||
+    createdAt === undefined ||
+    updatedAt === undefined
+  ) {
+    throw new Error(`Malformed bookmark row: ${row.id}`)
+  }
+
+  return {
+    id: row.id,
+    url: row.url,
+    title: row.title ?? undefined,
+    description: row.description ?? undefined,
+    tags,
+    status,
+    metadataStatus,
+    createdAt,
+    updatedAt
+  }
+}
+
+const bookmarkMatchesText = (bookmark: Bookmark, text: string): boolean =>
+  bookmark.url.toLocaleLowerCase().includes(text) ||
+    bookmark.title?.toLocaleLowerCase().includes(text) === true ||
+    bookmark.description?.toLocaleLowerCase().includes(text) === true
+
+const parseTags = (value: string): readonly string[] | undefined => {
+  const tags = parseJson(value)
+  return Array.isArray(tags) && tags.every(tag => typeof tag === 'string')
+    ? tags
+    : undefined
+}
+
+const parseMetadataStatus = (value: string): MetadataStatus | undefined => {
+  const status = parseJson(value)
+  return isMetadataStatus(status) ? status : undefined
+}
+
+const parseBookmarkStatus = (value: string): BookmarkStatus | undefined =>
+  value === 'unread' || value === 'read' || value === 'archived'
+    ? value
+    : undefined
+
+const parseDate = (value: string): Date | undefined => {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
+const parseJson = (value: string): unknown => {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+const isBookmarkRow = (value: unknown): value is BookmarkRow =>
+  isRecord(value) &&
+  typeof value.id === 'string' &&
+  typeof value.url === 'string' &&
+  (typeof value.title === 'string' || value.title === null) &&
+  (typeof value.description === 'string' || value.description === null) &&
+  typeof value.tags === 'string' &&
+  typeof value.status === 'string' &&
+  typeof value.metadata_status === 'string' &&
+  typeof value.created_at === 'string' &&
+  typeof value.updated_at === 'string'
+
+const isMetadataStatus = (value: unknown): value is MetadataStatus =>
+  isRecord(value) &&
+  (value.tag === 'not-requested' ||
+    value.tag === 'available' ||
+    (value.tag === 'failed' && typeof value.reason === 'string'))
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "benchmark:runtime-context": "tsx benchmarks/runtime-context.ts",
     "benchmark:runtime-loops": "tsx benchmarks/runtime-loops.ts",
     "lint": "oxlint --type-aware",
-    "test": "node --import tsx --test 'src/**/*.test.ts'",
+    "test": "node --import tsx --test 'src/**/*.test.ts' 'examples/**/*.test.ts'",
     "test:watch": "node --import tsx --test --test-reporter=dot --watch './src/**/*.test.ts'",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- add a node:sqlite-backed BookmarkStore handler for the bookmarks example
- wire the server to SQLite by default with BOOKMARKS_DB override
- add focused SQLite persistence tests and include example tests in pnpm test

## Verification
- corepack pnpm test
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build