### PR TITLE
[codex] Add tool agent example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ features.
 | --- | --- | --- | --- |
 | `advanced/bookmarks` | A fuller app with domain effects, HTTP, CLI/browser clients, persistence handlers, and tests. | Readers studying how larger Fx applications can be organized. | Server and browser app: `node --import tsx examples/advanced/bookmarks/server.ts`, then open `http://127.0.0.1:3000/`. CLI: with the server running, use `node --import tsx examples/advanced/bookmarks/cli.ts add https://example.com --tag demo` and `node --import tsx examples/advanced/bookmarks/cli.ts list`. |
 | `advanced/incident-collector` | Structured concurrency, named scopes, resource finalization, cancellation, fixture handlers, and tests. | Readers studying a realistic concurrent workflow without HTTP/browser scaffolding. | `node --import tsx examples/advanced/incident-collector/cli.ts` |
+| `advanced/tool-agent` | Tool-planning workflow with model effects, parallel tool calls, sandbox policy handlers, fixture handlers, and optional OpenAI model integration. | Readers studying agent-like workflows built from explicit effects and handlers. | `node --import tsx examples/advanced/tool-agent/cli.ts` |
 | `advanced/diagnostics.ts` | Trace capture policy, regional trace capture, source lookup, formatted diagnostics, and snapshots. | Readers debugging failures and tuning diagnostic detail. | `node --import tsx examples/advanced/diagnostics.ts` |
 
 Most examples import from local `src` paths so they can be run directly from

--- a/examples/advanced/tool-agent/cli.ts
+++ b/examples/advanced/tool-agent/cli.ts
@@ -1,0 +1,65 @@
+import { bounded, defaultAll } from '../../../src/Concurrent.js'
+import { defaultConsole, log } from '../../../src/Console.js'
+import { provide } from '../../../src/Env.js'
+import { returnAll } from '../../../src/Fail.js'
+import { fx, runPromise } from '../../../src/Fx.js'
+import { handleScoped } from '../../../src/Handler.js'
+import { w3cFetch } from '../../../src/HttpClient.js'
+import { console as logConsole } from '../../../src/Log.js'
+import { scope } from '../../../src/Scope.js'
+import { defaultTime } from '../../../src/Time.js'
+import { YieldFrom } from '../../../src/YieldFrom.js'
+import {
+  AgentEvents,
+  AgentSessionScope,
+  runAgent
+} from './domain.js'
+import { createToolAgentFixture, withFakeModel } from './fixture.js'
+import { withOpenAIModel, type OpenAIModelContext } from './openai.js'
+import { defaultToolSandboxPolicy, withToolSandbox } from './sandbox.js'
+
+const task = process.argv.slice(2).join(' ') || 'Review the package health and recommend next steps'
+const fixture = createToolAgentFixture()
+const logAgentEvents = handleScoped(YieldFrom<typeof AgentEvents>, AgentEvents, effect =>
+  log(`agent event: ${effect.arg}`)
+)
+
+const main = fx(function* ({ openAIApiKey }: OpenAIModelContext) {
+  const result = openAIApiKey === undefined
+    ? yield* runAgent(task).pipe(
+      withToolSandbox(defaultToolSandboxPolicy),
+      fixture.handleTools,
+      withFakeModel(),
+      logConsole,
+      defaultTime,
+      defaultAll,
+      bounded(4),
+      scope(AgentSessionScope),
+      logAgentEvents,
+      returnAll
+    )
+    : yield* runAgent(task).pipe(
+      withToolSandbox(defaultToolSandboxPolicy),
+      fixture.handleTools,
+      withOpenAIModel,
+      logConsole,
+      defaultTime,
+      defaultAll,
+      bounded(4),
+      scope(AgentSessionScope),
+      logAgentEvents,
+      w3cFetch(),
+      returnAll
+    )
+
+  yield* log(JSON.stringify(result, null, 2))
+})
+
+await main.pipe(
+  provide({
+    openAIApiKey: process.env.OPENAI_API_KEY,
+    openAIModel: process.env.OPENAI_MODEL ?? 'gpt-4.1-mini'
+  }),
+  defaultConsole,
+  runPromise
+)

