### PR TITLE
[codex] Add agent guidance docs

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -1,0 +1,173 @@
+# Agent Guide
+
+This guide is for coding agents writing application code with `fx`. The root
+`AGENTS.md` files are contributor guidance for changing this repository.
+
+## Core model
+
+An `Fx<E, A>` is a computation that returns `A` and may request effects `E`.
+Programs describe operations with `yield*`; handlers interpret those operations.
+
+```ts
+import { Effect, fx, handle, ok, run } from "@briancavalier/fx"
+
+class AskName extends Effect("app/AskName")<void, string> {}
+
+const askName = new AskName()
+
+const greet = fx(function* () {
+  return `Hello, ${yield* askName}`
+})
+
+const message = greet.pipe(
+  handle(AskName, () => ok("Ada")),
+  run
+)
+```
+
+The effect union should stay meaningful. If a program needs logging, storage, and
+recoverable validation, keep those effects visible in its `Fx<E, A>` type until
+a handler eliminates them.
+
+## Define effects directly
+
+Use `Effect(...)` classes for ordinary requests. Add a small constructor value or
+function only when it improves call-site clarity.
+
+```ts
+class SaveUser extends Effect("app/User/Save")<User, User> {}
+
+const saveUser = (user: User) => new SaveUser(user)
+```
+
+Avoid service containers, dependency graphs, and wrappers that only rename an
+existing effect. An effect should describe a request, not a hidden dependency.
+
+## Write business logic against effects
+
+Application logic should request operations and compose results. It should not
+perform platform side effects directly.
+
+```ts
+const registerUser = (input: RegisterInput) => fx(function* () {
+  const user = validateUser(input)
+  const saved = yield* saveUser(user)
+  yield* log("user registered", { id: saved.id })
+  return saved
+})
+```
+
+At platform boundaries, interpret effects with handlers and then run the program.
+
+```ts
+const result = registerUser(input).pipe(
+  handle(SaveUser, effect => databaseSave(effect.arg)),
+  defaultLog,
+  runPromise
+)
+```
+
+## Use `Fail` for recoverable errors
+
+Recoverable domain and boundary errors should be values in `Fail<E>`, not thrown
+JavaScript exceptions. Use `fail`, `trySync`, and `tryPromise` to convert
+recoverable exceptional states into effects.
+
+```ts
+import { fail, catchOnly } from "@briancavalier/fx/Fail"
+
+class InvalidEmail extends Error {}
+
+const parseEmail = (value: string) =>
+  value.includes("@")
+    ? ok(value)
+    : fail(new InvalidEmail(value))
+
+const recovered = parseEmail(input).pipe(
+  catchOnly(InvalidEmail, () => ok("unknown@example.com"))
+)
+```
+
+Reserve `throw` for hard crashes, internal invariants, and explicitly unsafe
+assertions.
+
+## Wrap async boundaries with `tryPromise`
+
+Use `tryPromise` when a promise can reject and the rejection is recoverable.
+Use `assertPromise` only when rejection should crash the running program.
+
+```ts
+import { tryPromise } from "@briancavalier/fx/Async"
+
+const readUser = (id: string) =>
+  tryPromise(signal =>
+    fetch(`/users/${id}`, { signal }).then(response => response.json())
+  )
+```
+
+The runtime provides an `AbortSignal`; pass it to cancellable platform APIs.
+
+## Compose handlers explicitly
+
+Handlers are ordinary pipe transforms. Keep the final interpreter pipeline easy
+to scan.
+
+```ts
+const main = program.pipe(
+  memoryUserStore(),
+  defaultLog,
+  defaultTime,
+  runPromise
+)
+```
+
+Do not hide large handler stacks behind broad framework-like layers unless the
+named boundary is real and useful for the application.
+
+## Choose the right runner
+
+- Use `run` only after all async, failure, handler-capture, and platform effects
+  have been eliminated.
+- Use `runPromise` for async programs when the caller does not need cancellation.
+- Use `runTask` when the caller needs to cancel or wait for disposal.
+- Use `runNodeMain` from `@briancavalier/fx/NodeRuntime` for Node entrypoints
+  that should shut down on process signals.
+
+## Concurrency and resources
+
+Use `all` and `race` to describe structured concurrency, then choose semantics
+with handlers such as `defaultAll`, `firstSettled`, `firstSuccess`, `bounded`,
+and `unbounded`.
+
+Use named scopes and finalization helpers when resources need cleanup. Keep
+acquire/register critical sections small and explicit.
+
+```ts
+const program = fx(function* () {
+  const [user, posts] = yield* all([fetchUser, fetchPosts])
+  return { user, posts }
+}).pipe(
+  defaultAll,
+  bounded(4),
+  runPromise
+)
+```
+
+## Boundary discipline
+
+Do:
+
+- keep domain programs platform-neutral,
+- model external work as effects,
+- convert recoverable thrown/rejected errors to `Fail`,
+- use pure handlers in tests,
+- compose handlers explicitly near runtime boundaries.
+
+Avoid:
+
+- direct `console.log`, `fetch`, file, or database calls inside reusable `Fx`
+  programs when an effect would keep the boundary explicit,
+- broad service-container abstractions,
+- hiding effect requirements behind ambient state,
+- wrapping one effect in a generator unless the wrapper adds sequencing or a
+  real domain operation.

