### PR TITLE
Add scoped timeout interruption

### DIFF
--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -23,7 +23,7 @@ Good examples:
 - compose handlers with `.pipe(...)`,
 - use library effects for observable behavior, e.g. `consoleLog` with
   `defaultConsole`, rather than direct `console.log` inside `Fx` programs,
-- show effect constructors in their pipeable form when available, e.g. `work.pipe(timeout({ ms: 500 }))`,
+- show effect constructors in their pipeable form when available, e.g. `work.pipe(timeout(RequestScope, { ms: 500 }))`,
 - keep the focus on user-facing effects and explicit handler composition,
 - recover or log failures without obscuring the handler composition,
 - end with `run`, `runPromise`, or `runTask`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ already matches the requested pattern.
 | --- | --- | --- | --- |
 | `intermediate/race-handlers.ts` | One `race` request interpreted with first-settled and first-success handlers. | Readers learning how handlers choose semantics. | `node --import tsx examples/intermediate/race-handlers.ts` |
 | `intermediate/interrupt-safe-finalization.ts` | Race cancellation, named scopes, and async finalization for interrupted work. | Readers working with resources under structured concurrency. | `node --import tsx examples/intermediate/interrupt-safe-finalization.ts` |
-| `intermediate/uninterruptible-mask.ts` | A protected acquire/register critical section with interruptible use. | Readers who need precise interruption boundaries. | `node --import tsx examples/intermediate/uninterruptible-mask.ts` |
+| `intermediate/uninterruptible-mask.ts` | Timeout-driven interruption after a protected acquire/register critical section. | Readers who need precise interruption boundaries. | `node --import tsx examples/intermediate/uninterruptible-mask.ts` |
 | `intermediate/ref.ts` | Atomic shared state updates across concurrent tasks. | Readers modeling safe mutable references. | `node --import tsx examples/intermediate/ref.ts` |
 | `intermediate/read-csv.ts` | Scoped `YieldFrom`, row transforms, managed resources, and early return. | Readers exploring scoped data-flow patterns. | `node --import tsx examples/intermediate/read-csv.ts` |
 | `intermediate/yield-sink-pipeline.ts` | Scoped `YieldFrom`, `Sink`, and discriminated pipe results. | Readers connecting push-style producers to pull-style receivers. | `node --import tsx examples/intermediate/yield-sink-pipeline.ts` |

--- a/examples/intermediate/uninterruptible-mask.ts
+++ b/examples/intermediate/uninterruptible-mask.ts
@@ -1,17 +1,18 @@
-import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise, uninterruptibleMask } from '@briancavalier/fx'
-import { firstSettled, race, unbounded } from '@briancavalier/fx/concurrent'
+import { assert as assertNoFail, consoleLog, control, defaultConsole, fx, runPromise, uninterruptibleMask } from '@briancavalier/fx'
+import { unbounded } from '@briancavalier/fx/concurrent'
 
-import { andFinallyExit, scope } from '@briancavalier/fx/scope'
+import { andFinallyExit, InterruptFrom, scope } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
+import { timeout } from '@briancavalier/fx/timeout'
 
 /*
  * `uninterruptibleMask` keeps a short critical section safe from interruption,
  * while `restore` makes the long-running use phase interruptible again.
  *
- * The fast branch wins the race while the slow branch is still acquiring its
- * resource. Interruption is deferred until the acquire/register section
- * completes, so cleanup is registered before the slow branch is interrupted.
+ * The timeout fires while the slow operation is still acquiring its resource.
+ * Interruption is deferred until the acquire/register section completes, so
+ * cleanup is registered before the slow operation is interrupted.
  */
 
 const ExampleScope = 'examples/intermediate/uninterruptible-mask' as const
