### PR TITLE
[codex] Add incident collector example

### DIFF
--- a/examples/incident-collector/cli.ts
+++ b/examples/incident-collector/cli.ts
@@ -47,7 +47,7 @@ const printableResult = (result: unknown): unknown =>
 
 await fx(function* () {
   yield* runSnapshot('successful snapshot', false)
-  yield* runSnapshot('failing collector cancels siblings', true)
+  yield* runSnapshot('failing snapshot interrupts collectors and fails bundle', true)
 }).pipe(
   defaultConsole,
   runPromise

--- a/examples/incident-collector/cli.ts
+++ b/examples/incident-collector/cli.ts
@@ -22,8 +22,8 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     incidentId: failDeploy ? 'INC-2026-05-17-B' : 'INC-2026-05-17-A',
     services: ['api', 'worker', 'billing']
   }).pipe(
-    scope(CollectorScope),
     fixture.handle,
+    scope(CollectorScope),
     logConsole,
     defaultTime,
     firstSuccess,
@@ -47,7 +47,7 @@ const printableResult = (result: unknown): unknown =>
 
 await fx(function* () {
   yield* runSnapshot('successful snapshot', false)
-  yield* runSnapshot('failing snapshot interrupts collectors and fails bundle', true)
+  yield* runSnapshot('failing collector fails while siblings are interrupted', true)
 }).pipe(
   defaultConsole,
   runPromise

--- a/examples/incident-collector/cli.ts
+++ b/examples/incident-collector/cli.ts
@@ -1,0 +1,57 @@
+import { bounded, defaultAll, firstSuccess } from '../../src/Concurrent.js'
+import { defaultConsole, error as consoleError, log } from '../../src/Console.js'
+import { returnAll } from '../../src/Fail.js'
+import { fx, runPromise } from '../../src/Fx.js'
+import { console as logConsole } from '../../src/Log.js'
+import { scope } from '../../src/Scope.js'
+import { defaultTime } from '../../src/Time.js'
+import {
+  BundleScope,
+  CollectorScope,
+  collectIncidentSnapshot,
+  createIncidentCollectorFixture
+} from './domain.js'
+
+const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
+  const fixture = createIncidentCollectorFixture({
+    failDeploy,
+    primaryRuntimeFails: true
+  })
+
+  const result = yield* collectIncidentSnapshot({
+    incidentId: failDeploy ? 'INC-2026-05-17-B' : 'INC-2026-05-17-A',
+    services: ['api', 'worker', 'billing']
+  }).pipe(
+    firstSuccess,
+    defaultAll,
+    bounded(6),
+    scope(CollectorScope),
+    scope(BundleScope),
+    fixture.handle,
+    logConsole,
+    defaultTime,
+    returnAll,
+  )
+
+  yield* log(`\n${label}`)
+  yield* log(JSON.stringify({ result: printableResult(result), state: fixture.state() }, null, 2))
+})
+
+const printableResult = (result: unknown): unknown =>
+  result instanceof Error
+    ? {
+      error: result.message,
+      cause: result.cause
+    }
+    : result
+
+await fx(function* () {
+  yield* runSnapshot('successful snapshot', false)
+  yield* runSnapshot('failing collector cancels siblings', true)
+}).pipe(
+  defaultConsole,
+  runPromise
+).catch(async error => {
+  await consoleError(error).pipe(defaultConsole, runPromise)
+  process.exitCode = 1
+})

--- a/examples/incident-collector/cli.ts
+++ b/examples/incident-collector/cli.ts
@@ -22,14 +22,14 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     incidentId: failDeploy ? 'INC-2026-05-17-B' : 'INC-2026-05-17-A',
     services: ['api', 'worker', 'billing']
   }).pipe(
-    firstSuccess,
-    defaultAll,
-    bounded(6),
     scope(CollectorScope),
-    scope(BundleScope),
     fixture.handle,
     logConsole,
     defaultTime,
+    firstSuccess,
+    defaultAll,
+    bounded(6),
+    scope(BundleScope),
     returnAll,
   )
 

