### PR TITLE
Exclude generated browser assets from lint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "ignorePatterns": [
+    "examples/advanced/bookmarks/browser/assets/**"
+  ],
   "rules": {
     "no-async-promise-executor": "off",
     "require-yield": "off"


### PR DESCRIPTION
## Summary
- ignore generated bookmark browser assets in oxlint config
- leave generated JS and authored runtime source unchanged

## Validation
- corepack pnpm build
- corepack pnpm lint
- corepack pnpm exec oxlint --type-aware --no-error-on-unmatched-pattern examples/advanced/bookmarks/browser/assets/src/internal/time.js