@@ -32,7 +33,10 @@ const useResource = (resource: string) => fx(function* () {
 const slow = uninterruptibleMask(restore => fx(function* () {
   const resource = yield* acquireResource
   yield* andFinallyExit(ExampleScope, exit => fx(function* () {
-    yield* consoleLog(`slow: releasing ${resource} after ${exit.type}`)
+    const reason = exit.type === 'interrupted' && exit.reason instanceof Error
+      ? ` (${exit.reason.message})`
+      : ''
+    yield* consoleLog(`slow: releasing ${resource} after ${exit.type}${reason}`)
     yield* sleep(100)
     yield* consoleLog(`slow: released ${resource}`)
   }))
@@ -41,21 +45,18 @@ const slow = uninterruptibleMask(restore => fx(function* () {
   return 'slow result'
 }))
 
-const fast = fx(function* () {
-  yield* consoleLog('fast: starting')
-  yield* sleep(50)
-  yield* consoleLog('fast: done')
-  return 'fast result'
-})
-
 const main = fx(function* () {
-  const result = yield* race([slow, fast])
-  yield* consoleLog('winner:', result)
+  const result = yield* slow.pipe(
+    timeout(ExampleScope, { ms: 50 })
+  )
+  yield* consoleLog('result:', result)
 })
 
 await main.pipe(
-  firstSettled,
   scope(ExampleScope),
+  control(InterruptFrom, () => fx(function* () {
+    yield* consoleLog('result: timed out')
+  })),
   defaultTime,
   unbounded,
   defaultConsole,

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,7 +19,7 @@ Rules for changes:
 - Prefer this module order: effect declaration, public constructors/combinators, public handlers, exported support types, internal handler functions, internal helper types/functions.
 - Effect constructor/combinator docs should describe the requested effect. Avoid promising semantics that are determined by handlers.
 - Handler docs should describe the interpretation that handler provides.
-- Prefer pipeable constructors for higher-order effects, e.g. `fx.pipe(retry(options))` or `fx.pipe(timeout(options))`.
+- Prefer pipeable constructors for higher-order effects, e.g. `fx.pipe(retry(options))` or `fx.pipe(timeout(RequestScope, options))`.
 - Prefer options objects once an effect constructor has more than one meaningful option or likely future extension point.
 - For higher-order scoped effects, preserve effect typing through the request and handler. If failures cross fork/race/task boundaries, convert them to data before racing unless runtime semantics explicitly preserve typed failures.
 - When default handlers create errors asynchronously or after handler interpretation, preserve request-site diagnostics with `Breadcrumb`/cause chaining rather than overwriting stacks.

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -636,7 +636,7 @@ describe('Fork', () => {
 })
 
 describe('Task interruption finalization', () => {
-  it('explicit task disposal releases scoped finalizers', async () => {
+  it('explicit task interruption releases scoped finalizers', async () => {
     const TestScope = 'test/Fork/DisposeScope' as const
     const released = [] as string[]
 
@@ -654,12 +654,12 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(released, ['task'])
   })
 
-  it('runs interrupted scoped finalizers once when task disposal is repeated', async () => {
+  it('runs interrupted scoped finalizers once when task interruption is repeated', async () => {
     const TestScope = 'test/Fork/DisposeOnceScope' as const
     const released = [] as string[]
 
@@ -677,8 +677,8 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
-    await task._disposeAndWait()
+    await task.interrupt()
+    await task.interrupt()
 
     assert.deepEqual(released, ['task'])
   })
@@ -701,12 +701,12 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope }])
   })
 
-  it('disposes queued bounded tasks before semaphore acquisition', async () => {
+  it('interrupts queued bounded tasks before semaphore acquisition', async () => {
     const events = [] as string[]
     const child = (label: string) => fx(function* () {
       events.push(`start ${label}`)
@@ -724,16 +724,16 @@ describe('Task interruption finalization', () => {
     )
 
     assert.deepEqual(events, ['start first'])
-    await withTimeout(tasks[1]._disposeAndWait(), 100)
+    await withTimeout(tasks[1].interrupt(), 100)
 
-    await tasks[0]._disposeAndWait()
+    await tasks[0].interrupt()
     await eventually(() => events.includes('start third'))
     assert.deepEqual(events, ['start first', 'start third'])
 
-    await tasks[2]._disposeAndWait()
+    await tasks[2].interrupt()
   })
 
-  it('runs async effects in interrupted finalizers before disposal completes', async () => {
+  it('runs async effects in interrupted finalizers before interruption completes', async () => {
     const TestScope = 'test/Fork/InterruptedAsyncFinalizer' as const
     const released = [] as string[]
 
@@ -752,7 +752,7 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(released, ['task'])
   })
@@ -779,7 +779,7 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(released, ['inner'])
   })
@@ -810,7 +810,7 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(released, ['scope', 'inner'])
   })
@@ -926,7 +926,7 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(released, ['task'])
   })
@@ -951,7 +951,7 @@ describe('Task interruption finalization', () => {
       runPromise
     ))
 
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.deepEqual(released, ['task'])
   })

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -77,7 +77,7 @@ export const fork = <const E, const A>(
  * handles.
  *
  * `forkEach` is the explicit handle-based form of concurrency. The caller owns
- * each returned task and decides when to wait for or dispose it.
+ * each returned task and decides when to wait for or interrupt it.
  */
 export const forkEach = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   fxs: Fxs,
@@ -320,56 +320,56 @@ type TaskErrorsOf<Tasks extends readonly Task<unknown, unknown>[]> = {
 
 const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
   tasks.forEach(t => t._markHandled())
-  const d = new DisposeAll(tasks)
+  const d = new InterruptAll(tasks)
   const p = Promise.all(tasks.map(t => t.promise)).then(
     async value => {
-      const cleanupFailures = await d.disposeAndWait()
+      const cleanupFailures = await d.interrupt()
       if (cleanupFailures.length > 0) throw resourceReleaseFailed(cleanupFailures)
       return value
     },
     async failure => {
-      const cleanupFailures = await d.disposeAndWait()
+      const cleanupFailures = await d.interrupt()
       if (cleanupFailures.length > 0) throw resourceReleaseFailed([failure, ...cleanupFailures])
       throw failure
     }
   )
-  return new Task(p, d, currentRuntimeContext(), d.disposed) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
+  return new Task(p, reason => { void d.interrupt(reason) }, currentRuntimeContext(), d.interrupted) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
 }
 
 const taskRace = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
   tasks.forEach(t => t._markHandled())
-  const d = new DisposeAll(tasks)
+  const d = new InterruptAll(tasks)
   const p = Promise.race(tasks.map(t => t.promise)).then(
     async value => {
-      const cleanupFailures = await d.disposeAndWait()
+      const cleanupFailures = await d.interrupt()
       if (cleanupFailures.length > 0) throw resourceReleaseFailed(cleanupFailures)
       return value as TaskResult<Tasks[number]>
     },
     async failure => {
-      const cleanupFailures = await d.disposeAndWait()
+      const cleanupFailures = await d.interrupt()
       if (cleanupFailures.length > 0) throw resourceReleaseFailed([failure, ...cleanupFailures])
       throw failure
     }
   )
-  return new Task(p, d, currentRuntimeContext(), d.disposed) as Task<TaskResult<Tasks[number]>, TaskErrors<Tasks[number]>>
+  return new Task(p, reason => { void d.interrupt(reason) }, currentRuntimeContext(), d.interrupted) as Task<TaskResult<Tasks[number]>, TaskErrors<Tasks[number]>>
 }
 
 const taskFirstSuccess = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
   tasks.forEach(t => t._markHandled())
-  const d = new DisposeAll(tasks)
+  const d = new InterruptAll(tasks)
   const p = firstSuccessfulPromise(tasks).then(
     async value => {
-      const cleanupFailures = await d.disposeAndWait()
+      const cleanupFailures = await d.interrupt()
       if (cleanupFailures.length > 0) throw resourceReleaseFailed(cleanupFailures)
       return value
     },
     async failure => {
-      const cleanupFailures = await d.disposeAndWait()
+      const cleanupFailures = await d.interrupt()
       if (cleanupFailures.length > 0) throw resourceReleaseFailed([failure, ...cleanupFailures])
       throw failure
     }
   )
-  return new Task(p, d, currentRuntimeContext(), d.disposed) as Task<TaskResult<Tasks[number]>, RaceAllFailed<TaskErrorsOf<Tasks>>>
+  return new Task(p, reason => { void d.interrupt(reason) }, currentRuntimeContext(), d.interrupted) as Task<TaskResult<Tasks[number]>, RaceAllFailed<TaskErrorsOf<Tasks>>>
 }
 
 const firstSuccessfulPromise = async <Tasks extends readonly Task<unknown, unknown>[]>(
@@ -397,29 +397,27 @@ const firstSuccessfulPromise = async <Tasks extends readonly Task<unknown, unkno
   throw new RaceAllFailed(failures as TaskErrorsOf<Tasks>)
 }
 
-class DisposeAll {
-  private readonly disposedResolver = Promise.withResolvers<void>()
-  readonly disposed = this.disposedResolver.promise
-  private disposedPromise?: Promise<readonly unknown[]>
+class InterruptAll {
+  private readonly interruptedResolver = Promise.withResolvers<void>()
+  readonly interrupted = this.interruptedResolver.promise
+  private interruptedPromise?: Promise<readonly unknown[]>
 
   constructor(private readonly tasks: Iterable<Task<unknown, unknown>>) {
-    this.disposed.catch(() => { })
+    this.interrupted.catch(() => { })
   }
 
-  [Symbol.dispose]() { void this.disposeAndWait() }
-
-  disposeAndWait() {
-    this.disposedPromise ??= Promise.allSettled([...this.tasks].map(t => t._disposeAndWait())).then(
+  interrupt(reason?: unknown) {
+    this.interruptedPromise ??= Promise.allSettled([...this.tasks].map(t => t.interrupt(reason))).then(
       results => {
         const failures = results.flatMap(result =>
           result.status === 'rejected' ? cleanupFailuresOf(result.reason) : []
         )
-        if (failures.length > 0) this.disposedResolver.reject(resourceReleaseFailed(failures))
-        else this.disposedResolver.resolve()
+        if (failures.length > 0) this.interruptedResolver.reject(resourceReleaseFailed(failures))
+        else this.interruptedResolver.resolve()
         return failures
       }
     )
-    return this.disposedPromise
+    return this.interruptedPromise
   }
 }
 
@@ -427,7 +425,7 @@ const resourceReleaseFailed = (failures: readonly unknown[]) =>
   new AggregateError(failures, 'Resource release failed')
 
 const cleanupFailuresOf = (failure: unknown): readonly unknown[] => {
-  // TODO: Investigate focused unwrapping for disposal-time ForkError wrappers
+  // TODO: Investigate focused unwrapping for interruption-time ForkError wrappers
   // around rejected Async cleanup, while preserving useful runtime traces.
   const cleanupFailure = isResourceReleaseFailure(failure)
     ? failure

--- a/src/HttpServer.test.ts
+++ b/src/HttpServer.test.ts
@@ -28,7 +28,6 @@ import { NodeHttpError, nodeHttp, type NodeHttpServerFactory } from './HttpServe
 import { HandlerCapture } from './HandlerCapture.js'
 import type { Interrupt } from './Interrupt.js'
 import { brand } from './Scope.js'
-import { dispose } from './Task.js'
 import { YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 const HttpServerEvents = brand<Yielding<ServerEvent>>()('test/HttpServer/events')
@@ -556,7 +555,7 @@ describe('HttpServer', () => {
         await assert.rejects(task.promise, error => error instanceof Error && error.cause === failure)
         assert.equal(closeCalled, true)
       } finally {
-        dispose(task)
+        await task.interrupt()
       }
     })
   })
@@ -629,7 +628,7 @@ const withServer = async (
   try {
     await test(port)
   } finally {
-    dispose(task)
+    await task.interrupt()
     await new Promise(resolve => setTimeout(resolve, 1))
   }
 }

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -134,7 +134,7 @@ describe('Interrupt masking', () => {
     assert.deepEqual(events, ['cleanup'])
   })
 
-  it('defers disposal during a masked async computation', async () => {
+  it('defers interruption during a masked async computation', async () => {
     let resolve!: () => void
     let aborted = false
 
@@ -146,11 +146,11 @@ describe('Interrupt masking', () => {
     }))))
 
     await eventually(() => resolve !== undefined)
-    const disposed = task._disposeAndWait()
+    const interrupted = task.interrupt()
 
     assert.equal(aborted, false)
     resolve()
-    await disposed
+    await interrupted
     assert.equal(aborted, false)
   })
 
@@ -176,9 +176,9 @@ describe('Interrupt masking', () => {
     )
 
     await eventually(() => resolve !== undefined)
-    const disposed = task._disposeAndWait()
+    const interrupted = task.interrupt()
     resolve('resource')
-    await disposed
+    await interrupted
 
     assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope }])
   })
@@ -202,11 +202,11 @@ describe('Interrupt masking', () => {
     )
 
     await eventually(() => resolve !== undefined)
-    const disposed = task._disposeAndWait()
+    const interrupted = task.interrupt()
     resolve(managed('resource', exit => fx(function* () {
       exits.push(exit)
     })))
-    await disposed
+    await interrupted
 
     assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope }])
   })