--- a/examples/incident-collector/domain.test.ts
+++ b/examples/incident-collector/domain.test.ts
@@ -1,0 +1,158 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { bounded, defaultAll, firstSuccess } from '../../src/Concurrent.js'
+import { returnAll } from '../../src/Fail.js'
+import { runPromise, type Fx } from '../../src/Fx.js'
+import type { HandlerCapture } from '../../src/HandlerCapture.js'
+import type { Interrupt } from '../../src/Interrupt.js'
+import { collect } from '../../src/Log.js'
+import { scope } from '../../src/Scope.js'
+import { withClock, VirtualClock } from '../../src/Time.js'
+import type { Async } from '../../src/Async.js'
+import {
+  BundleScope,
+  CollectorScope,
+  collectIncidentSnapshot,
+  createIncidentCollectorFixture,
+  type IncidentCollectorError,
+  type SnapshotSummary
+} from './domain.js'
+
+describe('incident collector example', () => {
+  it('writes snapshot entries and a manifest when collectors succeed', async () => {
+    const fixture = createIncidentCollectorFixture({ primaryRuntimeFails: true })
+    const result = await runSnapshot(fixture)
+
+    assertSummary(result)
+    assert.equal(result.incidentId, 'INC-1')
+    assert.equal(result.runtimeSource, 'replica')
+    assert.deepEqual(result.entries, [
+      'logs:api',
+      'logs:worker',
+      'logs:billing',
+      'metrics',
+      'deploy:2026.05.17.1',
+      'runtime:replica'
+    ])
+
+    const [bundle] = fixture.state().bundles
+    assert.equal(bundle?.exit, 'success')
+    assert.deepEqual(bundle?.entries.map(entry => entry.type), [
+      'deploy',
+      'service-log',
+      'service-log',
+      'metrics',
+      'runtime',
+      'service-log',
+      'manifest'
+    ])
+  })
+
+  it('cancels sibling collectors and closes the bundle when a required collector fails', async () => {
+    const fixture = createIncidentCollectorFixture({
+      failDeploy: true,
+      slowLogMs: 500
+    })
+    const result = await runSnapshot(fixture)
+    const state = fixture.state()
+
+    assertErrorCause(result, {
+      tag: 'CollectorUnavailable',
+      collector: 'deploy',
+      reason: 'deploy API unavailable'
+    })
+    assert.equal(state.bundles[0]?.exit, 'failure')
+    assert.ok(!state.events.includes('read-log:done:api'))
+    assert.ok(!state.events.includes('read-log:done:billing'))
+    assert.ok(!state.events.includes('write:manifest'))
+    assert.ok(state.events.some(event => event.startsWith('collector:deploy:')))
+  })
+
+  it('uses the first successful runtime source when the primary source fails', async () => {
+    const fixture = createIncidentCollectorFixture({ primaryRuntimeFails: true })
+    const result = await runSnapshot(fixture)
+    const state = fixture.state()
+
+    assertSummary(result)
+    assert.equal(result.runtimeSource, 'replica')
+    assert.ok(state.events.includes('runtime:primary'))
+    assert.ok(state.events.includes('runtime:replica'))
+  })
+
+  it('records named scope finalization exits for collectors and bundle resources', async () => {
+    const fixture = createIncidentCollectorFixture()
+    await runSnapshot(fixture)
+
+    const events = fixture.state().events
+    assert.ok(events.includes('bundle:INC-1:success'))
+    assert.ok(events.includes('collector:logs:success'))
+    assert.ok(events.includes('collector:metrics:success'))
+    assert.ok(events.includes('collector:deploy:success'))
+    assert.ok(events.includes('collector:runtime:success'))
+  })
+
+  it('keeps domain effects visible until handlers remove them', () => {
+    const program = collectIncidentSnapshot({
+      incidentId: 'INC-types',
+      services: ['api']
+    })
+    // @ts-expect-error the raw domain program still requires incident collector effects.
+    const unhandled: Fx<never, SnapshotSummary> = program
+    void unhandled
+
+    const fixture = createIncidentCollectorFixture()
+    const handled = program.pipe(
+      firstSuccess,
+      defaultAll,
+      bounded(6),
+      scope(CollectorScope),
+      scope(BundleScope),
+      fixture.handle,
+      withClock(new VirtualClock(0)),
+      collect,
+      returnAll
+    )
+
+    const runnable: Fx<Async | HandlerCapture<string> | Interrupt, unknown> = handled
+    void runnable
+  })
+})
+
+const runSnapshot = async (
+  fixture: ReturnType<typeof createIncidentCollectorFixture>,
+  clock = new VirtualClock(Date.parse('2026-05-17T00:00:00.000Z'))
+): Promise<SnapshotSummary | IncidentCollectorError | AggregateError | Error> => {
+  const running = collectIncidentSnapshot({
+    incidentId: 'INC-1',
+    services: ['api', 'worker', 'billing']
+  }).pipe(
+    firstSuccess,
+    defaultAll,
+    bounded(6),
+    scope(CollectorScope),
+    scope(BundleScope),
+    fixture.handle,
+    withClock(clock),
+    collect,
+    returnAll,
+    runPromise
+  )
+
+  await clock.waitAll()
+  const result = await running
+  return (Array.isArray(result) ? result[0] : result) as SnapshotSummary | IncidentCollectorError | AggregateError | Error
+}
+
+const assertSummary: (value: SnapshotSummary | IncidentCollectorError | AggregateError | Error) => asserts value is SnapshotSummary =
+  (value): asserts value is SnapshotSummary => {
+    assert.equal(typeof value, 'object')
+    assert.notEqual(value, null)
+    assert.ok(!('tag' in value))
+    assert.ok(!(value instanceof AggregateError))
+    assert.ok(!(value instanceof Error))
+  }
+
+const assertErrorCause = (value: unknown, cause: IncidentCollectorError): void => {
+  assert.ok(value instanceof Error)
+  assert.deepEqual(value.cause, cause)
+}