--- a/docs/recipes/build-http-routes.md
+++ b/docs/recipes/build-http-routes.md
@@ -4,6 +4,7 @@ Use this when exposing domain programs through a transport-neutral HTTP server.
 
 ```ts
 import { get } from "@briancavalier/fx/Env"
+import { assert as assertNoFail } from "@briancavalier/fx/Fail"
 import { route, routes, type RouteContext } from "@briancavalier/fx/HttpServer"
 import { fx, ok } from "@briancavalier/fx"
 
@@ -34,6 +35,7 @@ Handler pipeline:
 serve(appRoutes, { port: 3000 }).pipe(
   appHandlers,
   nodeHttp(),
+  assertNoFail,
   runNodeMain
 )
 ```

--- a/docs/recipes/build-http-routes.md
+++ b/docs/recipes/build-http-routes.md
@@ -1,0 +1,43 @@
+# Build HTTP Routes
+
+Use this when exposing domain programs through a transport-neutral HTTP server.
+
+```ts
+import { get } from "@briancavalier/fx/Env"
+import { route, routes, type RouteContext } from "@briancavalier/fx/HttpServer"
+import { fx, ok } from "@briancavalier/fx"
+
+const appRoutes = routes(
+  route("GET", "/health", ok({
+    status: 200,
+    body: { type: "text", value: "ok" }
+  })),
+
+  route("GET", "/users/:id", fx(function* () {
+    const { request } = yield* get<RouteContext>()
+    const user = yield* findUser(request.params.id)
+    return {
+      status: user === undefined ? 404 : 200,
+      body: { type: "json", value: user ?? { error: "not found" } }
+    }
+  }))
+)
+```
+
+Routes describe request handling without choosing the Node HTTP transport.
+Use route transforms such as `provideRoutesFrom` to provide request-derived
+context to groups of routes.
+
+Handler pipeline:
+
+```ts
+serve(appRoutes, { port: 3000 }).pipe(
+  appHandlers,
+  nodeHttp(),
+  runNodeMain
+)
+```
+
+Common mistake: putting storage, parsing policy, or platform-specific server
+logic directly into reusable domain programs instead of keeping it at the route
+or transport boundary.

--- a/docs/recipes/define-an-effect.md
+++ b/docs/recipes/define-an-effect.md
@@ -1,0 +1,36 @@
+# Define an Effect
+
+Use this when application logic needs to request an operation without choosing
+how it is performed.
+
+```ts
+import { Effect } from "@briancavalier/fx"
+
+type User = {
+  readonly id: string
+  readonly name: string
+}
+
+class FindUser extends Effect("app/User/Find")<string, User | undefined> {}
+
+const findUser = (id: string) => new FindUser(id)
+```
+
+The first type parameter is the request argument. The second is the answer that
+`yield*` receives.
+
+```ts
+const user = yield* findUser("user-1")
+```
+
+Handler pipeline:
+
+```ts
+program.pipe(
+  handle(FindUser, effect => ok(users.get(effect.arg))),
+  run
+)
+```
+
+Common mistake: creating a service object or wrapper class when one effect class
+and a small constructor function are enough.

--- a/docs/recipes/manage-resources-and-finalizers.md
+++ b/docs/recipes/manage-resources-and-finalizers.md
@@ -1,0 +1,40 @@
+# Manage Resources and Finalizers
+
+Use this when acquiring a resource that must be released when a named scope
+exits.
+
+```ts
+import { usingManaged, managed } from "@briancavalier/fx/Finalization"
+import { scope } from "@briancavalier/fx/Scope"
+
+const RequestScope = "app/Request" as const
+
+const openConnection = fx(function* () {
+  return managed(
+    { id: "connection-1" },
+    exit => closeConnection(exit)
+  )
+})
+
+const program = fx(function* () {
+  const connection = yield* usingManaged(RequestScope, openConnection)
+  return yield* query(connection)
+}).pipe(
+  scope(RequestScope)
+)
+```
+
+Use `using`, `usingExit`, or `usingManaged` to acquire and register cleanup in a
+small uninterruptible region.
+
+Handler pipeline:
+
+```ts
+program.pipe(
+  resourceHandlers,
+  runPromise
+)
+```
+
+Common mistake: acquiring a resource and registering its cleanup in separate,
+interruptible steps.

