### PR TITLE
Merge usingExit into using

### DIFF
--- a/docs/recipes/manage-resources-and-finalizers.md
+++ b/docs/recipes/manage-resources-and-finalizers.md
@@ -24,8 +24,9 @@ const program = fx(function* () {
 )
 ```
 
-Use `using`, `usingExit`, or `usingManaged` to acquire and register cleanup in a
-small uninterruptible region.
+Use `using` or `usingManaged` to acquire and register cleanup in a small
+uninterruptible region. `using` finalizers receive the acquired value and the
+scope exit, and may ignore the exit when cleanup does not depend on it.
 
 Handler pipeline:
 

--- a/examples/advanced/bookmarks/browser/assets/src/Finalization.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Finalization.js
@@ -19,14 +19,6 @@ export const andFinallyExit = (scope, f) => new Finally(scope, { finalizer: exit
  */
 export const using = (scope, initially, finally_) => uninterruptible(fx(function* () {
     const r = yield* initially;
-    yield* andFinally(scope, finally_(r));
-    return r;
-}));
-/**
- * Run an initial operation, register exit-aware cleanup for its result, and return it.
- */
-export const usingExit = (scope, initially, finally_) => uninterruptible(fx(function* () {
-    const r = yield* initially;
     yield* andFinallyExit(scope, exit => finally_(r, exit));
     return r;
 }));

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -1,7 +1,7 @@
 import { all, race, type All, type Race } from '@briancavalier/fx/concurrent'
 import { Effect, fail, type Fail, fx, type Fx, handle, type Interrupt, ok } from '@briancavalier/fx'
 
-import { usingExit, usingManaged, managed, type Finally, type Managed } from '@briancavalier/fx/scope'
+import { using, usingManaged, managed, type Finally, type Managed } from '@briancavalier/fx/scope'
 
 import { info, type Log } from '@briancavalier/fx/log'
 import { sleep, type Time } from '@briancavalier/fx/time'
@@ -302,7 +302,7 @@ const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function*
 
 const withCollector = <E, A>(collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<typeof CollectorScope, Log> | Interrupt, A> => fx(function* () {
   const name = yield* usingManaged(CollectorScope, startCollector(collector))
-  yield* usingExit(
+  yield* using(
     CollectorScope,
     ok(name),
     (name, exit) => info('collector finalized', { name, exit: exit.type })

--- a/examples/intermediate/interrupt-safe-finalization.ts
+++ b/examples/intermediate/interrupt-safe-finalization.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { firstSettled, race, unbounded } from '@briancavalier/fx/concurrent'
 
-import { scope, usingExit } from '@briancavalier/fx/scope'
+import { scope, using } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 
@@ -12,7 +12,7 @@ import { defaultTime, sleep } from '@briancavalier/fx/time'
  * `firstSettled` interrupts the losing database branch and waits for its
  * scoped async finalizer before the program logs the result.
  *
- * The example shows exit-aware cleanup with `usingExit`, named finalization
+ * The example shows exit-aware cleanup with `using`, named finalization
  * with `scope`, and structured race cancellation.
  */
 
@@ -31,7 +31,7 @@ const fetchFromCache = fx(function* () {
 })
 
 const fetchFromDatabase = fx(function* () {
-  const connection = yield* usingExit(
+  const connection = yield* using(
     RequestScope,
     openConnection,
     (_, exit) => fx(function* () {

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test'
 import { abort, Abort, orReturn } from './Abort.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { fx, ok, run, type Fx } from './Fx.js'
-import { andFinally, andFinallyExit, managed, using, usingExit, usingManaged, type Finally, type Managed } from './Finalization.js'
+import { andFinally, andFinallyExit, managed, using, usingManaged, type Finally, type Managed } from './Finalization.js'
 import type { Interrupt } from './Interrupt.js'
 import { returnFrom } from './ReturnFrom.js'
 import { brand, scope, type Exit } from './Scope.js'
@@ -29,7 +29,7 @@ describe('Finalization', () => {
   it('preserves finalizer effects in resource helper types', () => {
     const releaseFailure = new Error('release failed')
     const resource = using(TestScope, ok('resource'), () => yieldFrom(CleanupEvents, 'cleanup'))
-    const exitResource = usingExit(TestScope, ok('resource'), () => fail(releaseFailure))
+    const exitResource = using(TestScope, ok('resource'), () => fail(releaseFailure))
     const managedResource = usingManaged(TestScope, ok(managed(
       'resource',
       () => yieldFrom(CleanupEvents, 'cleanup')
@@ -249,7 +249,7 @@ describe('Finalization', () => {
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* using(TestScope, 
+      yield* using(TestScope,
         ok('resource'),
         resource => record(released, resource)
       )
@@ -261,12 +261,30 @@ describe('Finalization', () => {
     assert.deepEqual(released, ['resource'])
   })
 
-  it('usingExit provides the resource and success exit', () => {
+  it('using delays finalizer construction until scope exit', () => {
+    const events = [] as string[]
+
+    const result = run(fx(function* () {
+      const resource = yield* using(TestScope, ok('resource'),
+        resource => {
+          events.push(`release ${resource}`)
+          return record(events, 'cleanup')
+        }
+      )
+      events.push(`use ${resource}`)
+      return resource
+    }).pipe(scope(TestScope), returnFail))
+
+    assert.equal(result, 'resource')
+    assert.deepEqual(events, ['use resource', 'release resource', 'cleanup'])
+  })
+
+  it('using provides the resource and success exit', () => {
     const released = [] as string[]
     const exits = [] as Exit[]
 
     const result = run(fx(function* () {
-      return yield* usingExit(TestScope, ok('resource'),
+      return yield* using(TestScope, ok('resource'),
         (resource, exit) => fx(function* () {
           released.push(resource)
           exits.push(exit)
@@ -279,13 +297,13 @@ describe('Finalization', () => {
     assert.deepEqual(exits, [{ type: 'success', value: 'resource' }])
   })
 
-  it('usingExit provides the resource and failure exit', () => {
+  it('using provides the resource and failure exit', () => {
     const released = [] as string[]
     const exits = [] as Exit[]
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* usingExit(TestScope, 
+      yield* using(TestScope,
         ok('resource'),
         (resource, exit) => fx(function* () {
           released.push(resource)
@@ -304,12 +322,12 @@ describe('Finalization', () => {
     if (exit.type === 'failure') assert.equal(exit.failure.arg, programFailure)
   })
 
-  it('usingExit release failure participates in cleanup aggregation', () => {
+  it('using release failure participates in cleanup aggregation', () => {
     const programFailure = new Error('program failed')
     const releaseFailure = new Error('release failed')
 
     const result = run(fx(function* () {
-      yield* usingExit(TestScope, 
+      yield* using(TestScope,
         ok('resource'),
         () => fail(releaseFailure)
       )

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -62,19 +62,6 @@ export const andFinallyExit = <const Scope extends string, E>(
 export const using = <const Scope extends string, const IE, const FE, const R>(
   scope: Scope,
   initially: Fx<IE, R>,
-  finally_: (r: R) => Fx<FE, void>
-): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
-  const r = yield* initially
-  yield* andFinally(scope, finally_(r))
-  return r
-}))
-
-/**
- * Run an initial operation, register exit-aware cleanup for its result, and return it.
- */
-export const usingExit = <const Scope extends string, const IE, const FE, const R>(
-  scope: Scope,
-  initially: Fx<IE, R>,
   finally_: (r: R, exit: Exit) => Fx<FE, void>
 ): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
   const r = yield* initially

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -4,7 +4,7 @@ import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { fail, returnFail } from './Fail.js'
 import { firstSettled, race, unbounded } from './Concurrent.js'
-import { managed, usingExit, usingManaged } from './Finalization.js'
+import { managed, using, usingManaged } from './Finalization.js'
 import { bracket, fx, ok, run, runPromise, runTask, type Fx } from './Fx.js'
 import { control, handle } from './Handler.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
@@ -91,12 +91,12 @@ describe('Interrupt masking', () => {
   })
 
   it('runs registered finalizers when interrupted after masked acquire/register', async () => {
-    const TestScope = 'test/Interrupt/usingExit' as const
+    const TestScope = 'test/Interrupt/using' as const
     const exits = [] as Exit[]
     let resolve!: (value: string) => void
 
     const task = fx(function* () {
-      yield* usingExit(
+      yield* using(
         TestScope,
         assertPromise<string>(() => new Promise(r => {
           resolve = r
@@ -301,7 +301,7 @@ describe('Interrupt masking', () => {
     let settled = false
 
     const loser = fx(function* () {
-      yield* usingExit(
+      yield* using(
         TestScope,
         assertPromise<string>(() => new Promise(r => {
           resolveAcquire = r


### PR DESCRIPTION
## Summary
- make using register exit-aware finalizers and remove usingExit
- update tests, docs, and examples to use using for both ordinary and exit-aware cleanup
- keep managed/usingManaged and andFinally/andFinallyExit unchanged

## Validation
- node --import tsx --test src/Finalization.test.ts src/Interrupt.test.ts
- corepack pnpm build
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm lint (passes with existing no-implied-eval warning in browser asset time helper)