--- a/examples/advanced/tool-agent/domain.test.ts
+++ b/examples/advanced/tool-agent/domain.test.ts
@@ -1,0 +1,213 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { bounded, defaultAll } from '../../../src/Concurrent.js'
+import { returnAll } from '../../../src/Fail.js'
+import { runPromise, type Fx } from '../../../src/Fx.js'
+import type { HandlerCapture } from '../../../src/HandlerCapture.js'
+import { collect } from '../../../src/Log.js'
+import { scope } from '../../../src/Scope.js'
+import { withClock, VirtualClock } from '../../../src/Time.js'
+import { collectFrom } from '../../../src/YieldFrom.js'
+import type { Async } from '../../../src/Async.js'
+import type { Interrupt } from '../../../src/Interrupt.js'
+import {
+  AgentEvents,
+  AgentSessionScope,
+  runAgent,
+  type AgentAnswer,
+  type AgentEvent,
+  type AgentError
+} from './domain.js'
+import { createToolAgentFixture, withFakeModel, type FakeModelOptions } from './fixture.js'
+import { defaultToolSandboxPolicy, withToolSandbox, type ToolSandboxPolicy } from './sandbox.js'
+
+describe('tool agent example', () => {
+  it('plans, runs sandboxed tools in parallel, and summarizes results', async () => {
+    const fixture = createToolAgentFixture()
+    const { result, events } = await runToolAgent(fixture)
+
+    assertAnswer(result)
+    assert.equal(result.sessionId, 'agent-session-1')
+    assert.deepEqual(result.results.map(result => result.tool), [
+      'readProjectSummary',
+      'searchExamples',
+      'listOpenQuestions'
+    ])
+    assert.match(result.answer, /Recommendation/)
+    assert.ok(events.includes('session:open:agent-session-1'))
+    assert.ok(events.includes('session:close:agent-session-1:success'))
+    assert.deepEqual(events.filter(event => event.startsWith('model:')), [
+      'model:plan',
+      'model:summarize'
+    ])
+  })
+
+  it('rewrites unsafe fetchUrl tools before they reach the tool handler', async () => {
+    const fixture = createToolAgentFixture()
+    const { result, events } = await runToolAgent(fixture)
+
+    assertAnswer(result)
+    assert.ok(events.some(event => event === 'tool:start:searchExamples:safe search for https://example.com/fx/examples'))
+    assert.ok(!events.some(event => event.startsWith('tool:start:fetchUrl:')))
+  })
+
+  it('validates rewritten tool calls before running them', async () => {
+    const fixture = createToolAgentFixture()
+    const policy: ToolSandboxPolicy = {
+      ...defaultToolSandboxPolicy,
+      rewrite: {
+        fetchUrl: call => ({
+          tool: 'shell',
+          input: `curl ${call.input}`
+        })
+      }
+    }
+
+    const { result, events } = await runToolAgent(fixture, {
+      plan: [
+        { tool: 'fetchUrl', input: 'https://example.com/fx/examples' }
+      ]
+    }, new VirtualClock(Date.parse('2026-05-18T00:00:00.000Z')), policy)
+
+    const error = agentErrorCause(result, 'ToolDenied')
+    assert.equal(error.tool, 'shell')
+    assert.ok(!events.some(event => event.startsWith('tool:start:shell:')))
+  })
+
+  it('denies original tool calls before rewriting them', async () => {
+    const fixture = createToolAgentFixture()
+    const policy: ToolSandboxPolicy = {
+      ...defaultToolSandboxPolicy,
+      deny: {
+        ...defaultToolSandboxPolicy.deny,
+        fetchUrl: 'external fetches are blocked'
+      }
+    }
+
+    const { result, events } = await runToolAgent(fixture, {
+      plan: [
+        { tool: 'fetchUrl', input: 'https://example.com/fx/examples' }
+      ]
+    }, new VirtualClock(Date.parse('2026-05-18T00:00:00.000Z')), policy)
+
+    const error = agentErrorCause(result, 'ToolDenied')
+    assert.equal(error.tool, 'fetchUrl')
+    assert.ok(!events.some(event => event.startsWith('tool:start:searchExamples:')))
+  })
+
+  it('denies shell tools with a recoverable policy failure', async () => {
+    const fixture = createToolAgentFixture()
+
+    const { result, events } = await runToolAgent(fixture, {
+      plan: [
+        { tool: 'readProjectSummary', input: 'package health' },
+        { tool: 'shell', input: 'cat package.json' }
+      ]
+    })
+
+    const error = agentErrorCause(result, 'ToolDenied')
+    assert.equal(error.tool, 'shell')
+    assert.ok(events.includes('session:close:agent-session-1:failure'))
+    assert.ok(!events.some(event => event.startsWith('tool:start:shell:')))
+  })
+
+  it('fails when a tool fails and interrupts slower sibling tool work', async () => {
+    const fixture = createToolAgentFixture({
+      failTool: 'searchExamples',
+      toolDelayMs: {
+        readProjectSummary: 500,
+        searchExamples: 20,
+        listOpenQuestions: 500
+      }
+    })
+
+    const { result, events } = await runToolAgent(fixture)
+
+    const error = agentErrorCause(result, 'ToolUnavailable')
+    assert.equal(error.tool, 'searchExamples')
+    assert.ok(events.includes('tool:start:readProjectSummary:package health'))
+    assert.ok(events.includes('tool:start:searchExamples:safe search for https://example.com/fx/examples'))
+    assert.ok(!events.some(event => event.startsWith('tool:done:readProjectSummary:')))
+    assert.ok(!events.some(event => event.startsWith('tool:done:listOpenQuestions:')))
+    assert.ok(events.includes('session:close:agent-session-1:failure'))
+  })
+
+  it('keeps domain effects visible until handlers remove them', () => {
+    const program = runAgent('type visibility')
+    // @ts-expect-error the raw agent program still requires tool agent effects.
+    const unhandled: Fx<never, AgentAnswer> = program
+    void unhandled
+
+    const fixture = createToolAgentFixture()
+    const handled = program.pipe(
+      withToolSandbox(defaultToolSandboxPolicy),
+      fixture.handleTools,
+      withFakeModel(),
+      withClock(new VirtualClock(0)),
+      collect,
+      defaultAll,
+      bounded(4),
+      scope(AgentSessionScope),
+      returnAll,
+      collectFrom(AgentEvents)
+    )
+
+    const runnable: Fx<Async | HandlerCapture<string> | Interrupt, unknown> = handled
+    void runnable
+  })
+})
+
+const runToolAgent = async (
+  fixture: ReturnType<typeof createToolAgentFixture>,
+  modelOptions: FakeModelOptions = {},
+  clock = new VirtualClock(Date.parse('2026-05-18T00:00:00.000Z')),
+  policy: ToolSandboxPolicy = defaultToolSandboxPolicy
+): Promise<RunResult> => {
+  const running = runAgent('Review the package health and recommend next steps').pipe(
+    withToolSandbox(policy),
+    fixture.handleTools,
+    withFakeModel(modelOptions),
+    withClock(clock),
+    collect,
+    defaultAll,
+    bounded(4),
+    scope(AgentSessionScope),
+    returnAll,
+    collectFrom(AgentEvents),
+    runPromise
+  )
+
+  await clock.waitAll()
+  const [valueOrLogged, events] = await running
+  const value = Array.isArray(valueOrLogged) ? valueOrLogged[0] : valueOrLogged
+  return { result: value, events }
+}
+
+interface RunResult {
+  readonly result: AgentAnswer | AgentError | AggregateError | Error
+  readonly events: readonly AgentEvent[]
+}
+
+const assertAnswer: (value: AgentAnswer | AgentError | AggregateError | Error) => asserts value is AgentAnswer =
+  (value): asserts value is AgentAnswer => {
+    assert.equal(typeof value, 'object')
+    assert.notEqual(value, null)
+    assert.ok(!('tag' in value))
+    assert.ok(!(value instanceof AggregateError))
+    assert.ok(!(value instanceof Error))
+  }
+
+const agentErrorCause = (
+  value: AgentAnswer | AgentError | AggregateError | Error,
+  tag: AgentError['tag']
+): Extract<AgentError, { readonly tool: string }> => {
+  const error = isAgentError(value) ? value : value instanceof Error && isAgentError(value.cause) ? value.cause : undefined
+
+  if (error === undefined) assert.fail('expected an AgentError or Error with AgentError cause')
+  assert.equal(error.tag, tag)
+  assert.ok('tool' in error)
+  return error
+}
+
+const isAgentError = (value: unknown): value is AgentError =>
+  typeof value === 'object' && value !== null && 'tag' in value

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -1,0 +1,128 @@
+import { type All, all } from '../../../src/Concurrent.js'
+import { Effect } from '../../../src/Effect.js'
+import { fail, type Fail } from '../../../src/Fail.js'
+import { fx, type Fx } from '../../../src/Fx.js'
+import { usingManaged, type Finally, type Managed } from '../../../src/Finalization.js'
+import { info, type Log } from '../../../src/Log.js'
+import { brand } from '../../../src/Scope.js'
+import { type Yielding, type YieldFrom } from '../../../src/YieldFrom.js'
+import type { HandlerCapture } from '../../../src/HandlerCapture.js'
+import type { Interrupt } from '../../../src/Interrupt.js'
+import type { Time } from '../../../src/Time.js'
+
+export const AgentSessionScope = 'examples/advanced/tool-agent/AgentSession' as const
+export const AgentEvents = brand<Yielding<AgentEvent>>()('examples/advanced/tool-agent/AgentEvents')
+
+export type ToolName =
+  | 'readProjectSummary'
+  | 'searchExamples'
+  | 'listOpenQuestions'
+  | 'fetchUrl'
+  | 'shell'
+
+export interface ToolCall {
+  readonly tool: ToolName
+  readonly input: string
+}
+
+export interface ToolResult {
+  readonly tool: ToolName
+  readonly input: string
+  readonly content: string
+}
+
+export type ModelRequest =
+  | { readonly type: 'plan'; readonly task: string }
+  | {
+    readonly type: 'summarize'
+    readonly task: string
+    readonly results: readonly ToolResult[]
+  }
+
+export type ModelResponse =
+  | { readonly type: 'plan'; readonly toolCalls: readonly ToolCall[] }
+  | { readonly type: 'summary'; readonly answer: string }
+
+export interface AgentSession {
+  readonly id: string
+}
+
+export interface AgentAnswer {
+  readonly task: string
+  readonly sessionId: string
+  readonly toolCalls: readonly ToolCall[]
+  readonly results: readonly ToolResult[]
+  readonly answer: string
+}
+
+export type AgentEvent =
+  | `session:open:${string}`
+  | `session:close:${string}:${string}`
+  | `model:${ModelRequest['type']}`
+  | `tool:start:${ToolName}:${string}`
+  | `tool:done:${ToolName}:${string}`
+
+export type AgentError =
+  | { readonly tag: 'ToolDenied'; readonly tool: ToolName; readonly reason: string }
+  | { readonly tag: 'ToolUnavailable'; readonly tool: ToolName; readonly reason: string }
+  | { readonly tag: 'ModelError'; readonly reason: string; readonly cause?: unknown }
+
+export type ToolAgentEffects =
+  | AskModel
+  | RunTool
+  | StartAgentSession
+  | Log
+  | Time
+  | Finally<typeof AgentSessionScope, YieldFrom<typeof AgentEvents>>
+  | Interrupt
+  | Fail<AgentError>
+
+/**
+ * Request a model response without choosing a local fake or remote provider.
+ */
+export class AskModel extends Effect('example/ToolAgent/AskModel')<ModelRequest, ModelResponse> { }
+
+/**
+ * Request that a named tool call be executed.
+ */
+export class RunTool extends Effect('example/ToolAgent/RunTool')<ToolCall, ToolResult> { }
+
+/**
+ * Request a managed agent session for observable setup and cleanup.
+ */
+export class StartAgentSession extends Effect('example/ToolAgent/StartAgentSession')<
+  string,
+  Managed<AgentSession, YieldFrom<typeof AgentEvents>>
+> { }
+
+export const askModel = (request: ModelRequest) => new AskModel(request)
+export const runTool = (call: ToolCall) => new RunTool(call)
+export const startAgentSession = (task: string) => new StartAgentSession(task)
+
+export const runAgent = (
+  task: string
+): Fx<ToolAgentEffects | All<any> | HandlerCapture<'fx/Concurrent/All'>, AgentAnswer> => fx(function* () {
+  const session = yield* usingManaged(AgentSessionScope, startAgentSession(task))
+  yield* info('agent session started', { session: session.id, task })
+
+  const plan = yield* askModel({ type: 'plan', task })
+  if (plan.type !== 'plan') {
+    return yield* fail({ tag: 'ModelError', reason: 'model returned a summary when a plan was requested' })
+  }
+
+  const results = yield* all(plan.toolCalls.map(runTool))
+  const summary = yield* askModel({ type: 'summarize', task, results })
+  if (summary.type !== 'summary') {
+    return yield* fail({ tag: 'ModelError', reason: 'model returned a plan when a summary was requested' })
+  }
+
+  yield* info('agent session completed', { session: session.id, tools: results.map(result => result.tool) })
+
+  return {
+    task,
+    sessionId: session.id,
+    toolCalls: plan.toolCalls,
+    results,
+    answer: summary.answer
+  }
+})