--- a/docs/recipes/recover-with-fail.md
+++ b/docs/recipes/recover-with-fail.md
@@ -1,0 +1,35 @@
+# Recover with Fail
+
+Use this when an operation can fail recoverably and callers should decide how to
+recover.
+
+```ts
+import { fail, catchOnly } from "@briancavalier/fx/Fail"
+import { ok } from "@briancavalier/fx"
+
+class NotFound extends Error {}
+
+const requireUser = (user: User | undefined) =>
+  user === undefined
+    ? fail(new NotFound("user not found"))
+    : ok(user)
+
+const userOrGuest = requireUser(user).pipe(
+  catchOnly(NotFound, () => ok({ id: "guest", name: "Guest" }))
+)
+```
+
+`Fail<E>` stays in the effect union until `catchOnly`, `catchIf`, `catchAll`, or
+another handler eliminates it.
+
+Handler pipeline:
+
+```ts
+program.pipe(
+  catchOnly(NotFound, () => ok(guestUser)),
+  run
+)
+```
+
+Common mistake: throwing recoverable validation or lookup errors from inside an
+`Fx` program. Throw only for hard crashes or internal invariants.

--- a/docs/recipes/run-a-node-program.md
+++ b/docs/recipes/run-a-node-program.md
@@ -1,0 +1,32 @@
+# Run a Node Program
+
+Use this for Node entrypoints that should run async `Fx` programs and shut down
+cleanly on process signals.
+
+```ts
+import { runNodeMain } from "@briancavalier/fx/NodeRuntime"
+import { defaultConsole } from "@briancavalier/fx/Console"
+
+const main = program.pipe(
+  defaultConsole
+)
+
+await runNodeMain(main)
+```
+
+Use `runPromise` when the caller owns shutdown policy. Use `runNodeMain` when
+the entrypoint should install signal handlers for `SIGINT` and `SIGTERM`.
+
+Handler pipeline:
+
+```ts
+program.pipe(
+  appHandlers,
+  platformHandlers,
+  effect => runNodeMain(effect)
+)
+```
+
+Common mistake: running a program before all non-runtime effects have been
+handled. Leave only runtime-supported effects such as `Async`, `Interrupt`, and
+handler capture for the runner.

--- a/docs/recipes/test-with-pure-handlers.md
+++ b/docs/recipes/test-with-pure-handlers.md
@@ -1,0 +1,33 @@
+# Test with Pure Handlers
+
+Use this when testing domain logic without real platform dependencies.
+
+```ts
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { handle, ok, run } from "@briancavalier/fx"
+
+test("loads a user", () => {
+  const program = loadGreeting("user-1").pipe(
+    handle(FindUser, () => ok({ id: "user-1", name: "Ada" })),
+    run
+  )
+
+  assert.equal(program, "Hello, Ada")
+})
+```
+
+Pure handlers make the effect boundary explicit and keep tests deterministic.
+
+Handler pipeline:
+
+```ts
+domainProgram.pipe(
+  handle(AppEffect, () => ok(testValue)),
+  run
+)
+```
+
+Common mistake: testing domain programs by calling real HTTP, databases, clocks,
+or random number generators when a local handler would express the case more
+clearly.

--- a/docs/recipes/use-structured-concurrency.md
+++ b/docs/recipes/use-structured-concurrency.md
@@ -1,0 +1,35 @@
+# Use Structured Concurrency
+
+Use this when related child computations should be owned by the parent.
+
+```ts
+import { all, bounded, defaultAll } from "@briancavalier/fx/Concurrent"
+
+const loadDashboard = fx(function* () {
+  const [user, posts] = yield* all([
+    fetchUser,
+    fetchPosts
+  ])
+
+  return { user, posts }
+})
+```
+
+`all` describes the request. `defaultAll` chooses the default structured
+semantics, and `bounded` or `unbounded` chooses fork scheduling.
+
+Handler pipeline:
+
+```ts
+loadDashboard.pipe(
+  defaultAll,
+  bounded(4),
+  runPromise
+)
+```
+
+Use `race` with `firstSettled` for first-settled semantics, or `firstSuccess`
+when failures should be ignored until every child fails.
+
+Common mistake: using raw promises for child work that should be cancelled or
+disposed when the parent fails.

