### PR TITLE
[codex] Preserve finalizer effect types

### DIFF
--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -72,7 +72,7 @@ export type IncidentCollectorEffects =
   | Time
   | Log
   | Finally<typeof BundleScope>
-  | Finally<typeof CollectorScope>
+  | Finally<typeof CollectorScope, Log>
   | Interrupt
   | Fail<IncidentCollectorError>
 
@@ -303,7 +303,7 @@ const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function*
   return runtime
 }))
 
-const withCollector = <E, A>(collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<typeof CollectorScope> | Interrupt, A> => fx(function* () {
+const withCollector = <E, A>(collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<typeof CollectorScope, Log> | Interrupt, A> => fx(function* () {
   const name = yield* usingManaged(CollectorScope, startCollector(collector))
   yield* usingExit(
     CollectorScope,

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -3,13 +3,96 @@ import { describe, it } from 'node:test'
 
 import { abort, Abort, orReturn } from './Abort.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { fx, ok, run } from './Fx.js'
-import { andFinally, andFinallyExit, managed, using, usingExit, usingManaged } from './Finalization.js'
+import { fx, ok, run, type Fx } from './Fx.js'
+import { andFinally, andFinallyExit, managed, using, usingExit, usingManaged, type Finally, type Managed } from './Finalization.js'
+import type { Interrupt } from './Interrupt.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, type Exit } from './Scope.js'
+import { brand, scope, type Exit } from './Scope.js'
+import { collectFrom, YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 describe('Finalization', () => {
   const TestScope = 'test/Finalization' as const
+  const CleanupEvents = brand<Yielding<'cleanup'>>()('test/Finalization/cleanup')
+
+  it('preserves finalizer effects in constructor types', () => {
+    const releaseFailure = new Error('release failed')
+    const finalizer = andFinally(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
+    const exitFinalizer = andFinallyExit(TestScope, () => fail(releaseFailure))
+
+    const _: typeof finalizer extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>>, void> ? true : false = true
+    const __: typeof exitFinalizer extends Fx<Finally<typeof TestScope, Fail<Error>>, void> ? true : false = true
+
+    assert.equal(typeof _, 'boolean')
+    assert.equal(typeof __, 'boolean')
+  })
+
+  it('preserves finalizer effects in resource helper types', () => {
+    const releaseFailure = new Error('release failed')
+    const resource = using(TestScope, ok('resource'), () => yieldFrom(CleanupEvents, 'cleanup'))
+    const exitResource = usingExit(TestScope, ok('resource'), () => fail(releaseFailure))
+    const managedResource = usingManaged(TestScope, ok(managed(
+      'resource',
+      () => yieldFrom(CleanupEvents, 'cleanup')
+    )))
+
+    const _: typeof resource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
+    const __: typeof exitResource extends Fx<Finally<typeof TestScope, Fail<Error>> | Interrupt, 'resource'> ? true : false = true
+    const ___: typeof managedResource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
+
+    assert.equal(typeof _, 'boolean')
+    assert.equal(typeof __, 'boolean')
+    assert.equal(typeof ___, 'boolean')
+  })
+
+  it('exposes non-failure finalizer effects after scope', () => {
+    const scoped = fx(function* () {
+      yield* andFinally(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
+      return 'done'
+    }).pipe(scope(TestScope))
+
+    const _: typeof scoped extends Fx<YieldFrom<typeof CleanupEvents> | Fail<AggregateError>, 'done'> ? true : false = true
+
+    const result = run(scoped.pipe(
+      collectFrom(CleanupEvents),
+      returnFail
+    ))
+
+    assert.equal(typeof _, 'boolean')
+    assert.deepEqual(result, ['done', ['cleanup']])
+  })
+
+  it('exposes cleanup failures as AggregateError after scope', () => {
+    const releaseFailure = new Error('release failed')
+    const scoped = fx(function* () {
+      yield* andFinally(TestScope, fail(releaseFailure))
+      return 'done'
+    }).pipe(scope(TestScope))
+
+    const _: typeof scoped extends Fx<Fail<AggregateError>, 'done'> ? true : false = true
+
+    const result = run(scoped.pipe(returnFail))
+
+    assert.equal(typeof _, 'boolean')
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.deepEqual(result.arg.errors, [releaseFailure])
+  })
+
+  it('leaves finalizers from a different scope visible after scope', () => {
+    const OtherScope = 'test/Finalization/other' as const
+    const scoped = fx(function* () {
+      yield* andFinally(OtherScope, yieldFrom(CleanupEvents, 'cleanup'))
+      return 'done'
+    }).pipe(scope(TestScope))
+
+    const _: typeof scoped extends Fx<Finally<typeof OtherScope, YieldFrom<typeof CleanupEvents>>, 'done'> ? true : false = true
+    const next = scoped[Symbol.iterator]().next()
+
+    assert.equal(typeof _, 'boolean')
+    assert.equal(next.done, false)
+    assert.equal((next.value as { readonly scope?: unknown }).scope, OtherScope)
+  })
+
   it('releases finalizers in reverse registration order after success', () => {
     const released = [] as string[]
 
@@ -268,7 +351,7 @@ describe('Finalization', () => {
     const initFailure = new Error('init failed')
 
     const result = run(fx(function* () {
-      return yield* usingManaged(TestScope, fail(initFailure))
+      return yield* usingManaged(TestScope, fail(initFailure) as Fx<Fail<Error>, Managed<string>>)
     }).pipe(scope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -14,16 +14,16 @@ import type { Exit } from './Scope.js'
  */
 export interface Managed<A, E = never> {
   readonly value: A
-  readonly finalizer: (exit: Exit) => Fx<E, void>
+  readonly finalizer: Finalizer<E>
 }
 
-export type Finalizer = (exit: Exit) => Fx<unknown, void>
+export type Finalizer<E = unknown> = (exit: Exit) => Fx<E, void>
 
 /**
  * Request that a cleanup operation be run when the named scope exits.
  */
-export class Finally<const Scope extends string> extends ScopedEffect('fx/Finally')<Scope, {
-  readonly finalizer: Finalizer
+export class Finally<const Scope extends string, E = never> extends ScopedEffect('fx/Finally')<Scope, {
+  readonly finalizer: Finalizer<E>
 }, void> { }
 
 /**
@@ -32,7 +32,7 @@ export class Finally<const Scope extends string> extends ScopedEffect('fx/Finall
 export const andFinally = <const Scope extends string, E>(
   scope: Scope,
   f: Fx<E, void>
-): Fx<Finally<Scope>, void> =>
+): Fx<Finally<Scope, E>, void> =>
   new Finally(scope, { finalizer: () => f })
 
 /**
@@ -41,8 +41,8 @@ export const andFinally = <const Scope extends string, E>(
 export const andFinallyExit = <const Scope extends string, E>(
   scope: Scope,
   f: (exit: Exit) => Fx<E, void>
-): Fx<Finally<Scope>, void> =>
-  new Finally(scope, { finalizer: exit => f(exit) })
+): Fx<Finally<Scope, E>, void> =>
+  new Finally(scope, { finalizer: f })
 
 /**
  * Run an initial operation, register cleanup for its result, and return it.
@@ -51,7 +51,7 @@ export const using = <const Scope extends string, const IE, const FE, const R>(
   scope: Scope,
   initially: Fx<IE, R>,
   finally_: (r: R) => Fx<FE, void>
-): Fx<IE | Finally<Scope> | Interrupt, R> => uninterruptible(fx(function* () {
+): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
   const r = yield* initially
   yield* andFinally(scope, finally_(r))
   return r
@@ -64,7 +64,7 @@ export const usingExit = <const Scope extends string, const IE, const FE, const 
   scope: Scope,
   initially: Fx<IE, R>,
   finally_: (r: R, exit: Exit) => Fx<FE, void>
-): Fx<IE | Finally<Scope> | Interrupt, R> => uninterruptible(fx(function* () {
+): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
   const r = yield* initially
   yield* andFinallyExit(scope, exit => finally_(r, exit))
   return r
@@ -87,7 +87,7 @@ export const managed = <const A, const E>(
 export const usingManaged = <const Scope extends string, const IE, const FE, const A>(
   scope: Scope,
   initially: Fx<IE, Managed<A, FE>>
-): Fx<IE | Finally<Scope> | Interrupt, A> => uninterruptible(fx(function* () {
+): Fx<IE | Finally<Scope, FE> | Interrupt, A> => uninterruptible(fx(function* () {
   const m = yield* initially
   yield* andFinallyExit(scope, m.finalizer)
   return m.value

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -59,15 +59,26 @@ export function scope<const Scope extends string>(
 }
 
 export type ScopeEffects<E, Scope extends string> =
-  HandleScopeEffect<E, Scope> | CleanupFailure<E, Scope>
+  HandleScopeEffect<E, Scope> | CleanupEffects<E, Scope> | CleanupFailure<E, Scope>
 
 type HandleScopeEffect<E, Scope extends string> =
-  E extends Finally<Scope> ? never
+  E extends Finally<Scope, any> ? never
   : E extends ReturnFrom<Scope, any> ? never
   : E
 
+type MatchingFinally<E, Scope extends string> =
+  Extract<E, Finally<Scope, any>>
+
+type FinalizerEffects<E, Scope extends string> =
+  MatchingFinally<E, Scope> extends never
+    ? never
+    : MatchingFinally<E, Scope> extends Finally<Scope, infer FE> ? FE : never
+
+type CleanupEffects<E, Scope extends string> =
+  Exclude<FinalizerEffects<E, Scope>, Fail<any>>
+
 type CleanupFailure<E, Scope extends string> =
-  Extract<E, Finally<Scope>> extends never ? never : Fail<AggregateError>
+  MatchingFinally<E, Scope> extends never ? never : Fail<AggregateError>
 
 export type ReturnValue<E, Scope extends string> =
   E extends ReturnFrom<Scope, infer A> ? A : never
@@ -85,7 +96,7 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
   }
 
   *[Symbol.iterator](): Iterator<unknown, A> {
-    const finalizers = [] as Finalizer[]
+    const finalizers = [] as Finalizer<unknown>[]
     const { scopeName } = this
     const i = withActiveScope(scopeName, this.fx)[Symbol.iterator]()
     const captured: CapturedHandler = {


### PR DESCRIPTION
## Summary
- preserve finalizer effect rows in `Finally<Scope, E>` and finalization helpers
- expose non-failure finalizer effects after `scope(...)` while retaining `Fail<AggregateError>` cleanup aggregation
- update focused finalization tests and the incident collector effect signature

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm build`
- `corepack pnpm lint` (3 existing warnings, 0 errors)