--- a/examples/advanced/tool-agent/fixture.ts
+++ b/examples/advanced/tool-agent/fixture.ts
@@ -1,0 +1,121 @@
+import { fail } from '../../../src/Fail.js'
+import { fx, type Fx } from '../../../src/Fx.js'
+import { managed } from '../../../src/Finalization.js'
+import { handle } from '../../../src/Handler.js'
+import { sleep } from '../../../src/Time.js'
+import { yieldFrom } from '../../../src/YieldFrom.js'
+import {
+  AgentEvents,
+  AskModel,
+  RunTool,
+  StartAgentSession,
+  type AgentError,
+  type AgentSession,
+  type ModelRequest,
+  type ModelResponse,
+  type ToolCall,
+  type ToolName,
+  type ToolResult
+} from './domain.js'
+
+export const createToolAgentFixture = (options: FixtureOptions = {}) => {
+  let nextSessionId = 1
+  const toolDelayMs = options.toolDelayMs ?? {
+    readProjectSummary: 80,
+    searchExamples: 40,
+    listOpenQuestions: 120,
+    fetchUrl: 60,
+    shell: 10
+  }
+
+  const handleTools = <E, A>(program: Fx<E, A>) => program.pipe(
+    handle(StartAgentSession, () => fx(function* () {
+      const id = `agent-session-${nextSessionId}`
+      nextSessionId += 1
+      yield* yieldFrom(AgentEvents, `session:open:${id}`)
+      return managed(
+        { id } satisfies AgentSession,
+        exit => fx(function* () {
+          yield* yieldFrom(AgentEvents, `session:close:${id}:${exit.type}`)
+        })
+      )
+    })),
+    handle(RunTool, effect => fx(function* () {
+      yield* yieldFrom(AgentEvents, `tool:start:${effect.arg.tool}:${effect.arg.input}`)
+      yield* sleep(toolDelayMs[effect.arg.tool] ?? 30)
+
+      if (options.failTool === effect.arg.tool) {
+        return yield* fail({
+          tag: 'ToolUnavailable',
+          tool: effect.arg.tool,
+          reason: `${effect.arg.tool} is unavailable`
+        } satisfies AgentError)
+      }
+
+      yield* yieldFrom(AgentEvents, `tool:done:${effect.arg.tool}:${effect.arg.input}`)
+      return fakeToolResult(effect.arg)
+    }))
+  )
+
+  return {
+    handleTools
+  }
+}
+
+export interface FixtureOptions {
+  readonly failTool?: ToolName
+  readonly toolDelayMs?: Partial<Record<ToolName, number>>
+}
+
+export const withFakeModel = ({
+  plan = fallbackPlan
+}: FakeModelOptions = {}) =>
+  handle(AskModel, effect => fx(function* () {
+    yield* yieldFrom(AgentEvents, `model:${effect.arg.type}`)
+    return fakeModelResponse(effect.arg, plan)
+  }))
+
+export interface FakeModelOptions {
+  readonly plan?: readonly ToolCall[]
+}
+
+const fakeModelResponse = (
+  request: ModelRequest,
+  plan: readonly ToolCall[] = fallbackPlan
+): ModelResponse => {
+  if (request.type === 'plan') return { type: 'plan', toolCalls: plan }
+
+  const facts = request.results
+    .map(result => `${result.tool}: ${result.content}`)
+    .join('; ')
+
+  return {
+    type: 'summary',
+    answer: `Recommendation for "${request.task}": keep the package healthy by checking project metadata, example coverage, and open questions. Evidence: ${facts}.`
+  }
+}
+
+const fallbackPlan = [
+  { tool: 'readProjectSummary', input: 'package health' },
+  { tool: 'fetchUrl', input: 'https://example.com/fx/examples' },
+  { tool: 'listOpenQuestions', input: 'agent example follow-ups' }
+] satisfies readonly ToolCall[]
+
+const fakeToolResult = (call: ToolCall): ToolResult => {
+  switch (call.tool) {
+    case 'readProjectSummary':
+      return { ...call, content: 'package scripts include test, typecheck, build, and lint' }
+
+    case 'searchExamples':
+      return { ...call, content: `examples search matched advanced workflows for ${call.input}` }
+
+    case 'listOpenQuestions':
+      return { ...call, content: 'memory integration is a clear follow-up, not part of the first example' }
+
+    case 'fetchUrl':
+      return { ...call, content: `direct URL fetch skipped for ${call.input}` }
+
+    case 'shell':
+      return { ...call, content: `shell command was not executed: ${call.input}` }
+  }
+}