--- a/docs/recipes/wrap-a-promise.md
+++ b/docs/recipes/wrap-a-promise.md
@@ -4,6 +4,8 @@ Use this at async platform boundaries such as HTTP, files, databases, and timers
 
 ```ts
 import { tryPromise } from "@briancavalier/fx/Async"
+import { catchAll } from "@briancavalier/fx/Fail"
+import { ok, runPromise } from "@briancavalier/fx"
 
 const fetchJson = (url: string) =>
   tryPromise(signal =>
@@ -19,6 +21,7 @@ Handler pipeline:
 
 ```ts
 fetchJson("https://example.com/data.json").pipe(
+  catchAll(error => ok({ error })),
   runPromise
 )
 ```

--- a/docs/recipes/wrap-a-promise.md
+++ b/docs/recipes/wrap-a-promise.md
@@ -1,0 +1,27 @@
+# Wrap a Promise
+
+Use this at async platform boundaries such as HTTP, files, databases, and timers.
+
+```ts
+import { tryPromise } from "@briancavalier/fx/Async"
+
+const fetchJson = (url: string) =>
+  tryPromise(signal =>
+    fetch(url, { signal }).then(response => response.json())
+  )
+```
+
+`tryPromise` converts promise rejection into `Fail<unknown>` and requests the
+`Async` effect. The runtime passes an `AbortSignal`; forward it to cancellable
+APIs.
+
+Handler pipeline:
+
+```ts
+fetchJson("https://example.com/data.json").pipe(
+  runPromise
+)
+```
+
+Common mistake: using `assertPromise` for recoverable platform errors. Use
+`assertPromise` only when rejection should crash the program.

--- a/docs/recipes/write-a-handler.md
+++ b/docs/recipes/write-a-handler.md
@@ -1,0 +1,26 @@
+# Write a Handler
+
+Use this when a program has an effect and the boundary needs to interpret it.
+
+```ts
+import { handle, ok } from "@briancavalier/fx"
+
+const memoryUsers = (users: ReadonlyMap<string, User>) =>
+  handle(FindUser, effect => ok(users.get(effect.arg)))
+```
+
+Handlers remove the handled effect from the program's effect union and may add
+new effects of their own.
+
+```ts
+const result = program.pipe(
+  memoryUsers(new Map([["user-1", { id: "user-1", name: "Ada" }]])),
+  run
+)
+```
+
+Use `control` only when the handler needs to decide whether or how to resume the
+program.
+
+Common mistake: hiding many unrelated handlers behind a generic dependency layer.
+Prefer an explicit pipeline unless the grouped boundary has a real domain name.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,25 @@ if you are learning the core model, use `intermediate` for focused runtime
 features, and use `advanced` for app-shaped examples that combine several
 features.
 
+## Agent routing
+
+Use the smallest example that demonstrates the task:
+
+| Task | Start with | Why |
+| --- | --- | --- |
+| Minimal runnable program | `basic/hello.ts` | Shows one effect, one handler, and `run` without extra structure. |
+| Custom domain effects and pure tests | `basic/guessing-game` | Shows business logic written against effects and interpreted by handlers. |
+| HTTP boundary code | `basic/http-server-client` | Shows routes, request context, client/server boundaries, and in-memory handlers. |
+| Handler-chosen concurrency semantics | `intermediate/race-handlers.ts` | Shows one request interpreted by different race handlers. |
+| Interruption and cleanup | `intermediate/interrupt-safe-finalization.ts` | Shows cancellation, named scopes, and async finalizers. |
+| Scoped data-flow or early return | `intermediate/read-csv.ts` | Shows scoped `YieldFrom`, managed resources, transforms, and early return. |
+| App-shaped domain organization | `advanced/bookmarks` | Shows domain effects, HTTP, CLI/browser clients, persistence handlers, and tests. |
+| Structured concurrency plus resources | `advanced/incident-collector` | Shows `all`, `race`, named scopes, managed resources, finalization, and fixture handlers. |
+| Diagnostics and trace formatting | `advanced/diagnostics.ts` | Shows trace capture policy, regional traces, source lookup, and formatted output. |
+
+Avoid starting from an advanced example when a basic or intermediate example
+already matches the requested pattern.
+
 ## Basic
 
 | Example | What it shows | Best for | Run |

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,33 @@
+# fx
+
+> A small, strongly typed algebraic effects and handlers library for TypeScript.
+
+Use these files when helping someone write or modify code that uses `fx`.
+
+## Start here
+
+- `README.md`: high-level model, design tradeoffs, and a small first example.
+- `docs/agent-guide.md`: consumer-facing guide for coding agents using `fx` in application code.
+- `docs/recipes/`: compact task recipes for common implementation patterns.
+- `examples/README.md`: route from a user task to the closest runnable example.
+
+## Common tasks
+
+- Define a custom effect: `docs/recipes/define-an-effect.md`.
+- Write a handler: `docs/recipes/write-a-handler.md`.
+- Model recoverable errors: `docs/recipes/recover-with-fail.md`.
+- Wrap platform promises: `docs/recipes/wrap-a-promise.md`.
+- Test with pure handlers: `docs/recipes/test-with-pure-handlers.md`.
+- Run a Node program: `docs/recipes/run-a-node-program.md`.
+- Use structured concurrency: `docs/recipes/use-structured-concurrency.md`.
+- Manage resources and cleanup: `docs/recipes/manage-resources-and-finalizers.md`.
+- Build HTTP routes: `docs/recipes/build-http-routes.md`.
+
+## Contributor guidance
+
+- `AGENTS.md`: repo-wide contributor guidance for coding agents.
+- `src/AGENTS.md`: source-level implementation guidance.
+- `examples/AGENTS.md`: example style guidance.
+
+Do not treat contributor guidance as public API documentation. For application code,
+prefer `docs/agent-guide.md` and the recipes.

--- a/src/Async.ts
+++ b/src/Async.ts
@@ -12,11 +12,27 @@ export interface AsyncContext<A> extends TraceOrigin {
   readonly run: Run<A>
 }
 
+/**
+ * Request that an asynchronous operation be awaited by the runtime.
+ *
+ * Most application code should create `Async` requests with {@link tryPromise}
+ * or {@link assertPromise} instead of constructing this effect directly.
+ */
 export class Async extends Effect('fx/Async')<AsyncContext<any>> { }
 
 /**
- * Convert an async function into an Fx. If the promise rejects, the error will
- * be propagated as a {@link Fail} effect.
+ * Convert an async boundary into an Fx.
+ *
+ * Rejections are converted to {@link Fail} so callers can recover with
+ * `catchOnly`, `catchIf`, or `catchAll`. The runtime supplies an AbortSignal;
+ * pass it to cancellable platform APIs.
+ *
+ * @example
+ * ```ts
+ * const text = tryPromise(signal =>
+ *   fetch(url, { signal }).then(response => response.text())
+ * )
+ * ```
  */
 export const tryPromise = <const A>(f: Run<A>): Fx<Async | Fail<unknown>, A> =>
   flatten(assertPromise(

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -13,8 +13,10 @@ import { acquireAndRunFork } from './internal/runFork.js'
 import { currentRuntimeContext } from './internal/runtimeContext.js'
 
 /**
- * Request that a computation be started concurrently, returning a {@link Task}
- * handle for the running computation.
+ * Request that a computation be started concurrently.
+ *
+ * A `Fork` request returns a {@link Task} handle. The scheduling policy is
+ * supplied by handlers such as {@link bounded} or {@link unbounded}.
  */
 export class Fork extends Effect('fx/Concurrent/Fork')<ForkContext, Task<unknown, unknown>> { }
 
@@ -93,8 +95,11 @@ export const forkEach = <const Fxs extends readonly Fx<unknown, unknown>[]>(
 }>
 
 /**
- * Run a tuple of Fx computations concurrently in a structured scope, returning
- * the tuple of child results directly.
+ * Request that a tuple of Fx computations run concurrently in a structured
+ * scope, returning the tuple of child results directly.
+ *
+ * Pair `all` with {@link defaultAll} and a fork scheduler such as
+ * {@link bounded} or {@link unbounded}.
  *
  * @example
  * const [user, posts] = yield* all([fetchUser, fetchPosts])
@@ -115,8 +120,10 @@ export const all = <const Fxs extends readonly Fx<unknown, unknown>[]>(
 }
 
 /**
- * Race a tuple of Fx computations in a structured scope, returning the first
- * child result or failure to settle.
+ * Request that a tuple of Fx computations race in a structured scope.
+ *
+ * Pair `race` with {@link firstSettled} for first-settled semantics or
+ * {@link firstSuccess} when failed children should be ignored until all fail.
  *
  * @example
  * const value = yield* race([primary, fallback])
@@ -208,6 +215,11 @@ export class RaceAllFailed<Errors extends readonly unknown[]> extends Error {
  * Structured handlers such as {@link defaultAll} and {@link firstSettled}
  * elaborate into Fork requests, so `bounded` also limits their child
  * concurrency.
+ *
+ * @example
+ * ```ts
+ * program.pipe(defaultAll, bounded(4), runPromise)
+ * ```
  */
 export const bounded = (maxConcurrency: number) => <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, Fork>, HandlerCapture<'fx/Concurrent/Fork'>> | HandlerCapture<'fx/Concurrent/Fork'>, A> =>
   withCapturedHandlers('fx/Concurrent/Fork', f).pipe(

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -23,6 +23,22 @@ export interface EffectOrigin {
   readonly [EffectOriginTypeId]: TraceOrigin
 }
 
+/**
+ * Define an effect type with a stable string identity.
+ *
+ * Extend the returned class to describe one kind of request. The first type
+ * parameter is the request argument stored in `arg`; the second is the answer
+ * type received by `yield*`.
+ *
+ * @example
+ * ```ts
+ * class FindUser extends Effect('app/User/Find')<string, User | undefined> { }
+ *
+ * const findUser = (id: string) => new FindUser(id)
+ *
+ * const user = yield* findUser('user-1')
+ * ```
+ */
 export const Effect = <const T extends string>(id: T) => class <A, R = unknown> implements AnyEffect, Pipeable {
   public readonly _fxTypeId: typeof EffectTypeId = EffectTypeId;
   public readonly _fxEffectId = id;
@@ -43,6 +59,22 @@ export const Effect = <const T extends string>(id: T) => class <A, R = unknown> 
   }
 }
 
+/**
+ * Define an effect type whose requests are associated with a named scope.
+ *
+ * Scoped effects let handlers interpret only requests from a matching scope.
+ * Use them when a request should be local to a resource, region, or control
+ * boundary.
+ *
+ * @example
+ * ```ts
+ * class Stop<const Scope extends string>
+ *   extends ScopedEffect('app/Stop')<Scope, void, never> { }
+ *
+ * const stop = <const Scope extends string>(scope: Scope) =>
+ *   new Stop(scope, undefined)
+ * ```
+ */
 export const ScopedEffect = <const T extends string>(id: T) => class <
   const Scope extends string,
   A = void,
@@ -56,6 +88,12 @@ export const ScopedEffect = <const T extends string>(id: T) => class <
 export const isEffect = <E>(e: E): e is E & AnyEffect =>
   !!e && (e as any)._fxTypeId === EffectTypeId
 
+/**
+ * Attach diagnostic origin information to an effect request.
+ *
+ * Runtime handlers use this metadata to preserve request-site traces when an
+ * interpretation fails later at an async or platform boundary.
+ */
 export const withOrigin = <E extends object>(
   effect: E,
   origin: Breadcrumb,

--- a/src/Fail.ts
+++ b/src/Fail.ts
@@ -6,6 +6,13 @@ import { control } from './Handler.js'
 import type { TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
 
+/**
+ * Recoverable failure represented as an effect.
+ *
+ * Use `Fail<E>` for validation, domain, and platform-boundary failures that
+ * callers can handle. Throw JavaScript exceptions only for hard crashes or
+ * internal invariants.
+ */
 export class Fail<const E> extends Effect('fx/Fail')<E, never> {
   readonly origin: Breadcrumb
   readonly trace?: Trace
@@ -21,7 +28,9 @@ export class Fail<const E> extends Effect('fx/Fail')<E, never> {
 }
 
 /**
- * Fail with an error e.
+ * Fail with a recoverable error value.
+ *
+ * The returned Fx never produces a value until a failure handler recovers it.
  */
 export const fail = <const E>(
   e: E,
@@ -74,8 +83,11 @@ export const catchOnly = <const E1, const E extends AnyConstructor, const E2, co
 
 /**
  * Catch all failures and handle them with the provided function.
+ *
  * @example
- *   computation.pipe(catchAll(e => recoverFx))
+ * ```ts
+ * computation.pipe(catchAll(error => recover(error)))
+ * ```
  */
 export const catchAll = <const E1, const E2, const B>(handle: (e: ExtractFail<E1>) => Fx<E2, B>) =>
   catchIf((_: ExtractFail<E1>): _ is ExtractFail<E1> => true, handle)

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -21,6 +21,10 @@ export type Finalizer<E = unknown> = (exit: Exit) => Fx<E, void>
 
 /**
  * Request that a cleanup operation be run when the named scope exits.
+ *
+ * A `scope(...)` handler interprets `Finally` requests for its matching scope
+ * and runs registered finalizers when that scope succeeds, fails, returns,
+ * aborts, or is interrupted.
  */
 export class Finally<const Scope extends string, E = never> extends ScopedEffect('fx/Finally')<Scope, {
   readonly finalizer: Finalizer<E>
@@ -28,6 +32,8 @@ export class Finally<const Scope extends string, E = never> extends ScopedEffect
 
 /**
  * Register a cleanup operation to run when the named scope exits.
+ *
+ * Use this when the finalizer does not need to inspect the scope exit.
  */
 export const andFinally = <const Scope extends string, E>(
   scope: Scope,
@@ -37,6 +43,9 @@ export const andFinally = <const Scope extends string, E>(
 
 /**
  * Register a cleanup operation that receives the named scope's exit.
+ *
+ * Use this when cleanup behavior depends on whether the scope succeeded,
+ * failed, returned, aborted, or was interrupted.
  */
 export const andFinallyExit = <const Scope extends string, E>(
   scope: Scope,
@@ -46,6 +55,9 @@ export const andFinallyExit = <const Scope extends string, E>(
 
 /**
  * Run an initial operation, register cleanup for its result, and return it.
+ *
+ * Acquisition and finalizer registration happen in an uninterruptible region so
+ * an acquired resource is not left without cleanup.
  */
 export const using = <const Scope extends string, const IE, const FE, const R>(
   scope: Scope,
@@ -82,7 +94,11 @@ export const managed = <const A, const E>(
 })
 
 /**
- * Run an initial operation that returns a managed value, register its cleanup, and return its value.
+ * Run an initial operation that returns a managed value, register its cleanup,
+ * and return its value.
+ *
+ * Use this when acquisition naturally returns the value and its finalizer
+ * together.
  */
 export const usingManaged = <const Scope extends string, const IE, const FE, const A>(
   scope: Scope,

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -14,18 +14,30 @@ import { RunForkOptions, runFork } from './internal/runFork.js'
 import { TrySync } from './internal/sync.js'
 
 /**
- * A computation that produces a value of type `A`, and may produce effects of
- * type `E`.
+ * A computation that returns a value of type `A` and may request effects `E`.
+ *
+ * Application programs usually build `Fx` values with {@link fx}, request
+ * effects with `yield*`, and then eliminate those effects with handlers before
+ * running the program.
  */
 export interface Fx<E, A> extends Pipeable {
   [Symbol.iterator](): Iterator<E, A, unknown>
 }
 
 /**
- * Construct an Fx from a generator that uses `yield*` to produce effects.
- * A generator with a declared runtime parameter receives contextual parameters
- * from {@link Get}; defaulted contextual parameters are not supported because
- * they have runtime arity 0.
+ * Construct an Fx from a generator that uses `yield*` to request effects.
+ *
+ * A generator with a declared runtime parameter receives contextual values from
+ * {@link Get}; defaulted contextual parameters are not supported because they
+ * have runtime arity 0.
+ *
+ * @example
+ * ```ts
+ * const greet = fx(function* () {
+ *   const name = yield* askName
+ *   return `Hello, ${name}`
+ * })
+ * ```
  */
 export const fx: {
   <const E, const A>(f: () => Generator<E, A>): Fx<E, A>
@@ -108,7 +120,10 @@ export const flatten = <const E1, const E2, const A>(x: Fx<E1, Fx<E2, A>>): Fx<E
   x.pipe(flatMap(x => x))
 
 /**
- * Execute all the effects of the provided Fx, and return a {@link Task} for its result.
+ * Execute a runtime-ready Fx and return a cancellable {@link Task}.
+ *
+ * Use `runTask` when the caller needs to dispose the running computation or wait
+ * for cleanup. All non-runtime effects must be handled before calling it.
  */
 export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt, R>, options: RunForkOptions = {}): Task<R, never> => {
   return runFork(f.pipe(provideAll({})), {
@@ -118,8 +133,10 @@ export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrup
 }
 
 /**
- * Execute all the effects of the provided Fx, and return a Promise for its result,
- * discarding the ability to cancel the computation.
+ * Execute a runtime-ready Fx and return a Promise for its result.
+ *
+ * This discards explicit cancellation. Use {@link runTask} when the caller needs
+ * to cancel or wait for disposal.
  */
 export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt, R>, options: RunForkOptions = {}): Promise<R> => {
   return runTask(f, {
@@ -129,7 +146,11 @@ export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Inter
 }
 
 /**
- * Execute all the effects of the provided Fx, and return its result.
+ * Execute a synchronous Fx and return its result.
+ *
+ * Use `run` only after handlers have eliminated all effects except
+ * {@link Interrupt}. Use {@link runPromise} or {@link runTask} for async
+ * programs.
  */
 export const run = <const R>(f: Fx<Interrupt, R>): R =>
   f.pipe(provideAll({}), f => {
@@ -164,10 +185,11 @@ export const run = <const R>(f: Fx<Interrupt, R>): R =>
   })
 
 /**
- * Ensures that a resource is acquired, used, and then released,
- * even if an error occurs. Runs the `initially` effect to acquire a resource,
- * passes it to `f`, and guarantees that `andFinally` is run with the
- * resource after `f` returns or throws.
+ * Acquire a resource, use it, and release it even if use fails or is
+ * interrupted.
+ *
+ * `bracket` is useful for local acquire/use/release flows. For named resource
+ * scopes, prefer the helpers in `Finalization`.
  */
 export const bracket = <const IE, const FE, const E, const R, const A>(
   initially: Fx<IE, R>,

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -44,6 +44,10 @@ type EffectScope<T extends ScopedEffectType> =
 /**
  * Handle effects of the given type.
  *
+ * The handler receives the requested effect and returns an Fx for the answer.
+ * `handle` removes the handled effect from the program's effect union and adds
+ * any effects requested by the handler.
+ *
  * @example
  * ```ts
  * class AskName extends Effect('app/AskName')<void, string> { }
