### PR TITLE
Simplify Finally payload

### DIFF
--- a/examples/advanced/bookmarks/browser/assets/src/Finalization.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Finalization.js
@@ -9,11 +9,11 @@ export class Finally extends ScopedEffect('fx/Finally') {
 /**
  * Register a cleanup operation to run when the named scope exits.
  */
-export const andFinally = (scope, f) => new Finally(scope, { finalizer: () => f });
+export const andFinally = (scope, f) => new Finally(scope, () => f);
 /**
  * Register a cleanup operation that receives the named scope's exit.
  */
-export const andFinallyExit = (scope, f) => new Finally(scope, { finalizer: exit => f(exit) });
+export const andFinallyExit = (scope, f) => new Finally(scope, exit => f(exit));
 /**
  * Run an initial operation, register cleanup for its result, and return it.
  */

--- a/examples/advanced/bookmarks/browser/assets/src/Scope.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Scope.js
@@ -43,7 +43,7 @@ class ScopeBoundary {
                     const effect = ir.value;
                     const sameScope = effect.scope === scopeName;
                     if (sameScope && Finally.is(effect)) {
-                        finalizers.push(effect.arg.finalizer);
+                        finalizers.push(effect.arg);
                         ir = i.next(undefined);
                     }
                     else if (sameScope && ReturnFrom.is(effect)) {

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -26,9 +26,7 @@ export type Finalizer<E = unknown> = (exit: Exit) => Fx<E, void>
  * and runs registered finalizers when that scope succeeds, fails, returns,
  * aborts, or is interrupted.
  */
-export class Finally<const Scope extends string, E = never> extends ScopedEffect('fx/Finally')<Scope, {
-  readonly finalizer: Finalizer<E>
-}, void> { }
+export class Finally<const Scope extends string, E = never> extends ScopedEffect('fx/Finally')<Scope, Finalizer<E>, void> { }
 
 /**
  * Register a cleanup operation to run when the named scope exits.
@@ -39,7 +37,7 @@ export const andFinally = <const Scope extends string, E>(
   scope: Scope,
   f: Fx<E, void>
 ): Fx<Finally<Scope, E>, void> =>
-  new Finally(scope, { finalizer: () => f })
+  new Finally(scope, () => f)
 
 /**
  * Register a cleanup operation that receives the named scope's exit.
@@ -51,7 +49,7 @@ export const andFinallyExit = <const Scope extends string, E>(
   scope: Scope,
   f: (exit: Exit) => Fx<E, void>
 ): Fx<Finally<Scope, E>, void> =>
-  new Finally(scope, { finalizer: f })
+  new Finally(scope, f)
 
 /**
  * Run an initial operation, register cleanup for its result, and return it.

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -115,7 +115,7 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
           const sameScope = (effect as { readonly scope?: unknown }).scope === scopeName
 
           if (sameScope && Finally.is(effect)) {
-            finalizers.push(effect.arg.finalizer)
+            finalizers.push(effect.arg)
             ir = i.next(undefined)
           } else if (sameScope && ReturnFrom.is(effect)) {
             const exit = { type: 'returnFrom', scope: scopeName, value: effect.arg } satisfies Exit<Scope>


### PR DESCRIPTION
## Summary
- store the finalizer function directly as the Finally effect payload
- update scope interpretation to read effect.arg directly
- update the checked-in browser asset mirror

## Validation
- node --import tsx --test src/Finalization.test.ts src/Interrupt.test.ts src/Concurrent.test.ts src/Abort.test.ts
- corepack pnpm build
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm lint (passes with existing no-implied-eval warning in browser asset time helper)
- rg "arg\.finalizer|new Finally\([^\n]+\{ finalizer" src examples/advanced/bookmarks/browser/assets/src -n (no matches)