@@ -226,9 +226,9 @@ describe('Interrupt masking', () => {
     ).pipe(runTask)
 
     await eventually(() => resolve !== undefined)
-    const disposed = task._disposeAndWait()
+    const interrupted = task.interrupt()
     resolve('resource')
-    await disposed
+    await interrupted
 
     assert.deepEqual(released, ['resource'])
   })
@@ -247,7 +247,7 @@ describe('Interrupt masking', () => {
     })))
 
     await eventually(() => restoreStarted)
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.equal(restoreAborted, true)
   })
@@ -301,7 +301,7 @@ describe('Interrupt masking', () => {
     })))
 
     await eventually(() => started)
-    await task._disposeAndWait()
+    await task.interrupt()
 
     assert.equal(aborted, true)
   })
@@ -320,9 +320,9 @@ describe('Interrupt masking', () => {
     })))
 
     await eventually(() => resolveInner !== undefined)
-    const disposed = task._disposeAndWait()
+    const interrupted = task.interrupt()
     resolveInner()
-    await disposed
+    await interrupted
 
     assert.deepEqual(events, ['outer start', 'inner start', 'outer end'])
   })
@@ -347,12 +347,12 @@ describe('Interrupt masking', () => {
     }))))
 
     await eventually(() => restoreStarted)
-    const disposed = task._disposeAndWait()
+    const interrupted = task.interrupt()
     await Promise.resolve()
 
     assert.equal(restoreAborted, false)
     resolveRestore()
-    await disposed
+    await interrupted
 
     assert.deepEqual(events, ['outer start', 'outer end'])
     assert.equal(restoreAborted, false)

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -2,13 +2,77 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
-import { fail, returnFail } from './Fail.js'
+import { fail, Fail, returnFail } from './Fail.js'
 import { firstSettled, race, unbounded } from './Concurrent.js'
-import { managed, using, usingManaged } from './Finalization.js'
+import { andFinally, andFinallyExit, managed, using, usingManaged } from './Finalization.js'
 import { bracket, fx, ok, run, runPromise, runTask, type Fx } from './Fx.js'
 import { control, handle } from './Handler.js'
+import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
 import { scope, type Exit } from './Scope.js'