@@ -103,6 +107,10 @@ export const handleScoped = <T extends ScopedEffectType, const Scope extends Eff
 
 /**
  * Handle effects of the given type with control over resuming the program.
+ *
+ * Use `control` when a handler needs to choose whether, when, or how often to
+ * resume the suspended computation. Use {@link handle} for simple one-request,
+ * one-answer interpretation.
  *
  * @example
  * ```ts

--- a/src/HttpServer.ts
+++ b/src/HttpServer.ts
@@ -90,6 +90,9 @@ export type RouteHandler<E, Params extends ParamsRecord = ParamsRecord> =
 
 /**
  * A composable HTTP route declaration tree.
+ *
+ * Routes are transport-neutral declarations. A server handler such as the Node
+ * HTTP interpreter decides how requests are received and responses are written.
  */
 export type Routes<E = never> =
   | EmptyRoutes
@@ -132,6 +135,21 @@ export type Route<E, Params extends ParamsRecord = ParamsRecord> = {
 
 export const emptyRoutes: Routes<never> = { type: 'empty' }
 
+/**
+ * Declare one HTTP route.
+ *
+ * The handler is an Fx program that can request route context with `get` and
+ * may perform application effects. Those application effects remain visible in
+ * the route tree until handlers eliminate them.
+ *
+ * @example
+ * ```ts
+ * const health = route('GET', '/health', ok({
+ *   status: 200,
+ *   body: { type: 'text', value: 'ok' }
+ * }))
+ * ```
+ */
 export const route = <E>(
   method: Method,
   path: string,
@@ -149,6 +167,9 @@ type RouteList<Rs extends readonly unknown[]> = {
   readonly [K in keyof Rs]: Routes<unknown>
 }
 
+/**
+ * Concatenate route trees while preserving their combined effect requirements.
+ */
 export const routes = <const Rs extends readonly unknown[]>(
   ...routes: Rs & RouteList<Rs>
 ): ConcatRoutes<EffectsOfRoutes<Rs[number]>> => ({
@@ -156,6 +177,9 @@ export const routes = <const Rs extends readonly unknown[]>(
   routes: routes as readonly Routes<EffectsOfRoutes<Rs[number]>>[]
 })
 
+/**
+ * Mount a route tree under a path prefix.
+ */
 export const mount = <E>(
   prefix: string,
   routes: Routes<E>
@@ -176,6 +200,12 @@ export type RouteTransform<E1, E2> = {
   transform<A>(fx: Fx<E1 | Get<RouteContext<any>>, A>): Fx<E2 | Get<RouteContext<any>>, A>
 }['transform']
 
+/**
+ * Apply a lazy transform to every route handler in a route tree.
+ *
+ * Use this to provide route context, add logging, or interpret application
+ * effects without eagerly rewriting route handlers.
+ */
 export const transformRoutes = <E1, E2>(
   transform: RouteTransform<E1, E2>
 ) =>
@@ -185,6 +215,12 @@ export const transformRoutes = <E1, E2>(
     transform
   })
 
+/**
+ * Provide request-derived context to every route handler in a route tree.
+ *
+ * The context program can read {@link RouteContext}, perform effects, and
+ * provide the resulting fields to each route under the transform.
+ */
 export const provideRoutesFrom =
   <const PE, const C extends Record<PropertyKey, unknown>>(context: Fx<PE, C>) =>
     transformRoutes(provideFrom(context)) as
@@ -211,6 +247,12 @@ export type ServeOptions<OE = never> = {
   readonly observe?: (event: ServerEvent) => Fx<OE, void>
 }
 
+/**
+ * Request that an HTTP server run the provided routes.
+ *
+ * `serve` captures the surrounding handler context so route handlers can use
+ * application handlers installed at the server boundary.
+ */
 export const serve = <E, OE = never>(
   routes: Routes<E>,
   options: ServeOptions<OE>


### PR DESCRIPTION
## Summary

- add `llms.txt` as a low-token routing entrypoint for coding agents
- add a consumer-facing `docs/agent-guide.md` plus focused recipes under `docs/recipes/`
- add example routing guidance and improve JSDoc on the highest-traffic public modules

## Impact

This gives coding agents a compact path for using `fx` proficiently in application code without treating contributor `AGENTS.md` files as public API documentation. It also makes editor/API docs more explicit about requests, handlers, runtime boundaries, recoverable failures, concurrency, finalization, and HTTP routes.

## Validation

- `git diff --check`
- `corepack pnpm typecheck`
- `corepack pnpm lint` exited 0 with 3 existing warnings outside this docs slice:
  - unused `setTraceCapturePolicy` in `examples/advanced/diagnostics.ts`
  - unused `fx` in `examples/basic/hello.ts`
  - generated browser asset warning in `examples/advanced/bookmarks/browser/assets/src/internal/time.js`