--- a/examples/advanced/tool-agent/openai.ts
+++ b/examples/advanced/tool-agent/openai.ts
@@ -1,0 +1,148 @@
+import { catchAll, failFrom, type Fail } from '../../../src/Fail.js'
+import { flatMap, fx, ok, type Fx } from '../../../src/Fx.js'
+import { handle } from '../../../src/Handler.js'
+import {
+  expectSuccess,
+  json,
+  request,
+  type JSONValue
+} from '../../../src/HttpClient.js'
+import {
+  AskModel,
+  type AgentError,
+  type ModelRequest,
+  type ModelResponse,
+  type ToolCall,
+  type ToolName
+} from './domain.js'
+
+export type OpenAIModelContext = {
+  readonly openAIApiKey?: string
+  readonly openAIModel: string
+}
+
+const askOpenAI = (effect: AskModel) => fx(function* ({
+  openAIApiKey,
+  openAIModel
+}: OpenAIModelContext) {
+  if (openAIApiKey === undefined) {
+    return yield* failFrom(effect, {
+      tag: 'ModelError',
+      reason: 'OPENAI_API_KEY is required for OpenAI model mode'
+    } satisfies AgentError)
+  }
+
+  return yield* request({
+    method: 'POST',
+    url: new URL('https://api.openai.com/v1/responses'),
+    headers: [
+      ['authorization', `Bearer ${openAIApiKey}`],
+      ['accept', 'application/json']
+    ],
+    body: {
+      type: 'json',
+      value: {
+        model: openAIModel,
+        input: openAIInput(effect.arg)
+      }
+    }
+  }).pipe(
+    flatMap(expectSuccess),
+    flatMap(json),
+    flatMap(body => parseOpenAIResponse(effect, body)),
+    catchAll(cause => failFrom(effect, isAgentError(cause)
+      ? cause
+      : { tag: 'ModelError', reason: 'OpenAI model request failed', cause }))
+  )
+})
+
+export const withOpenAIModel = handle(AskModel, askOpenAI)
+
+const parseOpenAIResponse = (
+  effect: AskModel,
+  body: JSONValue
+): Fx<Fail<AgentError>, ModelResponse> => {
+  const text = openAIOutputText(body)
+  if (text === undefined) {
+    return failFrom(effect, { tag: 'ModelError', reason: 'OpenAI response did not contain output text' })
+  }
+
+  if (effect.arg.type === 'plan') {
+    return ok({ type: 'plan', toolCalls: parseToolPlan(text) })
+  }
+
+  return ok({ type: 'summary', answer: text.trim() })
+}
+
+const openAIInput = (modelRequest: ModelRequest): string => {
+  if (modelRequest.type === 'plan') {
+    return [
+      'Plan tool calls for this task.',
+      'Return only JSON: {"toolCalls":[{"tool":"readProjectSummary|searchExamples|listOpenQuestions|fetchUrl","input":"..."}]}.',
+      'Use at most three calls. Prefer safe local tools.',
+      `Task: ${modelRequest.task}`
+    ].join('\n')
+  }
+
+  return [
+    'Summarize these tool results in one concise recommendation.',
+    `Task: ${modelRequest.task}`,
+    JSON.stringify(modelRequest.results)
+  ].join('\n')
+}
+
+const openAIOutputText = (body: JSONValue): string | undefined => {
+  if (!isRecord(body)) return undefined
+  if (typeof body.output_text === 'string') return body.output_text
+
+  const output = body.output
+  if (!Array.isArray(output)) return undefined
+
+  const text: string[] = []
+  for (const item of output) {
+    if (!isRecord(item) || !Array.isArray(item.content)) continue
+    for (const content of item.content) {
+      if (isRecord(content) && typeof content.text === 'string') text.push(content.text)
+    }
+  }
+
+  return text.length === 0 ? undefined : text.join('\n')
+}
+
+const parseToolPlan = (text: string): readonly ToolCall[] => {
+  try {
+    const parsed = JSON.parse(text) as unknown
+    if (!isRecord(parsed) || !Array.isArray(parsed.toolCalls)) return fallbackPlan
+
+    const calls = parsed.toolCalls.filter(isToolCall)
+    return calls.length === 0 ? fallbackPlan : calls.slice(0, 3)
+  } catch {
+    return fallbackPlan
+  }
+}
+
+const fallbackPlan = [
+  { tool: 'readProjectSummary', input: 'package health' },
+  { tool: 'fetchUrl', input: 'https://example.com/fx/examples' },
+  { tool: 'listOpenQuestions', input: 'agent example follow-ups' }
+] satisfies readonly ToolCall[]
+
+const isToolCall = (value: unknown): value is ToolCall =>
+  isRecord(value)
+  && isToolName(value.tool)
+  && typeof value.input === 'string'
+
+const isToolName = (value: unknown): value is ToolName =>
+  value === 'readProjectSummary'
+  || value === 'searchExamples'
+  || value === 'listOpenQuestions'
+  || value === 'fetchUrl'
+  || value === 'shell'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const isAgentError = (value: unknown): value is AgentError =>
+  isRecord(value)
+  && typeof value.tag === 'string'
+  && (value.tag === 'ToolDenied' || value.tag === 'ToolUnavailable' || value.tag === 'ModelError')