+
+describe('Typed interruption', () => {
+  const TestScope = 'test/InterruptFrom' as const
+
+  it('provides the reason to exit-aware finalizers', () => {
+    const reason = { type: 'test-interrupt' }
+    const exits = [] as Exit[]
+
+    const result = fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
+        exits.push(exit)
+      }))
+      yield* interruptFrom(TestScope, reason)
+    }).pipe(
+      scope(TestScope),
+      control(InterruptFrom, () => ok('interrupted')),
+      returnFail,
+      run
+    )
+
+    assert.equal(result, 'interrupted')
+    assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope, reason }])
+  })
+
+  it('leaves the interrupt visible after scope cleanup', () => {
+    const f = interruptFrom(TestScope).pipe(scope(TestScope))
+    const next = f[Symbol.iterator]().next()
+
+    assert.equal(InterruptFrom.is(next.value), true)
+    assert.equal((next.value as InterruptFrom<typeof TestScope>).scope, TestScope)
+  })
+
+  it('does not handle interrupts from a different scope', () => {
+    const OtherScope = 'test/InterruptFrom/other' as const
+    const f = fx(function* () {
+      yield* interruptFrom(OtherScope)
+      return 'done'
+    }).pipe(scope(TestScope))
+
+    const next = f[Symbol.iterator]().next()
+
+    assert.equal(InterruptFrom.is(next.value), true)
+    assert.equal((next.value as InterruptFrom<typeof OtherScope>).scope, OtherScope)
+  })
+
+  it('surfaces cleanup failures before re-yielding the interrupt', () => {
+    const cleanupFailure = new Error('cleanup failed')
+
+    const result = fx(function* () {
+      yield* andFinally(TestScope, fail(cleanupFailure))
+      yield* interruptFrom(TestScope)
+    }).pipe(
+      scope(TestScope),
+      control(InterruptFrom, () => ok('interrupted')),
+      returnFail,
+      run
+    )
+
+    assert.ok(result instanceof Fail)
+    assert.ok(result.arg instanceof AggregateError)
+    assert.deepEqual(result.arg.errors, [cleanupFailure])
+  })
+})
 
 describe('Interrupt masking', () => {
   it('is transparent for pure computations', () => {

--- a/src/InterruptFrom.ts
+++ b/src/InterruptFrom.ts
@@ -1,0 +1,23 @@
+import { at } from './Breadcrumb.js'
+import { ScopedEffect, withOrigin } from './Effect.js'
+import { Fx } from './Fx.js'
+
+/**
+ * Interrupt the named scope.
+ */
+export class InterruptFrom<const Scope extends string, Reason = undefined>
+  extends ScopedEffect('fx/InterruptFrom')<Scope, Reason, never> { }
+
+export function interruptFrom<const Scope extends string>(
+  scope: Scope
+): Fx<InterruptFrom<Scope>, never>
+export function interruptFrom<const Scope extends string, const Reason>(
+  scope: Scope,
+  reason: Reason
+): Fx<InterruptFrom<Scope, Reason>, never>
+export function interruptFrom(scope: string, reason?: unknown): Fx<InterruptFrom<string, unknown>, never> {
+  return withOrigin(
+    new InterruptFrom(scope, reason),
+    at('fx/InterruptFrom/interruptFrom', interruptFrom)
+  )
+}

--- a/src/NodeProcess.test.ts
+++ b/src/NodeProcess.test.ts
@@ -75,7 +75,7 @@ describe('NodeProcess', () => {
     assert.equal(process.count('SIGINT'), 1)
     assert.equal(process.count('SIGTERM'), 1)
 
-    task[Symbol.dispose]()
+    await task.interrupt()
     await tick()
 
     assert.equal(process.count('SIGINT'), 0)

--- a/src/NodeRuntime.ts
+++ b/src/NodeRuntime.ts
@@ -49,7 +49,7 @@ export const runNodePromise = <const E extends NodeRuntimeEffects>(
     if (shuttingDown) return
     shuttingDown = true
     cleanup()
-    void task._disposeAndWait().then(stopped.resolve, stopped.reject)
+    void task.interrupt().then(stopped.resolve, stopped.reject)
   }
 
   if (signals !== false) {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -4,10 +4,11 @@ import { Fail, fail, returnFail } from './Fail.js'
 import { Finalizer, Finally } from './Finalization.js'
 import { Fx, fx } from './Fx.js'
 import { CapturedHandler, HandlerCapture } from './HandlerCapture.js'
+import { InterruptFrom } from './InterruptFrom.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { drainIteratorReturn, isInterpretingReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
-import { withActiveScope } from './internal/runtimeContext.js'
+import { interruptionReason, withActiveScope } from './internal/runtimeContext.js'
 
 export const brand = <Brand>() =>
   <const Name extends string>(name: Name): Name & Brand =>
@@ -49,6 +50,7 @@ export interface Aborted<Scope extends string> {
 export interface Interrupted<Scope extends string> {
   readonly type: 'interrupted'
   readonly scope: Scope
+  readonly reason?: unknown
 }
 
 export function scope<const Scope extends string>(
@@ -127,6 +129,11 @@ class ScopeBoundary<E, A, Scope extends string> implements Fx<unknown, A>, Pipea
             const failures = yield* release(exit)
             if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A
             return (yield effect) as A
+          } else if (sameScope && InterruptFrom.is(effect)) {
+            const exit = interruptedExit(scopeName, effect.arg)
+            const failures = yield* release(exit)
+            if (failures.length > 0) return (yield* withActiveScope(scopeName, failCleanup(failures))) as A
+            return (yield effect) as A
           } else if (Fail.is(effect)) {
             const exit = { type: 'failure', failure: effect } satisfies Exit
             const failures = yield* release(exit)
@@ -169,7 +176,7 @@ const collectInterruptedCleanupFailures = function* <A, Scope extends string>(
   step: (ir: IteratorResult<unknown, A>) => Generator<unknown, A, unknown>
 ): Generator<unknown, readonly unknown[], unknown> {
   const failures = [] as unknown[]
-  const exit = { type: 'interrupted', scope: scopeName } satisfies Exit<Scope>
+  const exit = interruptedExit(scopeName, interruptionReason())
 
   yield* collectCleanupFailures(failures, function* () {
     failures.push(...yield* release(exit))
@@ -186,6 +193,11 @@ const collectInterruptedCleanupFailures = function* <A, Scope extends string>(
 
   return failures
 }
+
+const interruptedExit = <Scope extends string>(scope: Scope, reason: unknown): Exit<Scope> =>
+  reason === undefined
+    ? { type: 'interrupted', scope }
+    : { type: 'interrupted', scope, reason }
 
 const collectCleanupFailures = function* (
   failures: unknown[],

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -5,40 +5,31 @@ import type { RuntimeContext } from './internal/runtimeContext.js'
 import { withActiveRuntimeContext } from './internal/runtimeContext.js'
 
 export class Task<A, E> {
-  private disposed = false
+  private interrupted = false
   private handled = false
   public readonly E!: E
 
   constructor(
     public readonly promise: Promise<A>,
-    private readonly dispose: Disposable,
+    private readonly interruptTask: (reason?: unknown) => void,
     public readonly _runtimeContext?: RuntimeContext,
-    private readonly disposedPromise: Promise<void> = Promise.resolve()
+    private readonly interruptedPromise: Promise<void> = Promise.resolve()
   ) {
-    this.disposedPromise.catch(() => { })
+    this.interruptedPromise.catch(() => { })
   }
 
-  [Symbol.dispose]() {
-    this.disposeWithReason(undefined)
-  }
-
-  private disposeWithReason(reason: unknown) {
-    if (this.disposed) return
-    this.disposed = true
-    this.promise.catch(() => { })
-    if (isReasonedDisposable(this.dispose)) this.dispose._disposeWithReason(reason)
-    else this.dispose[Symbol.dispose]()
-  }
-
-  /** @internal Runtime-owned disposal helper. */
-  async _disposeAndWait(reason?: unknown) {
-    this.disposeWithReason(reason)
-    await this.disposedPromise
+  async interrupt(reason?: unknown) {
+    if (!this.interrupted) {
+      this.interrupted = true
+      this.promise.catch(() => { })
+      this.interruptTask(reason)
+    }
+    await this.interruptedPromise
   }
 
   /** @internal Runtime-owned unhandled fork diagnostic state. */
-  get _disposed() {
-    return this.disposed
+  get _interrupted() {
+    return this.interrupted
   }
 
   /** @internal Runtime-owned unhandled fork diagnostic state. */
@@ -52,24 +43,14 @@ export class Task<A, E> {
   }
 }
 
-interface ReasonedDisposable extends Disposable {
-  _disposeWithReason(reason: unknown): void
-}
-
-const isReasonedDisposable = (d: Disposable): d is ReasonedDisposable =>
-  '_disposeWithReason' in d
-
-export const dispose = <const A, const E>(t: Task<A, E>) =>
-  t[Symbol.dispose]()
-
 export const wait = <const A, const E>(t: Task<A, E>) =>
   flatten(assertPromise<Fx<E | Fail<unknown>, A>>(
     s => {
       t._markHandled()
-      const dispose = () => t[Symbol.dispose]()
-      s.addEventListener('abort', dispose)
+      const interrupt = () => { void t.interrupt() }
+      s.addEventListener('abort', interrupt)
 
-      const p = t.promise.finally(() => s.removeEventListener('abort', dispose))
+      const p = t.promise.finally(() => s.removeEventListener('abort', interrupt))
       const context = t._runtimeContext
       return context === undefined
         ? p.then(ok, fail)

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -19,15 +19,20 @@ export class Task<A, E> {
   }
 
   [Symbol.dispose]() {
+    this.disposeWithReason(undefined)
+  }
+
+  private disposeWithReason(reason: unknown) {
     if (this.disposed) return
     this.disposed = true
     this.promise.catch(() => { })
-    this.dispose[Symbol.dispose]()
+    if (isReasonedDisposable(this.dispose)) this.dispose._disposeWithReason(reason)
+    else this.dispose[Symbol.dispose]()
   }
 
   /** @internal Runtime-owned disposal helper. */
-  async _disposeAndWait() {
-    this[Symbol.dispose]()
+  async _disposeAndWait(reason?: unknown) {
+    this.disposeWithReason(reason)
     await this.disposedPromise
   }
 
@@ -46,6 +51,13 @@ export class Task<A, E> {
     this.handled = true
   }
 }
+
+interface ReasonedDisposable extends Disposable {
+  _disposeWithReason(reason: unknown): void
+}
+
+const isReasonedDisposable = (d: Disposable): d is ReasonedDisposable =>
+  '_disposeWithReason' in d
 
 export const dispose = <const A, const E>(t: Task<A, E>) =>
   t[Symbol.dispose]()

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -1,27 +1,34 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { unbounded } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
-import { handle } from './Handler.js'
-import { TimeoutError, defaultTimeout, timeout } from './Timeout.js'
+import { andFinallyExit } from './Finalization.js'
+import { control } from './Handler.js'
+import { InterruptFrom } from './InterruptFrom.js'
+import { scope, type Exit } from './Scope.js'
+import { TimeoutInterrupt, timeout } from './Timeout.js'
 import { sleep, withClock } from './Time.js'
-import { getTrace, snapshotError } from './Trace.js'
+import { getTrace } from './Trace.js'
 import { VirtualClock } from './internal/time.js'
 
 describe('Timeout', () => {
+  const TestScope = 'test/Timeout' as const
+
   it('returns the result when the Fx completes before the timeout', async () => {
     const c = new VirtualClock(0)
+    let reasons = 0
 
-    const f = fx(function* () {
+    const p = fx(function* () {
       yield* sleep(50)
       return 'ok'
-    })
-
-    const p = f.pipe(
-      timeout({ ms: 100 }),
-      defaultTimeout(),
+    }).pipe(
+      timeout(TestScope, {
+        ms: 100,
+        reason: () => void (reasons += 1)
+      }),
+      scope(TestScope),
+      control(InterruptFrom, () => ok('interrupted')),
       returnFail,
       unbounded,
       withClock(c),
@@ -33,43 +40,25 @@ describe('Timeout', () => {
 
     assert.ok(!Fail.is(r))
     assert.equal(r, 'ok')
+    assert.equal(reasons, 0)
   })
 
-  it('does not call onTimeout when the Fx completes before the timeout', async () => {
+  it('interrupts the scope with the timeout reason when the timeout wins', async () => {
     const c = new VirtualClock(0)
-    let timeouts = 0
-
-    const p = sleep(50).pipe(
-      timeout({ ms: 100, onTimeout: () => void (timeouts += 1) }),
-      defaultTimeout(),
-      returnFail,
-      unbounded,
-      withClock(c),
-      runPromise
-    )
-
-    assert.equal(timeouts, 0)
-
-    await c.step(50)
-    const r = await p
-
-    assert.ok(!Fail.is(r))
-    assert.equal(timeouts, 0)
-  })
-
-  it('fails with TimeoutError when the timeout wins', async () => {
-    const c = new VirtualClock(0)
+    const reason = { type: 'timeout' }
+    const exits = [] as Exit[]
     let completed = false
 
-    const f = fx(function* () {
+    const p = fx(function* () {
+      yield* andFinallyExit(TestScope, exit => fx(function* () {
+        exits.push(exit)
+      }))
       yield* sleep(100)
       completed = true
-      return 'late'
-    })
-
-    const p = f.pipe(
-      timeout({ ms: 50 }),
-      defaultTimeout(),
+    }).pipe(
+      timeout(TestScope, { ms: 50, reason: () => reason }),
+      scope(TestScope),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       returnFail,
       unbounded,
       withClock(c),
@@ -79,20 +68,24 @@ describe('Timeout', () => {
     await c.step(50)
     const r = await p
 
-    assert.ok(Fail.is(r))
-    assert.ok(r.arg instanceof TimeoutError)
-    assert.equal(r.arg.ms, 50)
-
-    await c.step(50)
+    assert.equal(r, reason)
     assert.equal(completed, false)
+    assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope, reason }])
   })
 
-  it('preserves the timeout call site as the default TimeoutError cause', async () => {
+  it('uses a trace-bearing TimeoutInterrupt as the default reason', async () => {
     const c = new VirtualClock(0)
+    let exit!: Exit
 
-    const p = sleep(100).pipe(
-      timeout({ ms: 50 }),
-      defaultTimeout(),
+    const p = fx(function* () {
+      yield* andFinallyExit(TestScope, e => fx(function* () {
+        exit = e
+      }))
+      yield* sleep(100)
+    }).pipe(
+      timeout(TestScope, { ms: 50 }),
+      scope(TestScope),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       returnFail,
       unbounded,
       withClock(c),
@@ -100,29 +93,29 @@ describe('Timeout', () => {
     )
 
     await c.step(50)
-    const r = await p
+    const reason = await p
 
-    assert.ok(Fail.is(r))
-    assert.ok(r.arg instanceof TimeoutError)
-    assert.equal(r.arg.code, 'FX_TIMEOUT')
-    assert.ok(r.arg.cause instanceof Error)
-    assert.match(r.arg.cause.stack ?? '', /Timeout\.test\.ts/)
-    assert.deepEqual(traceMessages(r.arg).slice(0, 1), ['Timeout requested after 50ms'])
-    assert.equal(snapshotError(r.arg).trace?.frames[0].kind, 'timeout')
+    assert.ok(reason instanceof TimeoutInterrupt)
+    assert.equal(reason.ms, 50)
+    assert.equal(reason.code, 'FX_TIMEOUT_INTERRUPT')
+    assert.ok(reason.cause instanceof Error)
+    assert.match(reason.cause.stack ?? '', /Timeout\.test\.ts/)
+    assert.deepEqual(traceMessages(reason).slice(0, 1), [`Timeout interrupted ${TestScope} after 50ms`])
+    assert.equal(exit.type, 'interrupted')
+    assert.equal(exit.reason, reason)
   })
 
   it('preserves original failures when the Fx fails before the timeout', async () => {
     const c = new VirtualClock(0)
 
-    const f = fx(function* () {
+    const p = fx(function* () {
       yield* sleep(50)
       yield* fail('failed')
       return 'unreachable'
-    })
-
-    const p = f.pipe(
-      timeout({ ms: 100 }),
-      defaultTimeout(),
+    }).pipe(
+      timeout(TestScope, { ms: 100 }),
+      scope(TestScope),
+      control(InterruptFrom, () => ok('interrupted')),
       returnFail,
       unbounded,
       withClock(c),
@@ -136,66 +129,47 @@ describe('Timeout', () => {
     assert.equal(r.arg, 'failed')
   })
 
-  it('uses a custom timeout failure value', async () => {
+  it('waits for interrupted cleanup before settling', async () => {
     const c = new VirtualClock(0)
+    const events = [] as string[]
+    let settled = false
 
-    class CustomTimeout extends Error {
-      readonly name = 'CustomTimeout'
-      readonly code = 'TimedOut'
-
-      constructor(readonly ms: number, options?: ErrorOptions) {
-        super(`Custom timeout after ${ms}ms`, options)
-      }
-    }
-
-    const p = sleep(100).pipe(
-      timeout({ ms: 50, onTimeout: ({ ms, origin }) => new CustomTimeout(ms, { cause: origin }) }),
-      defaultTimeout(),
+    const p = fx(function* () {
+      yield* andFinallyExit(TestScope, () => fx(function* () {
+        events.push('cleanup:start')
+        yield* sleep(25)
+        events.push('cleanup:end')
+      }))
+      yield* sleep(100)
+    }).pipe(
+      timeout(TestScope, { ms: 50 }),
+      scope(TestScope),
+      control(InterruptFrom, () => ok('interrupted')),
       returnFail,
       unbounded,
       withClock(c),
       runPromise
-    )
+    ).then(r => {
+      settled = true
+      return r
+    })
 
     await c.step(50)
-    const r = await p
+    await Promise.resolve()
 
-    assert.ok(Fail.is(r))
-    assert.ok(r.arg instanceof CustomTimeout)
-    assert.equal(r.arg.ms, 50)
-    assert.ok(r.arg.cause instanceof Error)
-    assert.match(r.arg.cause.stack ?? '', /Timeout\.test\.ts/)
+    assert.equal(settled, false)
+    assert.deepEqual(events, ['cleanup:start'])
+
+    await c.step(25)
+    assert.equal(await p, 'interrupted')
+    assert.equal(settled, true)
+    assert.deepEqual(events, ['cleanup:start', 'cleanup:end'])
   })
 
-  it('runs timed Fx with the captured handler context', async () => {
-    class CurrentValue extends Effect('test/Timeout/CurrentValue')<void, string> { }
-
-    const c = new VirtualClock(0)
-
-    const f = fx(function* () {
-      yield* sleep(50)
-      return yield* new CurrentValue()
-    }).pipe(
-      timeout({ ms: 100 }),
-      handle(CurrentValue, () => ok('handled')),
-      defaultTimeout(),
-      returnFail,
-      unbounded,
-      withClock(c)
-    )
-
-    const p = f.pipe(runPromise)
-    await c.step(50)
-    const r = await p
-
-    assert.ok(!Fail.is(r))
-    assert.equal(r, 'handled')
-  })
-
-  it('does not handle timeout failures until defaultTimeout is applied', () => {
+  it('leaves timeout interruption visible until explicitly handled', () => {
     assert.throws(() => {
-      // @ts-expect-error Timeout is not handled
-      run(ok('ok').pipe(timeout({ ms: 1 })))
+      // @ts-expect-error Timeout interruption is not handled
+      run(ok('ok').pipe(timeout(TestScope, { ms: 1 }), scope(TestScope)))
     }, /Unhandled effect in run/)
   })
 })

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -44,7 +44,7 @@ export function timeout<const Scope extends string, const Reason>(
       if (result.type === 'success') return result.value
       if (result.type === 'failure') return yield* fail(result.failure)
 
-      yield* tryPromise(() => task._disposeAndWait(result.reason))
+      yield* tryPromise(() => task.interrupt(result.reason))
       return yield* interruptFrom(scope, result.reason)
     }) as Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<Scope, Reason | TimeoutInterrupt>, A>
 }

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -1,69 +1,62 @@
-import { Async } from './Async.js'
+import { Async, assertPromise, tryPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
-import { Fork, firstSettled, race } from './Concurrent.js'
-import { Effect } from './Effect.js'
+import { Fork, firstSettled, fork, race } from './Concurrent.js'
 import { Fail, catchAll, fail } from './Fail.js'
-import { Fx, flatMap, flatten, fx, map, ok } from './Fx.js'
-import { Handle } from './Handler.js'
-import { HandlerCapture, handleCaptured, withCapturedHandlers } from './HandlerCapture.js'
+import { Fx, fx, map, ok } from './Fx.js'
+import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
 import { Sleep, sleep } from './Time.js'
 import { attachTrace, captureTrace } from './Trace.js'
 import type { TraceOrigin } from './Trace.js'
 
 /**
- * A timeout effect. Programs yield {@link Timeout} values to request that a
- * computation be run with a time limit.
- */
-export class Timeout<const E, const A, const TE> extends Effect('fx/Timeout')<TimeoutContext<E, A, TE>, Fx<unknown, A>> { }
-
-/**
- * Request that an Fx be run with a timeout.
+ * Run an Fx with a time limit, interrupting the named scope when the timeout wins.
  *
- * @example
- * const result = await fetchUser.pipe(
- *   timeout({ ms: 1000 }),
- *   defaultTimeout(),
- *   defaultTime,
- *   unbounded,
- *   runPromise
- * )
+ * The interrupted scope runs its finalizers with a {@link TimeoutInterrupt}
+ * reason, then re-yields the matching {@link InterruptFrom} so callers choose
+ * how to recover or report the timeout.
  */
-export function timeout(options: DefaultTimeoutOptions): <const E, const A>(f: Fx<E, A>) => Fx<Exclude<E, Fail<any>> | Timeout<ErrorsOf<E>, A, TimeoutError> | HandlerCapture<'fx/Timeout'>, A>
-export function timeout<const TE>(options: TimeoutOptions<TE>): <const E, const A>(f: Fx<E, A>) => Fx<Exclude<E, Fail<any>> | Timeout<ErrorsOf<E>, A, TE> | HandlerCapture<'fx/Timeout'>, A>
-export function timeout<const TE>({ ms, onTimeout }: DefaultTimeoutOptions | TimeoutOptions<TE>) {
-  const origin = at(`Timeout requested after ${ms}ms`, timeout)
+export function timeout<const Scope extends string>(
+  scope: Scope,
+  options: DefaultTimeoutInterruptOptions
+): <const E, const A>(f: Fx<E, A>) => Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<Scope, TimeoutInterrupt>, A>
+export function timeout<const Scope extends string, const Reason>(
+  scope: Scope,
+  options: TimeoutInterruptOptions<Reason>
+): <const E, const A>(f: Fx<E, A>) => Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<Scope, Reason>, A>
+export function timeout<const Scope extends string, const Reason>(
+  scope: Scope,
+  { ms, reason }: DefaultTimeoutInterruptOptions | TimeoutInterruptOptions<Reason>
+) {
+  const origin = at(`Timeout interrupted ${scope} after ${ms}ms`, timeout)
   const trace = captureTrace(origin, undefined, { kind: 'timeout' })
-  return <const E, const A>(f: Fx<E, A>): Fx<Exclude<E, Fail<any>> | Timeout<ErrorsOf<E>, A, TE | TimeoutError> | HandlerCapture<'fx/Timeout'>, A> =>
-    withCapturedHandlers('fx/Timeout', f).pipe(
-      flatMap(fx =>
-        new Timeout<ErrorsOf<E>, A, TE | TimeoutError>({
-          fx,
-          ms,
-          origin,
-          trace,
-          onTimeout: onTimeout ?? defaultTimeoutError
-        }) as Fx<Timeout<ErrorsOf<E>, A, TE | TimeoutError>, Fx<Exclude<E, Fail<any>> | Timeout<ErrorsOf<E>, A, TE | TimeoutError>, A>>
-      ),
-      flatten
-    )
+  return <const E, const A>(f: Fx<E, A>): Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<Scope, Reason | TimeoutInterrupt>, A> =>
+    fx(function* () {
+      const task = yield* fork(attempt(f as Fx<Fail<ErrorsOf<E>>, A>), { origin, trace })
+      task._markHandled()
+      const result = yield* race([
+        assertPromise(() => task.promise as Promise<AttemptResult<ErrorsOf<E>, A>>),
+        sleep(ms).pipe(map(() => ({
+          type: 'timeout',
+          reason: reason === undefined ? makeTimeoutInterrupt({ ms, origin, trace }) : reason({ ms, origin, trace })
+        }) as const))
+      ], { origin, trace }).pipe(firstSettled)
+
+      if (result.type === 'success') return result.value
+      if (result.type === 'failure') return yield* fail(result.failure)
+
+      yield* tryPromise(() => task._disposeAndWait(result.reason))
+      return yield* interruptFrom(scope, result.reason)
+    }) as Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<Scope, Reason | TimeoutInterrupt>, A>
 }
 
-/**
- * Default handler for Timeout. Runs the computation and fails if it does not
- * complete within the requested time.
- */
-export const defaultTimeout = () =>
-  <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyTimeout, Fork | Sleep | Async | Fail<ErrorsOfTimeout<E> | TimeoutErrorOf<E>>>, HandlerCapture<'fx/Timeout'>>, A> =>
-    f.pipe(handleCaptured('fx/Timeout', Timeout, runTimeout)) as Fx<Handle<Handle<E, AnyTimeout, Fork | Sleep | Async | Fail<ErrorsOfTimeout<E> | TimeoutErrorOf<E>>>, HandlerCapture<'fx/Timeout'>>, A>
-
-export class TimeoutError extends Error {
-  readonly name = 'TimeoutError'
-  declare readonly code: 'FX_TIMEOUT'
+export class TimeoutInterrupt extends Error {
+  readonly name = 'TimeoutInterrupt'
+  declare readonly code: 'FX_TIMEOUT_INTERRUPT'
 
   constructor(readonly ms: number, options?: ErrorOptions) {
-    super(`Timed out after ${ms}ms`, options)
+    super(`Interrupted after ${ms}ms`, options)
     Object.defineProperty(this, 'code', {
-      value: 'FX_TIMEOUT',
+      value: 'FX_TIMEOUT_INTERRUPT',
       enumerable: false,
       writable: false,
       configurable: true
@@ -71,56 +64,37 @@ export class TimeoutError extends Error {
   }
 }
 
-export interface DefaultTimeoutOptions {
+export interface DefaultTimeoutInterruptOptions {
   readonly ms: number
-  readonly onTimeout?: undefined
+  readonly reason?: undefined
 }
 
-export interface TimeoutOptions<TE> {
+export interface TimeoutInterruptOptions<Reason> {
   readonly ms: number
-  readonly onTimeout: (e: TimeoutExpired) => TE
+  readonly reason: (e: TimeoutExpired) => Reason
 }
 
 export interface TimeoutExpired extends TraceOrigin {
   readonly ms: number
 }
 
-export interface TimeoutContext<_E, A, TE> extends TraceOrigin {
-  readonly fx: Fx<unknown, A>
-  readonly ms: number
-  readonly onTimeout: (e: TimeoutExpired) => TE
-}
-
 export type ErrorsOf<E> = UnwrapFail<Extract<E, Fail<any>>>
-export type ErrorsOfTimeout<E> = E extends Timeout<infer R, any, any> ? R : never
-export type TimeoutErrorOf<E> = E extends Timeout<any, any, infer TE> ? TE : never
 
-const runTimeout = <const E, const A, const TE>(timeout: Timeout<E, A, TE>): Fx<Fork | Sleep | Async, Fx<Fail<E | TE>, A>> => fx(function* () {
-  const t = timeout.arg
-  const result = yield* race([
-    attempt(t.fx as Fx<Fail<E>, A>),
-    sleep(t.ms).pipe(map(() => ({ type: 'timeout', failure: t.onTimeout(t) } as const)))
-  ], t).pipe(firstSettled)
-
-  return result.type === 'success' ? ok(result.value) : fail(result.failure)
-})
-
-const attempt = <const E, const A>(f: Fx<Fail<E>, A>): Fx<never, TimeoutResult<E, A, never>> =>
+const attempt = <const E, const A>(f: Fx<Fail<E>, A>): Fx<never, AttemptResult<E, A>> =>
   f.pipe(
     map(value => ({ type: 'success', value }) as const),
     catchAll(failure => ok({ type: 'failure', failure }) as Fx<never, Failure<E>>)
-  ) as Fx<never, TimeoutResult<E, A, never>>
+  ) as Fx<never, AttemptResult<E, A>>
 
-type AnyTimeout = Timeout<any, any, any> | Timeout<never, any, any>
 type UnwrapFail<F> = F extends Fail<infer E> ? E : never
 
-const defaultTimeoutError = ({ ms, origin, trace }: TimeoutExpired) => {
-  const error = new TimeoutError(ms, { cause: origin })
+const makeTimeoutInterrupt = ({ ms, origin, trace }: TimeoutExpired) => {
+  const error = new TimeoutInterrupt(ms, { cause: origin })
   if (trace !== undefined) attachTrace(error, trace)
   return error
 }
 
-type TimeoutResult<E, A, TE> = Success<A> | Failure<E> | TimedOut<TE>
+type AttemptResult<E, A> = Success<A> | Failure<E>
 
 interface Success<A> {
   readonly type: 'success'
@@ -130,9 +104,4 @@ interface Success<A> {
 interface Failure<E> {
   readonly type: 'failure'
   readonly failure: E
-}
-
-interface TimedOut<TE> {
-  readonly type: 'timeout'
-  readonly failure: TE
 }

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -6,11 +6,13 @@ import { all, defaultAll, firstSettled, fork, race, unbounded } from './Concurre
 import { Fail, fail, returnFail } from './Fail.js'
 import { andFinally } from './Finalization.js'
 import { fx, runPromise } from './Fx.js'
+import { control } from './Handler.js'
+import { InterruptFrom } from './InterruptFrom.js'
 import { defaultRetry, retry } from './Retry.js'
 import { scope } from './Scope.js'
 import { wait } from './Task.js'
 import { sleep, withClock } from './Time.js'
-import { TimeoutError, defaultTimeout, timeout } from './Timeout.js'
+import { TimeoutInterrupt, timeout } from './Timeout.js'
 import { MaxTraceDepth, appendTrace, attachTrace, captureTrace, formatDiagnostic, formatError, formatTrace, getTrace, getTraceCapturePolicy, prependTrace, setTraceCapturePolicy, snapshotError, snapshotTrace, withTraceCapture } from './Trace.js'
 import type { Trace, TraceOptions } from './Trace.js'
 import type { Breadcrumb } from './Breadcrumb.js'
@@ -403,18 +405,29 @@ describe('Trace', () => {
 
   it('propagates regional trace policy through timeout and retry handlers', async () => {
     const clock = new VirtualClock(0)
+    const TimeoutScope = 'test/Trace/timeout' as const
     const timeoutProgram = fx(function* () {
-      return yield* sleep(100).pipe(timeout({ ms: 50 }), defaultTimeout())
+      return yield* sleep(100).pipe(timeout(TimeoutScope, { ms: 50 }))
     })
 
-    const timeoutPromise = timeoutProgram.pipe(withTraceCapture('labels'), returnFail, unbounded, withClock(clock), runPromise)
+    const timeoutPromise = timeoutProgram.pipe(
+      scope(TimeoutScope),
+      control(InterruptFrom, (_, interrupt) => fx(function* () {
+        return interrupt.arg
+      })),
+      withTraceCapture('labels'),
+      returnFail,
+      unbounded,
+      withClock(clock),
+      runPromise
+    )
     await clock.step(50)
     const timeoutResult = await timeoutPromise
 
-    assert.ok(Fail.is(timeoutResult))
-    assert.ok(timeoutResult.arg instanceof TimeoutError)
-    assert.equal(snapshotError(timeoutResult.arg).trace?.frames[0]?.kind, 'timeout')
-    assert.equal(snapshotError(timeoutResult.arg).trace?.frames[0]?.location, undefined)
+    assert.ok(!Fail.is(timeoutResult))
+    assert.ok(timeoutResult instanceof TimeoutInterrupt)
+    assert.equal(snapshotError(timeoutResult).trace?.frames[0]?.kind, 'timeout')
+    assert.equal(snapshotError(timeoutResult).trace?.frames[0]?.location, undefined)
 
     const retryError = new Error('retry failed')
     const retryProgram = fx(function* () {

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -28,6 +28,7 @@ test('root export surface contains small-program core', () => {
   assert.equal(typeof Core.get, 'function')
   assert.equal(typeof Core.provideAll, 'function')
   assert.equal(typeof Core.Task, 'function')
+  assert.equal('dispose' in Core, false)
   assert.equal(typeof Core.consoleLog, 'function')
   assert.equal(typeof Core.defaultConsole, 'function')
   assert.equal(typeof Core.formatDiagnostic, 'function')

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -61,6 +61,7 @@ test('feature export surfaces group related functionality', () => {
   assert.equal(typeof Ref.of, 'function')
   assert.equal(typeof Retry.retry, 'function')
   assert.equal(typeof Scope.scope, 'function')
+  assert.equal(typeof Scope.interruptFrom, 'function')
   assert.equal(typeof Scope.yieldFrom, 'function')
   assert.equal(typeof Sink.next, 'function')
   assert.equal(typeof Time.sleep, 'function')

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -76,7 +76,7 @@ export {
   type Interrupt,
   type RestoreInterrupt
 } from '../Interrupt.js'
-export { dispose, Task, wait } from '../Task.js'
+export { Task, wait } from '../Task.js'
 export { at, indexed, type Breadcrumb } from '../Breadcrumb.js'
 export {
   formatDiagnostic,

--- a/src/exports/scope.ts
+++ b/src/exports/scope.ts
@@ -1,5 +1,6 @@
 export * from '../Abort.js'
 export * from '../Finalization.js'
+export * from '../InterruptFrom.js'
 export * from '../ReturnFrom.js'
 export * from '../Scope.js'
 export * from '../YieldFrom.js'

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -13,7 +13,7 @@ import { DisposableSet } from './disposable.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
 import { withInterpretedReturn } from './iteratorClose.js'
 import type { RuntimeContext } from './runtimeContext.js'
-import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext } from './runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
 
 export type RunForkOptions = TraceOptions & {
   readonly maxConcurrency?: number
@@ -85,9 +85,12 @@ const runForkLoop = async <const E, const A>(
 
   try {
     const i = iteratorWithRuntimeContext(f, runtimeContext)
-    const interrupt = async (cleanupMasks: readonly InterruptMaskBegin['arg'][] = disposables.maskSnapshot()): Promise<A> => {
+    const interrupt = async (
+      cleanupMasks: readonly InterruptMaskBegin['arg'][] = disposables.maskSnapshot(),
+      reason: unknown = disposables.interruptionReason
+    ): Promise<A> => {
       if (interrupting === undefined) {
-        interrupting = closeInterruptedIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed, cleanupMasks)
+        interrupting = closeInterruptedIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed, cleanupMasks, reason)
         interrupting.catch(() => { })
       }
       await interrupting
@@ -117,12 +120,14 @@ const closeInterruptedIterator = async <const E, const A>(
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
   disposed: PromiseWithResolvers<void>,
-  cleanupMasks: readonly InterruptMaskBegin['arg'][]
+  cleanupMasks: readonly InterruptMaskBegin['arg'][],
+  reason: unknown
 ): Promise<void> => {
   const cleanup = new InterruptState(cleanupMasks)
+  const cleanupContext = withInterruptionReason(runtimeContext, reason)
   try {
-    const ir = returnWithRuntimeContext(i, runtimeContext)
-    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, runtimeContext)
+    const ir = returnWithRuntimeContext(i, cleanupContext)
+    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, cleanupContext)
     disposed.resolve()
   } catch (e) {
     disposed.reject(e)
@@ -143,7 +148,7 @@ const runIterator = async <const E, const A>(
   unhandled: Promise<never>,
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
-  interrupt?: (masks?: readonly InterruptMaskBegin['arg'][]) => Promise<A>
+  interrupt?: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<A>
 ): Promise<A> => {
   while (!ir.done) {
     if (Async.is(ir.value)) {
@@ -208,9 +213,10 @@ const runIterator = async <const E, const A>(
 class InterruptState implements Disposable {
   private readonly disposables = new DisposableSet()
   private readonly masks: InterruptMaskState
-  private interrupt?: (masks?: readonly InterruptMaskBegin['arg'][]) => Promise<unknown>
+  private interrupt?: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<unknown>
   private interrupting?: Promise<unknown>
   private requested = false
+  private reason: unknown
 
   constructor(masks: readonly InterruptMaskBegin['arg'][] = []) {
     this.masks = new InterruptMaskState(masks)
@@ -220,11 +226,15 @@ class InterruptState implements Disposable {
     return this.requested
   }
 
+  get interruptionReason() {
+    return this.reason
+  }
+
   get canInterrupt() {
     return this.requested && this.masks.canInterrupt
   }
 
-  setInterrupt(interrupt: (masks?: readonly InterruptMaskBegin['arg'][]) => Promise<unknown>) {
+  setInterrupt(interrupt: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<unknown>) {
     this.interrupt = interrupt
     if (this.requested && this.masks.canInterrupt) void this.interruptNow(interrupt).catch(() => { })
   }
@@ -250,7 +260,12 @@ class InterruptState implements Disposable {
   }
 
   [Symbol.dispose]() {
+    this._disposeWithReason(undefined)
+  }
+
+  _disposeWithReason(reason: unknown) {
     this.requested = true
+    this.reason = reason
     if (!this.masks.canInterrupt) return
     this.disposeActive()
     if (this.interrupt !== undefined) void this.interruptNow(this.interrupt).catch(() => { })
@@ -260,9 +275,12 @@ class InterruptState implements Disposable {
     this.disposables[Symbol.dispose]()
   }
 
-  async interruptNow<A>(interrupt: (masks?: readonly InterruptMaskBegin['arg'][]) => Promise<A>, masks: readonly InterruptMaskBegin['arg'][] = this.maskSnapshot()): Promise<A> {
+  async interruptNow<A>(
+    interrupt: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<A>,
+    masks: readonly InterruptMaskBegin['arg'][] = this.maskSnapshot()
+  ): Promise<A> {
     this.disposeActive()
-    this.interrupting ??= interrupt(masks)
+    this.interrupting ??= interrupt(masks, this.reason)
     return await this.interrupting as A
   }
 }

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -29,11 +29,11 @@ export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCa
 
   const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, disposed, origin, trace, runtimeContext)
     .finally(() => {
-      disposables.disposeActive()
+      disposables.interruptActive()
       disposed.resolve()
     })
 
-  return taskWithRuntimeContext(promise, disposables, runtimeContext, disposed.promise)
+  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
 }
 
 export const acquireAndRunFork = (f: ForkContext, s: Semaphore, context: readonly CapturedHandler[] = [], runtimeContext: RuntimeContext | undefined = currentRuntimeContext()): Task<unknown, unknown> => {
@@ -43,11 +43,11 @@ export const acquireAndRunFork = (f: ForkContext, s: Semaphore, context: readonl
   const promise = acquire(s, disposables, disposed,
     () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, runtimeContext)
       .finally(() => {
-        disposables.disposeActive()
+        disposables.interruptActive()
         disposed.resolve()
       }))
 
-  return taskWithRuntimeContext(promise, disposables, runtimeContext, disposed.promise)
+  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
 }
 
 const runForkInternal = <const E, const A>(
@@ -133,7 +133,7 @@ const closeInterruptedIterator = async <const E, const A>(
     disposed.reject(e)
     throw e
   } finally {
-    cleanup.disposeActive()
+    cleanup.interruptActive()
   }
 }
 
@@ -155,8 +155,8 @@ const runIterator = async <const E, const A>(
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
       const { run, origin } = ir.value.arg
       const t = runTask(run, effectContext)
-      disposables.add(t)
-      const promise = t.promise.finally(() => disposables.remove(t))
+      disposables.addTask(t)
+      const promise = t.promise.finally(() => disposables.removeTask(t))
       let a
       try {
         a = await Promise.race([promise, unhandled])
@@ -166,7 +166,7 @@ const runIterator = async <const E, const A>(
         const asyncTrace = capturePrependTraceWithContext(effectContext, origin, trace, { kind: 'async' })
         throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext), effectContext, { cause: e })
       }
-      // stop if the scope was disposed while we were waiting
+      // stop if the scope was interrupted while we were waiting
       if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt)
       ir = resumeWithRuntimeContext(i, effectContext, a)
     } else if (Fork.is(ir.value)) {
@@ -174,12 +174,12 @@ const runIterator = async <const E, const A>(
       const forkOrigin = ir.value.arg.origin
       const forkTrace = capturePrependTraceWithContext(effectContext, forkOrigin, trace, forkFrameMetadata(ir.value.arg.trace))
       const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext)
-      disposables.add(t)
+      disposables.addTask(t)
       t.promise
-        .finally(() => disposables.remove(t))
+        .finally(() => disposables.removeTask(t))
         .catch(e => {
           queueMicrotask(() => {
-            if (t._handled || t._disposed || disposables.interruptRequested) return
+            if (t._handled || t._interrupted || disposables.interruptRequested) return
             rejectUnhandled(
               new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext), effectContext, { cause: e })
             )
@@ -210,10 +210,11 @@ const runIterator = async <const E, const A>(
   return ir.value as A
 }
 
-class InterruptState implements Disposable {
+class InterruptState {
   private readonly disposables = new DisposableSet()
+  private readonly tasks = new Set<Task<unknown, unknown>>()
   private readonly masks: InterruptMaskState
-  private interrupt?: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<unknown>
+  private interruptHandler?: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<unknown>
   private interrupting?: Promise<unknown>
   private requested = false
   private reason: unknown
@@ -235,7 +236,7 @@ class InterruptState implements Disposable {
   }
 
   setInterrupt(interrupt: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<unknown>) {
-    this.interrupt = interrupt
+    this.interruptHandler = interrupt
     if (this.requested && this.masks.canInterrupt) void this.interruptNow(interrupt).catch(() => { })
   }
 
@@ -245,6 +246,14 @@ class InterruptState implements Disposable {
 
   remove(disposable: Disposable) {
     this.disposables.remove(disposable)
+  }
+
+  addTask(task: Task<unknown, unknown>) {
+    this.tasks.add(task)
+  }
+
+  removeTask(task: Task<unknown, unknown>) {
+    this.tasks.delete(task)
   }
 
   maskSnapshot() {
@@ -259,29 +268,30 @@ class InterruptState implements Disposable {
     this.masks.unmask(token)
   }
 
-  [Symbol.dispose]() {
-    this._disposeWithReason(undefined)
-  }
-
-  _disposeWithReason(reason: unknown) {
+  interrupt(reason?: unknown) {
     this.requested = true
     this.reason = reason
     if (!this.masks.canInterrupt) return
-    this.disposeActive()
-    if (this.interrupt !== undefined) void this.interruptNow(this.interrupt).catch(() => { })
+    this.interruptActive()
+    if (this.interruptHandler !== undefined) void this.interruptNow(this.interruptHandler).catch(() => { })
   }
 
-  disposeActive() {
+  interruptActive() {
     this.disposables[Symbol.dispose]()
+    this.interruptActiveTasks()
   }
 
   async interruptNow<A>(
     interrupt: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<A>,
     masks: readonly InterruptMaskBegin['arg'][] = this.maskSnapshot()
   ): Promise<A> {
-    this.disposeActive()
+    this.interruptActive()
     this.interrupting ??= interrupt(masks, this.reason)
     return await this.interrupting as A
+  }
+
+  private interruptActiveTasks() {
+    for (const task of this.tasks) void task.interrupt(this.reason).catch(() => { })
   }
 }
 
@@ -354,25 +364,25 @@ const runTask = <A>(run: (s: AbortSignal) => Promise<A>, runtimeContext?: Runtim
   const s = new DisposableAbortController()
   try {
     return runtimeContext === undefined
-      ? new Task<A, unknown>(run(s.signal), s, runtimeContext)
+      ? new Task<A, unknown>(run(s.signal), reason => s.abort(reason), runtimeContext)
       : withActiveRuntimeContext(runtimeContext, () =>
-        new Task<A, unknown>(run(s.signal), s, runtimeContext)
+        new Task<A, unknown>(run(s.signal), reason => s.abort(reason), runtimeContext)
       )
   } catch (e) {
     s[Symbol.dispose]()
-    return taskWithRuntimeContext(Promise.reject(e), s, runtimeContext)
+    return taskWithRuntimeContext(Promise.reject(e), reason => s.abort(reason), runtimeContext)
   }
 }
 
 const taskWithRuntimeContext = <A, E>(
   promise: Promise<A>,
-  dispose: Disposable,
+  interruptTask: (reason?: unknown) => void,
   runtimeContext?: RuntimeContext,
-  disposed?: Promise<void>
+  interrupted?: Promise<void>
 ): Task<A, E> =>
   runtimeContext === undefined
-    ? new Task<A, E>(promise, dispose, runtimeContext, disposed)
-    : withActiveRuntimeContext(runtimeContext, () => new Task<A, E>(promise, dispose, runtimeContext, disposed))
+    ? new Task<A, E>(promise, interruptTask, runtimeContext, interrupted)
+    : withActiveRuntimeContext(runtimeContext, () => new Task<A, E>(promise, interruptTask, runtimeContext, interrupted))
 
 const iteratorWithRuntimeContext = <E, A>(
   f: Fx<E, A>,

--- a/src/internal/runtimeContext.ts
+++ b/src/internal/runtimeContext.ts
@@ -12,6 +12,7 @@ import { Pipeable, pipeThis } from './pipe.js'
 export interface RuntimeContext {
   readonly traceCapturePolicy?: TraceCapturePolicy
   readonly activeScopes?: readonly string[]
+  readonly interruptionReason?: unknown
 }
 
 export const RuntimeContextTypeId = Symbol('fx/RuntimeContext')
@@ -71,6 +72,15 @@ export const capturesStack = (context?: RuntimeContext): boolean =>
 
 export const activeScopes = (context: RuntimeContext | undefined = activeRuntimeContext): readonly string[] =>
   context?.activeScopes ?? []
+
+export const interruptionReason = (context: RuntimeContext | undefined = activeRuntimeContext): unknown =>
+  context?.interruptionReason
+
+export const withInterruptionReason = (
+  context: RuntimeContext | undefined,
+  reason: unknown
+): RuntimeContext | undefined =>
+  reason === undefined ? context : { ...context, interruptionReason: reason }
 
 export const withActiveScope = <E, A>(scope: string, fx: Fx<E, A>): Fx<E, A> => {
   const scopes = activeScopes()


### PR DESCRIPTION
## Summary
- add typed scoped interruption via InterruptFrom and interruption reasons observed by scoped finalizers
- replace failure-oriented timeout/defaultTimeout/TimeoutError with scoped timeout(scope, { ms, reason? })
- thread timeout reasons through timed task interruption so finalizers can observe TimeoutInterrupt or a custom reason
- refactor Task away from JS Disposable: Task.interrupt(reason?) is now the lifecycle API, and low-level Disposable remains only for resource handles
- update the uninterruptible-mask example and timeout guidance to use scoped interruption

## Notes
This intentionally removes the race-based Timeout effect and failure-oriented defaultTimeout model. Timeout is now a lifecycle interruption of a named scope, and scope(...) still re-yields the matching InterruptFrom after running finalizers so callers must choose their own recovery/reporting policy.

Task interruption is no longer modeled as JS disposal. Task no longer exposes Symbol.dispose, _disposeAndWait, or the dispose(task) helper; internal runtime paths use explicit interruption and keep JS Disposable for low-level resources such as timers, queues, semaphore acquisition, and abort-controller handles.

This first slice does not attempt universal descendant-task cancellation-cause propagation. It hardens reason threading for the timed task and its scoped finalizers, leaving broader cancellation-cause propagation for a later design pass.

## Validation
- node --import tsx --test src/Interrupt.test.ts src/Timeout.test.ts src/Concurrent.test.ts src/NodeProcess.test.ts src/HttpServer.test.ts
- corepack pnpm build
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm lint (passes with existing generated-asset no-implied-eval warning)
- node --import tsx examples/intermediate/uninterruptible-mask.ts