--- a/examples/incident-collector/domain.test.ts
+++ b/examples/incident-collector/domain.test.ts
@@ -95,6 +95,18 @@ describe('incident collector example', () => {
     assert.ok(events.includes('collector:runtime:success'))
   })
 
+  it('records exit on each opened bundle when incident ids repeat', async () => {
+    const fixture = createIncidentCollectorFixture()
+    await runSnapshot(fixture)
+    await runSnapshot(fixture)
+
+    const bundles = fixture.state().bundles
+    assert.deepEqual(bundles.map(bundle => [bundle.id, bundle.incidentId, bundle.exit]), [
+      ['snapshot-1', 'INC-1', 'success'],
+      ['snapshot-2', 'INC-1', 'success']
+    ])
+  })
+
   it('keeps domain effects visible until handlers remove them', () => {
     const program = collectIncidentSnapshot({
       incidentId: 'INC-types',

--- a/examples/incident-collector/domain.test.ts
+++ b/examples/incident-collector/domain.test.ts
@@ -48,7 +48,7 @@ describe('incident collector example', () => {
     ])
   })
 
-  it('interrupts collectors but fails the bundle when a required collector fails', async () => {
+  it('fails the collector that caused cancellation and interrupts sibling collectors', async () => {
     const fixture = createIncidentCollectorFixture({
       failDeploy: true,
       slowLogMs: 500
@@ -67,7 +67,7 @@ describe('incident collector example', () => {
     assert.ok(!state.events.includes('write:manifest'))
     assert.ok(state.events.includes('collector:logs:interrupted'))
     assert.ok(state.events.includes('collector:metrics:interrupted'))
-    assert.ok(state.events.includes('collector:deploy:interrupted'))
+    assert.ok(state.events.includes('collector:deploy:failure'))
     assert.ok(state.events.includes('collector:runtime:interrupted'))
     assert.ok(state.events.includes('bundle:INC-1:failure'))
   })
@@ -118,8 +118,8 @@ describe('incident collector example', () => {
 
     const fixture = createIncidentCollectorFixture()
     const handled = program.pipe(
-      scope(CollectorScope),
       fixture.handle,
+      scope(CollectorScope),
       withClock(new VirtualClock(0)),
       collect,
       firstSuccess,
@@ -142,8 +142,8 @@ const runSnapshot = async (
     incidentId: 'INC-1',
     services: ['api', 'worker', 'billing']
   }).pipe(
-    scope(CollectorScope),
     fixture.handle,
+    scope(CollectorScope),
     withClock(clock),
     collect,
     firstSuccess,

--- a/examples/incident-collector/domain.test.ts
+++ b/examples/incident-collector/domain.test.ts
@@ -48,7 +48,7 @@ describe('incident collector example', () => {
     ])
   })
 
-  it('cancels sibling collectors and closes the bundle when a required collector fails', async () => {
+  it('interrupts collectors but fails the bundle when a required collector fails', async () => {
     const fixture = createIncidentCollectorFixture({
       failDeploy: true,
       slowLogMs: 500
@@ -65,7 +65,11 @@ describe('incident collector example', () => {
     assert.ok(!state.events.includes('read-log:done:api'))
     assert.ok(!state.events.includes('read-log:done:billing'))
     assert.ok(!state.events.includes('write:manifest'))
-    assert.ok(state.events.some(event => event.startsWith('collector:deploy:')))
+    assert.ok(state.events.includes('collector:logs:interrupted'))
+    assert.ok(state.events.includes('collector:metrics:interrupted'))
+    assert.ok(state.events.includes('collector:deploy:interrupted'))
+    assert.ok(state.events.includes('collector:runtime:interrupted'))
+    assert.ok(state.events.includes('bundle:INC-1:failure'))
   })
 
   it('uses the first successful runtime source when the primary source fails', async () => {

--- a/examples/incident-collector/domain.test.ts
+++ b/examples/incident-collector/domain.test.ts
@@ -102,14 +102,14 @@ describe('incident collector example', () => {
 
     const fixture = createIncidentCollectorFixture()
     const handled = program.pipe(
-      firstSuccess,
-      defaultAll,
-      bounded(6),
       scope(CollectorScope),
-      scope(BundleScope),
       fixture.handle,
       withClock(new VirtualClock(0)),
       collect,
+      firstSuccess,
+      defaultAll,
+      bounded(6),
+      scope(BundleScope),
       returnAll
     )
 
@@ -126,14 +126,14 @@ const runSnapshot = async (
     incidentId: 'INC-1',
     services: ['api', 'worker', 'billing']
   }).pipe(
-    firstSuccess,
-    defaultAll,
-    bounded(6),
     scope(CollectorScope),
-    scope(BundleScope),
     fixture.handle,
     withClock(clock),
     collect,
+    firstSuccess,
+    defaultAll,
+    bounded(6),
+    scope(BundleScope),
     returnAll,
     runPromise
   )

--- a/examples/incident-collector/domain.ts
+++ b/examples/incident-collector/domain.ts
@@ -1,0 +1,332 @@
+import { all, race, type All, type Race } from '../../src/Concurrent.js'
+import { Effect } from '../../src/Effect.js'
+import { fail, type Fail } from '../../src/Fail.js'
+import { fx, ok, type Fx } from '../../src/Fx.js'
+import { usingExit, usingManaged, managed, type Finally, type Managed } from '../../src/Finalization.js'
+import { handle } from '../../src/Handler.js'
+import { info, type Log } from '../../src/Log.js'
+import { sleep, type Time } from '../../src/Time.js'
+import type { HandlerCapture } from '../../src/HandlerCapture.js'
+import type { Interrupt } from '../../src/Interrupt.js'
+
+export const SnapshotScope = 'examples/incident-collector/Snapshot' as const
+export const BundleScope = 'examples/incident-collector/Bundle' as const
+export const CollectorScope = 'examples/incident-collector/Collector' as const
+
+export type IncidentId = string
+export type ServiceName = 'api' | 'worker' | 'billing'
+export type CollectorName = 'logs' | 'metrics' | 'deploy' | 'runtime'
+
+export interface SnapshotRequest {
+  readonly incidentId: IncidentId
+  readonly services: readonly ServiceName[]
+}
+
+export interface SnapshotSummary {
+  readonly incidentId: IncidentId
+  readonly bundleId: string
+  readonly entries: readonly string[]
+  readonly runtimeSource: string
+}
+
+export interface Bundle {
+  readonly id: string
+}
+
+export interface ServiceLog {
+  readonly service: ServiceName
+  readonly lines: readonly string[]
+}
+
+export interface Metrics {
+  readonly checks: readonly string[]
+}
+
+export interface DeployContext {
+  readonly version: string
+  readonly deployedBy: string
+}
+
+export interface RuntimeStatus {
+  readonly source: string
+  readonly status: string
+}
+
+export type BundleEntry =
+  | { readonly type: 'service-log'; readonly service: ServiceName; readonly lines: readonly string[] }
+  | { readonly type: 'metrics'; readonly checks: readonly string[] }
+  | { readonly type: 'deploy'; readonly version: string; readonly deployedBy: string }
+  | { readonly type: 'runtime'; readonly source: string; readonly status: string }
+  | { readonly type: 'manifest'; readonly incidentId: IncidentId; readonly entries: readonly string[] }
+
+export type IncidentCollectorError =
+  | { readonly tag: 'CollectorUnavailable'; readonly collector: CollectorName; readonly reason: string }
+  | { readonly tag: 'ServiceLogUnavailable'; readonly service: ServiceName; readonly reason: string }
+
+export type IncidentCollectorEffects =
+  | OpenBundle
+  | StartCollector
+  | WriteBundleEntry
+  | ReadServiceLog
+  | FetchMetrics
+  | FetchDeployContext
+  | FetchRuntimeStatus
+  | Time
+  | Log
+  | Finally<typeof BundleScope>
+  | Finally<typeof CollectorScope>
+  | Interrupt
+  | Fail<IncidentCollectorError>
+
+/**
+ * Request a managed bundle where snapshot artifacts can be written.
+ */
+export class OpenBundle extends Effect('example/IncidentCollector/OpenBundle')<IncidentId, Managed<Bundle>> { }
+
+/**
+ * Request a managed collector session for observable collector lifetime.
+ */
+export class StartCollector extends Effect('example/IncidentCollector/StartCollector')<CollectorName, Managed<CollectorName>> { }
+
+/**
+ * Request that an artifact be written to the active snapshot bundle.
+ */
+export class WriteBundleEntry extends Effect('example/IncidentCollector/WriteBundleEntry')<{
+  readonly bundle: Bundle
+  readonly entry: BundleEntry
+}, void> { }
+
+/**
+ * Request logs for one service.
+ */
+export class ReadServiceLog extends Effect('example/IncidentCollector/ReadServiceLog')<ServiceName, ServiceLog> { }
+
+/**
+ * Request current service health metrics.
+ */
+export class FetchMetrics extends Effect('example/IncidentCollector/FetchMetrics')<IncidentId, Metrics> { }
+
+/**
+ * Request deploy context for the incident.
+ */
+export class FetchDeployContext extends Effect('example/IncidentCollector/FetchDeployContext')<IncidentId, DeployContext> { }
+
+/**
+ * Request runtime status from a named source.
+ */
+export class FetchRuntimeStatus extends Effect('example/IncidentCollector/FetchRuntimeStatus')<string, RuntimeStatus> { }
+
+export const openBundle = (incidentId: IncidentId) => new OpenBundle(incidentId)
+export const startCollector = (collector: CollectorName) => new StartCollector(collector)
+export const writeBundleEntry = (bundle: Bundle, entry: BundleEntry) => new WriteBundleEntry({ bundle, entry })
+export const readServiceLog = (service: ServiceName) => new ReadServiceLog(service)
+export const fetchMetrics = (incidentId: IncidentId) => new FetchMetrics(incidentId)
+export const fetchDeployContext = (incidentId: IncidentId) => new FetchDeployContext(incidentId)
+export const fetchRuntimeStatus = (source: string) => new FetchRuntimeStatus(source)
+
+export const collectIncidentSnapshot = (
+  request: SnapshotRequest
+): Fx<IncidentCollectorEffects | All<any> | Race<any> | HandlerCapture<'fx/Concurrent/All'> | HandlerCapture<'fx/Concurrent/Race'> | Interrupt, SnapshotSummary> => fx(function* () {
+  const bundle = yield* usingManaged(BundleScope, openBundle(request.incidentId))
+  yield* info('snapshot started', { incidentId: request.incidentId, bundle: bundle.id })
+
+  const [logs, _metrics, deploy, runtime] = yield* all([
+    collectServiceLogs(bundle, request.services),
+    collectMetrics(bundle, request.incidentId),
+    collectDeploy(bundle, request.incidentId),
+    collectRuntime(bundle)
+  ])
+
+  const entries = [
+    ...logs.map(log => `logs:${log.service}`),
+    'metrics',
+    `deploy:${deploy.version}`,
+    `runtime:${runtime.source}`
+  ]
+
+  yield* writeBundleEntry(bundle, {
+    type: 'manifest',
+    incidentId: request.incidentId,
+    entries
+  })
+  yield* info('snapshot completed', { incidentId: request.incidentId, bundle: bundle.id })
+
+  return {
+    incidentId: request.incidentId,
+    bundleId: bundle.id,
+    entries,
+    runtimeSource: runtime.source
+  }
+})
+
+export interface FixtureState {
+  readonly bundles: readonly BundleRecord[]
+  readonly events: readonly string[]
+}
+
+export interface BundleRecord {
+  readonly id: string
+  readonly incidentId: IncidentId
+  readonly entries: readonly BundleEntry[]
+  readonly exit?: string
+}
+
+export interface FixtureOptions {
+  readonly failDeploy?: boolean
+  readonly primaryRuntimeFails?: boolean
+  readonly slowLogMs?: number
+}
+
+export const createIncidentCollectorFixture = (options: FixtureOptions = {}) => {
+  const bundles = [] as MutableBundleRecord[]
+  const events = [] as string[]
+  const slowLogMs = options.slowLogMs ?? 200
+
+  const handleFixture = <E, A>(program: Fx<E, A>) => program.pipe(
+    handle(OpenBundle, effect => ok(managed(
+      openBundleRecord(bundles, effect.arg),
+      exit => fx(function* () {
+        const record = bundles.find(bundle => bundle.incidentId === effect.arg)
+        if (record !== undefined) record.exit = exit.type
+        events.push(`bundle:${effect.arg}:${exit.type}`)
+      })
+    ))),
+    handle(StartCollector, effect => ok(managed(
+      effect.arg,
+      exit => fx(function* () {
+        events.push(`collector:${effect.arg}:${exit.type}`)
+      })
+    ))),
+    handle(WriteBundleEntry, effect => {
+      const record = bundles.find(bundle => bundle.id === effect.arg.bundle.id)
+      if (record !== undefined) record.entries.push(effect.arg.entry)
+      events.push(`write:${effect.arg.entry.type}`)
+      return ok(undefined)
+    }),
+    handle(ReadServiceLog, effect => fx(function* () {
+      events.push(`read-log:start:${effect.arg}`)
+      yield* sleep(effect.arg === 'billing' ? slowLogMs : 40)
+      events.push(`read-log:done:${effect.arg}`)
+      return {
+        service: effect.arg,
+        lines: [`${effect.arg}: request latency normal`, `${effect.arg}: no recent errors`]
+      }
+    })),
+    handle(FetchMetrics, effect => fx(function* () {
+      yield* sleep(60)
+      events.push(`metrics:${effect.arg}`)
+      return { checks: ['http-5xx-rate:normal', 'queue-depth:normal'] }
+    })),
+    handle(FetchDeployContext, effect => fx(function* () {
+      yield* sleep(30)
+      events.push(`deploy:${effect.arg}`)
+      if (options.failDeploy === true) {
+        return yield* fail({
+          tag: 'CollectorUnavailable',
+          collector: 'deploy',
+          reason: 'deploy API unavailable'
+        } satisfies IncidentCollectorError)
+      }
+      return { version: '2026.05.17.1', deployedBy: 'release automation' }
+    })),
+    handle(FetchRuntimeStatus, effect => fx(function* () {
+      const primary = effect.arg === 'primary'
+      yield* sleep(primary ? 20 : 80)
+      events.push(`runtime:${effect.arg}`)
+      if (primary && options.primaryRuntimeFails === true) {
+        return yield* fail({
+          tag: 'CollectorUnavailable',
+          collector: 'runtime',
+          reason: 'primary status endpoint unavailable'
+        } satisfies IncidentCollectorError)
+      }
+      return { source: effect.arg, status: 'healthy' }
+    }))
+  )
+
+  return {
+    handle: handleFixture,
+    state: (): FixtureState => ({
+      bundles: bundles.map(({ entries, ...bundle }) => ({
+        ...bundle,
+        entries: [...entries]
+      })),
+      events: [...events]
+    })
+  }
+}
+
+const collectServiceLogs = (bundle: Bundle, services: readonly ServiceName[]) => withCollector('logs', fx(function* () {
+  const logs = yield* all(services.map(service => collectOneServiceLog(bundle, service)))
+  return logs
+}))
+
+const collectOneServiceLog = (bundle: Bundle, service: ServiceName) => fx(function* () {
+  const log = yield* readServiceLog(service)
+  yield* writeBundleEntry(bundle, {
+    type: 'service-log',
+    service: log.service,
+    lines: log.lines
+  })
+  return log
+})
+
+const collectMetrics = (bundle: Bundle, incidentId: IncidentId) => withCollector('metrics', fx(function* () {
+  const metrics = yield* fetchMetrics(incidentId)
+  yield* writeBundleEntry(bundle, {
+    type: 'metrics',
+    checks: metrics.checks
+  })
+  return metrics
+}))
+
+const collectDeploy = (bundle: Bundle, incidentId: IncidentId) => withCollector('deploy', fx(function* () {
+  const deploy = yield* fetchDeployContext(incidentId)
+  yield* writeBundleEntry(bundle, {
+    type: 'deploy',
+    version: deploy.version,
+    deployedBy: deploy.deployedBy
+  })
+  return deploy
+}))
+
+const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function* () {
+  const runtime = yield* race([
+    fetchRuntimeStatus('primary'),
+    fetchRuntimeStatus('replica')
+  ])
+  yield* writeBundleEntry(bundle, {
+    type: 'runtime',
+    source: runtime.source,
+    status: runtime.status
+  })
+  return runtime
+}))
+
+const withCollector = <E, A>(collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<typeof CollectorScope> | Interrupt, A> => fx(function* () {
+  const name = yield* usingManaged(CollectorScope, startCollector(collector))
+  yield* usingExit(
+    CollectorScope,
+    ok(name),
+    (name, exit) => info('collector finalized', { name, exit: exit.type })
+  )
+  yield* info('collector started', { name })
+  return yield* program
+})
+
+interface MutableBundleRecord {
+  readonly id: string
+  readonly incidentId: IncidentId
+  readonly entries: BundleEntry[]
+  exit?: string
+}
+
+const openBundleRecord = (bundles: MutableBundleRecord[], incidentId: IncidentId): Bundle => {
+  const record = {
+    id: `snapshot-${bundles.length + 1}`,
+    incidentId,
+    entries: []
+  } satisfies MutableBundleRecord
+  bundles.push(record)
+  return { id: record.id }
+}

--- a/examples/incident-collector/domain.ts
+++ b/examples/incident-collector/domain.ts
@@ -9,7 +9,6 @@ import { sleep, type Time } from '../../src/Time.js'
 import type { HandlerCapture } from '../../src/HandlerCapture.js'
 import type { Interrupt } from '../../src/Interrupt.js'
 
-export const SnapshotScope = 'examples/incident-collector/Snapshot' as const
 export const BundleScope = 'examples/incident-collector/Bundle' as const
 export const CollectorScope = 'examples/incident-collector/Collector' as const
 
@@ -60,8 +59,7 @@ export type BundleEntry =
   | { readonly type: 'manifest'; readonly incidentId: IncidentId; readonly entries: readonly string[] }
 
 export type IncidentCollectorError =
-  | { readonly tag: 'CollectorUnavailable'; readonly collector: CollectorName; readonly reason: string }
-  | { readonly tag: 'ServiceLogUnavailable'; readonly service: ServiceName; readonly reason: string }
+  { readonly tag: 'CollectorUnavailable'; readonly collector: CollectorName; readonly reason: string }
 
 export type IncidentCollectorEffects =
   | OpenBundle

--- a/examples/incident-collector/domain.ts
+++ b/examples/incident-collector/domain.ts
@@ -181,14 +181,16 @@ export const createIncidentCollectorFixture = (options: FixtureOptions = {}) => 
   const slowLogMs = options.slowLogMs ?? 200
 
   const handleFixture = <E, A>(program: Fx<E, A>) => program.pipe(
-    handle(OpenBundle, effect => ok(managed(
-      openBundleRecord(bundles, effect.arg),
-      exit => fx(function* () {
-        const record = bundles.find(bundle => bundle.incidentId === effect.arg)
-        if (record !== undefined) record.exit = exit.type
-        events.push(`bundle:${effect.arg}:${exit.type}`)
-      })
-    ))),
+    handle(OpenBundle, effect => {
+      const record = openBundleRecord(bundles, effect.arg)
+      return ok(managed(
+        { id: record.id } satisfies Bundle,
+        exit => fx(function* () {
+          record.exit = exit.type
+          events.push(`bundle:${effect.arg}:${exit.type}`)
+        })
+      ))
+    }),
     handle(StartCollector, effect => ok(managed(
       effect.arg,
       exit => fx(function* () {
@@ -319,12 +321,12 @@ interface MutableBundleRecord {
   exit?: string
 }
 
-const openBundleRecord = (bundles: MutableBundleRecord[], incidentId: IncidentId): Bundle => {
+const openBundleRecord = (bundles: MutableBundleRecord[], incidentId: IncidentId): MutableBundleRecord => {
   const record = {
     id: `snapshot-${bundles.length + 1}`,
     incidentId,
     entries: []
   } satisfies MutableBundleRecord
   bundles.push(record)
-  return { id: record.id }
+  return record
 }


### PR DESCRIPTION
## Summary

Adds an incident collector example that demonstrates structured concurrency, resource management and finalization, and named scopes.

The example includes a domain module with local effects and fixture handlers, a runnable CLI demo, and focused tests covering success, fail-fast cancellation, first-success racing, finalizer exits, and effect typing.

## Validation

- node --import tsx examples/incident-collector/cli.ts
- node --import tsx --test examples/incident-collector/domain.test.ts
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm test
- corepack pnpm build