--- a/examples/advanced/tool-agent/sandbox.ts
+++ b/examples/advanced/tool-agent/sandbox.ts
@@ -1,0 +1,53 @@
+import { fail, type Fail } from '../../../src/Fail.js'
+import { type Fx } from '../../../src/Fx.js'
+import { handle } from '../../../src/Handler.js'
+import {
+  runTool,
+  RunTool,
+  type AgentError,
+  type ToolCall,
+  type ToolName,
+  type ToolResult
+} from './domain.js'
+
+export interface ToolSandboxPolicy {
+  readonly allow: readonly ToolName[]
+  readonly deny?: Partial<Record<ToolName, string>>
+  readonly rewrite?: Partial<Record<ToolName, (call: ToolCall) => ToolCall>>
+}
+
+export const defaultToolSandboxPolicy = {
+  allow: ['readProjectSummary', 'searchExamples', 'listOpenQuestions'],
+  deny: {
+    shell: 'shell access is outside the agent sandbox'
+  },
+  rewrite: {
+    fetchUrl: call => ({
+      tool: 'searchExamples',
+      input: `safe search for ${call.input}`
+    })
+  }
+} satisfies ToolSandboxPolicy
+
+export const withToolSandbox = (policy: ToolSandboxPolicy) =>
+  <E, A>(program: Fx<E, A>) => program.pipe(
+    handle(RunTool, (effect): Fx<RunTool | Fail<AgentError>, ToolResult> => {
+      const original = effect.arg
+      const deniedOriginal = policy.deny?.[original.tool]
+      if (deniedOriginal !== undefined) {
+        return fail({ tag: 'ToolDenied', tool: original.tool, reason: deniedOriginal } satisfies AgentError)
+      }
+
+      const rewrite = policy.rewrite?.[original.tool]
+      const call = rewrite === undefined ? original : rewrite(original)
+
+      const deniedCall = policy.deny?.[call.tool]
+      if (deniedCall !== undefined) {
+        return fail({ tag: 'ToolDenied', tool: call.tool, reason: deniedCall } satisfies AgentError)
+      }
+
+      return policy.allow.includes(call.tool)
+        ? runTool(call)
+        : fail({ tag: 'ToolDenied', tool: call.tool, reason: 'tool is not allowlisted' } satisfies AgentError)
+    })
+  )


### PR DESCRIPTION
## Summary

Adds an advanced tool-using agent example that demonstrates explicit model/tool/session effects, sandbox policy handling, parallel tool calls, deterministic fixture handlers, and optional OpenAI model integration through the existing HttpClient/w3cFetch path.

Updates the examples README so readers can find the new advanced-tier example.

## Validation

- node --import tsx examples/advanced/tool-agent/cli.ts
- node --import tsx --test examples/advanced/tool-agent/domain.test.ts
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm lint

Note: lint exits cleanly with 3 pre-existing warnings outside this new example.