### PR TITLE
[codex] Refactor bookmark JSON codec boundary

### DIFF
--- a/docs/recipes/use-codecs.md
+++ b/docs/recipes/use-codecs.md
@@ -4,21 +4,23 @@ Use this when application logic needs to encode or decode external data without
 depending directly on a schema library.
 
 ```ts
-import { fail, fx, ok, run, trySync } from "@briancavalier/fx"
-import { codecKey, decode, encode, withCodec } from "@briancavalier/fx/codec"
+import { fx, ok, returnAll, run } from "@briancavalier/fx"
+import { codecFail, codecKey, codecOk, decodeOrFail, encodeOrFail, withCodec } from "@briancavalier/fx/codec"
 
 type User = {
   readonly id: string
   readonly name: string
 }
 
-const UserJson = codecKey<User, string>()("UserJson", {
+class InvalidUserJson extends Error { }
+
+const UserJson = codecKey<User, string, InvalidUserJson>()("UserJson", {
   description: "User encoded as JSON"
 })
 
 const program = (input: string) => fx(function* () {
-  const user = yield* decode(UserJson, input)
-  return yield* encode(UserJson, { ...user, name: user.name.toUpperCase() })
+  const user = yield* decodeOrFail(UserJson, input)
+  return yield* encodeOrFail(UserJson, { ...user, name: user.name.toUpperCase() })
 })
 ```
 
@@ -26,16 +28,25 @@ A codec key is both a runtime identity and a phantom type. Use `codecKey` with
 a string literal or a `const` symbol so TypeScript preserves the specific key
 identity. You can attach metadata such as `description` for diagnostics and
 documentation. The handler matches the key identity with `Object.is`, while
-TypeScript tracks the decoded and encoded types.
+TypeScript tracks the decoded type, encoded type, and declared recoverable
+codec failures. The third type parameter declares decode failures; the fourth
+type parameter can declare a different encode failure type when needed.
 
 Handler pipeline:
 
 ```ts
 program(input).pipe(
   withCodec(UserJson, {
-    encode: user => ok(JSON.stringify(user)),
-    decode: text => trySync(() => JSON.parse(text) as User)
+    encode: user => ok(codecOk(JSON.stringify(user))),
+    decode: text => {
+      try {
+        return ok(codecOk(JSON.parse(text) as User))
+      } catch {
+        return ok(codecFail(new InvalidUserJson()))
+      }
+    }
   }),
+  returnAll,
   run
 )
 ```
@@ -44,15 +55,16 @@ Use `withDecoder` when a boundary only reads external data. Use `withEncoder`
 when it only writes external data. Use `withCodec` when the same boundary needs
 both directions.
 
-Recoverable parse, validation, and schema errors should become `Fail`, either
-directly with `fail` or by wrapping throwing APIs with `trySync` or
-`tryPromise`.
+Codec handlers return `CodecResult` values. Use `codecOk` for successful
+answers and `codecFail` for declared codec failures. Operations such as
+`decodeOrFail` and `encodeOrFail` translate failed codec results into `Fail`;
+plain `decode` and `encode` return the handler answer directly.
 
 Adapters can stay local to the boundary:
 
 ```ts
 const fromZodResult = <A>(result: z.ZodSafeParseResult<A>) =>
-  result.success ? ok(result.data) : fail(result.error)
+  ok(result.success ? codecOk(result.data) : codecFail(result.error))
 
 const withZodUserJson = withCodec(UserJson, {
   encode: user => fromZodResult(z.safeEncode(userJsonCodec, user)),
@@ -61,6 +73,9 @@ const withZodUserJson = withCodec(UserJson, {
 ```
 
 ```ts
+const fromEither = <E, A>(either: Either<E, A>) =>
+  ok(Either.isRight(either) ? codecOk(either.right) : codecFail(either.left))
+
 const withEffectUserJson = withCodec(UserJson, {
   encode: user => fromEither(Schema.encodeEither(userJsonSchema)(user)),
   decode: text => fromEither(Schema.decodeUnknownEither(userJsonSchema)(text))

--- a/examples/advanced/bookmarks/README.md
+++ b/examples/advanced/bookmarks/README.md
@@ -1,0 +1,117 @@
+# Bookmarks Example
+
+This is a small reading queue application that shows how `fx` programs can keep
+domain behavior independent from platform handlers.
+
+The example includes:
+
+- an HTTP API server with SQLite persistence,
+- a CLI client for adding, listing, and updating bookmarks,
+- a browser UI served by the same server,
+- focused domain, client, codec, and store tests.
+
+## Run The Server
+
+Build the package exports first because the runnable examples import the public
+package subpaths:
+
+```sh
+corepack pnpm build
+```
+
+Start the API and browser server:
+
+```sh
+corepack pnpm exec tsx examples/advanced/bookmarks/server.ts
+```
+
+By default the server listens at `http://127.0.0.1:3000/` and stores data in
+`bookmarks.sqlite` in the current working directory. You can override those
+defaults:
+
+```sh
+HOST=127.0.0.1 PORT=3001 BOOKMARKS_DB=/tmp/bookmarks.sqlite \
+  corepack pnpm exec tsx examples/advanced/bookmarks/server.ts
+```
+
+## Use The CLI
+
+The CLI talks to `http://127.0.0.1:3000/api` by default:
+
+```sh
+corepack pnpm exec tsx examples/advanced/bookmarks/cli.ts add https://example.com --tag typescript
+corepack pnpm exec tsx examples/advanced/bookmarks/cli.ts list
+corepack pnpm exec tsx examples/advanced/bookmarks/cli.ts read bookmark-1
+corepack pnpm exec tsx examples/advanced/bookmarks/cli.ts archive bookmark-1
+corepack pnpm exec tsx examples/advanced/bookmarks/cli.ts refresh bookmark-1
+```
+
+Point it at another server with `BOOKMARKS_URL`:
+
+```sh
+BOOKMARKS_URL=http://127.0.0.1:3001/api \
+  corepack pnpm exec tsx examples/advanced/bookmarks/cli.ts list --status unread
+```
+
+## Use The Browser UI
+
+Start the server, then open:
+
+```text
+http://127.0.0.1:3000/
+```
+
+The server serves `examples/advanced/bookmarks/browser/index.html` and the
+checked-in browser assets under `examples/advanced/bookmarks/browser/assets`.
+If you change the browser source under `examples/advanced/bookmarks/browser`,
+rebuild those assets with:
+
+```sh
+corepack pnpm exec tsc --project examples/advanced/bookmarks/browser/tsconfig.json
+```
+
+## Tests
+
+Run the whole repository validation:
+
+```sh
+corepack pnpm typecheck
+corepack pnpm test
+corepack pnpm lint
+```
+
+For only the bookmarks tests:
+
+```sh
+corepack pnpm exec node --import tsx --test 'examples/advanced/bookmarks/*.test.ts'
+```
+
+## What This Example Highlights
+
+The domain in `domain.ts` is written as effectful programs over capabilities
+such as bookmark storage, metadata fetching, time, random ids, and logging. It
+does not know whether it is running in tests, over SQLite, behind HTTP, from the
+CLI, or in the browser.
+
+The server in `server.ts` interprets HTTP routes with `@briancavalier/fx/http-server`,
+uses `transformRoutes` to apply bookmark JSON codecs once to the API route tree,
+and keeps request body stream reading at the HTTP boundary.
+
+The client in `client.ts` uses `@briancavalier/fx/http-client` to read response
+bodies as UTF-8 text, then decodes bookmark JSON through codec operations. The
+exported client functions keep a stable client error surface while their
+internal raw programs still expose codec operations.
+
+The codecs in `codec.ts` model JSON text as the encoded form:
+
+- `BookmarkJson: Bookmark <-> string`
+- `BookmarksJson: readonly Bookmark[] <-> string`
+- `AddBookmarkInputJson: AddBookmarkInput <-> string`
+
+The codec handler is intentionally hand-rolled so the example stays dependency
+free. The same boundary could delegate to Zod, Valibot, Arktype, Effect Schema,
+Standard Schema-compatible adapters, or application-specific parsing code.
+
+The SQLite store in `store-sqlite.ts` is another handler for the same domain
+storage effects used by the tests. That keeps persistence details at the edge
+instead of threading database APIs through domain workflows.

--- a/examples/advanced/bookmarks/cli.test.ts
+++ b/examples/advanced/bookmarks/cli.test.ts
@@ -88,12 +88,13 @@ describe('bookmarks API client', () => {
     assert.equal(result.createdAt.toISOString(), bookmarkWire.createdAt)
     assert.equal(requests[0]?.method, 'POST')
     assert.equal(requests[0]?.url.href, 'http://localhost/api/bookmarks')
+    assert.deepEqual(requests[0]?.headers, [['content-type', 'application/json']])
     assert.deepEqual(requests[0]?.body, {
-      type: 'json',
-      value: {
+      type: 'text',
+      value: JSON.stringify({
         url: 'https://example.com',
         tags: ['typescript']
-      }
+      })
     })
   })
 

--- a/examples/advanced/bookmarks/client.ts
+++ b/examples/advanced/bookmarks/client.ts
@@ -1,28 +1,47 @@
-import { type Async, catchAll, fail, type Fail, flatMap, type Fx } from '@briancavalier/fx'
+import { type Async, catchAll, catchOnly, fail, type Fail, flatMap, type Fx } from '@briancavalier/fx'
 
-import { decode } from '@briancavalier/fx/codec'
-import { expectSuccess, json, request, type HttpRequest, type JSONValue } from '@briancavalier/fx/http-client'
+import { decodeOrFail, encodeOrFail } from '@briancavalier/fx/codec'
+import type { Decode, Encode } from '@briancavalier/fx/codec'
+import { expectSuccess, request, text, type Headers, type HttpRequest, type RequestBody } from '@briancavalier/fx/http-client'
 
-import { BookmarkJson, BookmarksJson, type BookmarkWire, withBookmarkCodecs } from './codec.js'
+import { AddBookmarkInputJson, BookmarkJson, BookmarksJson, InvalidBookmarkJson, withBookmarkCodecs } from './codec.js'
 import type { AddBookmarkInput, Bookmark, BookmarkQuery } from './domain.js'
 
 export type BookmarkClientError =
   | { readonly tag: 'BookmarkRequestFailed'; readonly cause: unknown }
   | { readonly tag: 'InvalidBookmarkResponse'; readonly value: unknown }
 
+type BookmarkClientCodecEffects =
+  | Encode<typeof AddBookmarkInputJson>
+  | Decode<typeof BookmarkJson>
+  | Decode<typeof BookmarksJson>
+  | Fail<InvalidBookmarkJson>
+
 export type BookmarkClientEffects =
   | HttpRequest
   | Async
   | Fail<BookmarkClientError>
 
+type BookmarkClientRawEffects =
+  | BookmarkClientEffects
+  | BookmarkClientCodecEffects
+
 export const createBookmark = (
   baseUrl: URL,
   input: AddBookmarkInput
 ): Fx<BookmarkClientEffects, Bookmark> =>
-  requestJson(baseUrl, 'bookmarks', {
-    method: 'POST',
-    body: { type: 'json', value: input }
-  }).pipe(
+  createBookmarkRaw(baseUrl, input).pipe(withClientCodecs)
+
+const createBookmarkRaw = (
+  baseUrl: URL,
+  input: AddBookmarkInput
+): Fx<BookmarkClientRawEffects, Bookmark> =>
+  encodeOrFail(AddBookmarkInputJson, input).pipe(
+    flatMap(body => requestText(baseUrl, 'bookmarks', {
+      method: 'POST',
+      body: { type: 'text', value: body },
+      headers: jsonHeaders
+    })),
     flatMap(decodeBookmark)
   )
 
@@ -30,7 +49,13 @@ export const listBookmarks = (
   baseUrl: URL,
   query: BookmarkQuery = {}
 ): Fx<BookmarkClientEffects, readonly Bookmark[]> =>
-  requestJson(baseUrl, 'bookmarks', {
+  listBookmarksRaw(baseUrl, query).pipe(withClientCodecs)
+
+const listBookmarksRaw = (
+  baseUrl: URL,
+  query: BookmarkQuery = {}
+): Fx<BookmarkClientRawEffects, readonly Bookmark[]> =>
+  requestText(baseUrl, 'bookmarks', {
     query: bookmarkQueryParams(query)
   }).pipe(
     flatMap(decodeBookmarks)
@@ -40,7 +65,13 @@ export const markBookmarkRead = (
   baseUrl: URL,
   id: string
 ): Fx<BookmarkClientEffects, Bookmark> =>
-  requestJson(baseUrl, `bookmarks/${encodeURIComponent(id)}/read`, {
+  markBookmarkReadRaw(baseUrl, id).pipe(withClientCodecs)
+
+const markBookmarkReadRaw = (
+  baseUrl: URL,
+  id: string
+): Fx<BookmarkClientRawEffects, Bookmark> =>
+  requestText(baseUrl, `bookmarks/${encodeURIComponent(id)}/read`, {
     method: 'PATCH'
   }).pipe(
     flatMap(decodeBookmark)
@@ -50,7 +81,13 @@ export const archiveBookmark = (
   baseUrl: URL,
   id: string
 ): Fx<BookmarkClientEffects, Bookmark> =>
-  requestJson(baseUrl, `bookmarks/${encodeURIComponent(id)}/archive`, {
+  archiveBookmarkRaw(baseUrl, id).pipe(withClientCodecs)
+
+const archiveBookmarkRaw = (
+  baseUrl: URL,
+  id: string
+): Fx<BookmarkClientRawEffects, Bookmark> =>
+  requestText(baseUrl, `bookmarks/${encodeURIComponent(id)}/archive`, {
     method: 'PATCH'
   }).pipe(
     flatMap(decodeBookmark)
@@ -60,7 +97,13 @@ export const refreshBookmarkMetadata = (
   baseUrl: URL,
   id: string
 ): Fx<BookmarkClientEffects, Bookmark> =>
-  requestJson(baseUrl, `bookmarks/${encodeURIComponent(id)}/metadata/refresh`, {
+  refreshBookmarkMetadataRaw(baseUrl, id).pipe(withClientCodecs)
+
+const refreshBookmarkMetadataRaw = (
+  baseUrl: URL,
+  id: string
+): Fx<BookmarkClientRawEffects, Bookmark> =>
+  requestText(baseUrl, `bookmarks/${encodeURIComponent(id)}/metadata/refresh`, {
     method: 'POST'
   }).pipe(
     flatMap(decodeBookmark)
@@ -68,22 +111,24 @@ export const refreshBookmarkMetadata = (
 
 type RequestOptions = {
   readonly method?: 'GET' | 'POST' | 'PATCH'
-  readonly body?: { readonly type: 'json'; readonly value: unknown }
+  readonly body?: RequestBody
+  readonly headers?: Headers
   readonly query?: URLSearchParams
 }
 
-const requestJson = (
+const requestText = (
   baseUrl: URL,
   path: string,
   options: RequestOptions = {}
-): Fx<HttpRequest | Async | Fail<BookmarkClientError>, JSONValue> =>
+): Fx<HttpRequest | Async | Fail<BookmarkClientError>, string> =>
   request({
     method: options.method,
     url: apiUrl(baseUrl, path, options.query),
-    body: options.body
+    body: options.body,
+    headers: options.headers
   }).pipe(
     flatMap(expectSuccess),
-    flatMap(json),
+    flatMap(text),
     catchAll(cause => fail({ tag: 'BookmarkRequestFailed', cause }))
   )
 
@@ -103,15 +148,16 @@ const bookmarkQueryParams = (query: BookmarkQuery): URLSearchParams => {
   return params
 }
 
-const decodeBookmarks = (value: JSONValue): Fx<Fail<BookmarkClientError>, readonly Bookmark[]> =>
-  withBookmarkCodecs(decode(BookmarksJson, value as readonly BookmarkWire[])).pipe(
-    catchAll(() => invalidResponse<readonly Bookmark[]>(value))
-  )
+const decodeBookmarks = (value: string): Fx<Decode<typeof BookmarksJson> | Fail<InvalidBookmarkJson>, readonly Bookmark[]> =>
+  decodeOrFail(BookmarksJson, value)
 
-const decodeBookmark = (value: JSONValue): Fx<Fail<BookmarkClientError>, Bookmark> =>
-  withBookmarkCodecs(decode(BookmarkJson, value as BookmarkWire)).pipe(
-    catchAll(() => invalidResponse<Bookmark>(value))
-  )
+const decodeBookmark = (value: string): Fx<Decode<typeof BookmarkJson> | Fail<InvalidBookmarkJson>, Bookmark> =>
+  decodeOrFail(BookmarkJson, value)
 
-const invalidResponse = <A>(value: unknown): Fx<Fail<BookmarkClientError>, A> =>
-  fail({ tag: 'InvalidBookmarkResponse', value })
+const jsonHeaders: Headers = [['content-type', 'application/json']]
+
+const withClientCodecs = <E, A>(program: Fx<E, A>): Fx<Exclude<E, BookmarkClientCodecEffects> | Fail<BookmarkClientError>, A> =>
+  program.pipe(
+    withBookmarkCodecs,
+    catchOnly(InvalidBookmarkJson, error => fail({ tag: 'InvalidBookmarkResponse', value: error } as const))
+  ) as Fx<Exclude<E, BookmarkClientCodecEffects> | Fail<BookmarkClientError>, A>

--- a/examples/advanced/bookmarks/codec.test.ts
+++ b/examples/advanced/bookmarks/codec.test.ts
@@ -2,27 +2,28 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assert as assertNoFail, returnAll, run } from '@briancavalier/fx'
 
-import { decode, encode } from '@briancavalier/fx/codec'
-import { AddBookmarkInputJson, BookmarkJson, type AddBookmarkInputWire, InvalidBookmarkJson, withBookmarkCodecs } from './codec.js'
+import { decodeOrFail, encodeOrFail } from '@briancavalier/fx/codec'
+import { AddBookmarkInputJson, BookmarkJson, InvalidBookmarkJson, withBookmarkCodecs } from './codec.js'
 import type { Bookmark } from './domain.js'
 
 describe('bookmarks codecs', () => {
   it('encodes bookmark dates as ISO strings for JSON responses', () => {
-    const encoded = withBookmarkCodecs(encode(BookmarkJson, bookmark)).pipe(
+    const encoded = withBookmarkCodecs(encodeOrFail(BookmarkJson, bookmark)).pipe(
       assertNoFail,
       run
     )
 
-    assert.equal(encoded.createdAt, '2024-01-01T00:00:00.000Z')
-    assert.equal(encoded.updatedAt, '2024-01-02T00:00:00.000Z')
+    const parsed = JSON.parse(encoded) as Record<string, unknown>
+    assert.equal(parsed.createdAt, '2024-01-01T00:00:00.000Z')
+    assert.equal(parsed.updatedAt, '2024-01-02T00:00:00.000Z')
   })
 
   it('decodes bookmark ISO date strings into Dates', () => {
-    const decoded = withBookmarkCodecs(decode(BookmarkJson, {
+    const decoded = withBookmarkCodecs(decodeOrFail(BookmarkJson, JSON.stringify({
       ...bookmark,
       createdAt: '2024-01-01T00:00:00.000Z',
       updatedAt: '2024-01-02T00:00:00.000Z'
-    })).pipe(
+    }))).pipe(
       assertNoFail,
       run
     )
@@ -34,10 +35,10 @@ describe('bookmarks codecs', () => {
   })
 
   it('decodes valid add bookmark input JSON', () => {
-    const decoded = withBookmarkCodecs(decode(AddBookmarkInputJson, {
+    const decoded = withBookmarkCodecs(decodeOrFail(AddBookmarkInputJson, JSON.stringify({
       url: 'https://example.com',
       tags: ['typescript', 'effects']
-    })).pipe(
+    }))).pipe(
       assertNoFail,
       run
     )
@@ -49,10 +50,19 @@ describe('bookmarks codecs', () => {
   })
 
   it('rejects invalid add bookmark input tags', () => {
-    const decoded = withBookmarkCodecs(decode(AddBookmarkInputJson, {
+    const decoded = withBookmarkCodecs(decodeOrFail(AddBookmarkInputJson, JSON.stringify({
       url: 'https://example.com',
       tags: [1]
-    } as unknown as AddBookmarkInputWire)).pipe(
+    }))).pipe(
+      returnAll,
+      run
+    )
+
+    assert.ok(decoded instanceof InvalidBookmarkJson)
+  })
+
+  it('rejects malformed add bookmark JSON', () => {
+    const decoded = withBookmarkCodecs(decodeOrFail(AddBookmarkInputJson, '{"url":')).pipe(
       returnAll,
       run
     )

--- a/examples/advanced/bookmarks/codec.ts
+++ b/examples/advanced/bookmarks/codec.ts
@@ -1,6 +1,6 @@
-import { fail, type Fail, type Fx, ok } from '@briancavalier/fx'
+import { type Fx, ok } from '@briancavalier/fx'
 
-import { codecKey, type Decode, type Encode, withCodec } from '@briancavalier/fx/codec'
+import { codecFail, codecKey, codecOk, type CodecResult, type Decode, type Encode, withCodec } from '@briancavalier/fx/codec'
 import type { AddBookmarkInput, Bookmark, BookmarkStatus, MetadataStatus } from './domain.js'
 
 export type BookmarkWire = {
@@ -22,15 +22,15 @@ export type AddBookmarkInputWire = {
 
 export class InvalidBookmarkJson extends Error { }
 
-export const BookmarkJson = codecKey<Bookmark, BookmarkWire>()(Symbol('examples/advanced/bookmarks/BookmarkJson'), {
+export const BookmarkJson = codecKey<Bookmark, string, InvalidBookmarkJson>()('examples/advanced/bookmarks/BookmarkJson', {
   description: 'Bookmark JSON with Date fields encoded as ISO strings'
 })
 
-export const BookmarksJson = codecKey<readonly Bookmark[], readonly BookmarkWire[]>()(Symbol('examples/advanced/bookmarks/BookmarksJson'), {
+export const BookmarksJson = codecKey<readonly Bookmark[], string, InvalidBookmarkJson>()('examples/advanced/bookmarks/BookmarksJson', {
   description: 'Bookmark array JSON with Date fields encoded as ISO strings'
 })
 
-export const AddBookmarkInputJson = codecKey<AddBookmarkInput, AddBookmarkInputWire>()(Symbol('examples/advanced/bookmarks/AddBookmarkInputJson'), {
+export const AddBookmarkInputJson = codecKey<AddBookmarkInput, string, InvalidBookmarkJson>()('examples/advanced/bookmarks/AddBookmarkInputJson', {
   description: 'Add bookmark request JSON'
 })
 
@@ -42,22 +42,26 @@ type BookmarkCodecEffects =
   | Encode<typeof AddBookmarkInputJson>
   | Decode<typeof AddBookmarkInputJson>
 
-export const withBookmarkCodecs = <E extends BookmarkCodecEffects, A>(program: Fx<E, A>): Fx<Fail<InvalidBookmarkJson>, A> => program.pipe(
+// This example uses a small hand-rolled JSON codec so the data boundary is easy
+// to inspect without adding dependencies. A real application could keep the same
+// codec keys and delegate these handlers to Zod, Valibot, Arktype, Effect
+// Schema, a Standard Schema adapter, or a project-local parser/serializer.
+export const withBookmarkCodecs = <E, A>(program: Fx<E, A>): Fx<Exclude<E, BookmarkCodecEffects>, A> => program.pipe(
   withCodec(BookmarkJson, {
-    encode: bookmark => ok(bookmarkToWire(bookmark)),
-    decode: decodeBookmarkWire
+    encode: bookmark => ok(encodeJson(bookmarkToWire(bookmark))),
+    decode: text => ok(flatMapCodecResult(parseJson(text), decodeBookmarkWire))
   }),
   withCodec(BookmarksJson, {
-    encode: bookmarks => ok(bookmarks.map(bookmarkToWire)),
-    decode: decodeBookmarkWireArray
+    encode: bookmarks => ok(encodeJson(bookmarks.map(bookmarkToWire))),
+    decode: text => ok(flatMapCodecResult(parseJson(text), decodeBookmarkWireArray))
   }),
   withCodec(AddBookmarkInputJson, {
-    encode: input => ok(input),
-    decode: decodeAddBookmarkInputWire
+    encode: input => ok(encodeJson(input)),
+    decode: text => ok(flatMapCodecResult(parseJson(text), decodeAddBookmarkInputWire))
   })
-) as Fx<Fail<InvalidBookmarkJson>, A>
+) as Fx<Exclude<E, BookmarkCodecEffects>, A>
 
-const decodeBookmarkWireArray = (values: readonly BookmarkWire[]): Fx<Fail<InvalidBookmarkJson>, readonly Bookmark[]> => {
+const decodeBookmarkWireArray = (values: unknown): CodecResult<InvalidBookmarkJson, readonly Bookmark[]> => {
   if (!Array.isArray(values)) return invalidBookmarkJson('expected bookmark array')
 
   const bookmarks: Bookmark[] = []
@@ -66,7 +70,7 @@ const decodeBookmarkWireArray = (values: readonly BookmarkWire[]): Fx<Fail<Inval
     if (bookmark === undefined) return invalidBookmarkJson('invalid bookmark JSON')
     bookmarks.push(bookmark)
   }
-  return ok(bookmarks)
+  return codecOk(bookmarks)
 }
 
 const bookmarkToWire = (bookmark: Bookmark): BookmarkWire => ({
@@ -81,9 +85,9 @@ const bookmarkToWire = (bookmark: Bookmark): BookmarkWire => ({
   updatedAt: bookmark.updatedAt.toISOString()
 })
 
-const decodeBookmarkWire = (value: BookmarkWire): Fx<Fail<InvalidBookmarkJson>, Bookmark> => {
+const decodeBookmarkWire = (value: unknown): CodecResult<InvalidBookmarkJson, Bookmark> => {
   const bookmark = parseBookmarkWire(value)
-  return bookmark === undefined ? invalidBookmarkJson('invalid bookmark JSON') : ok(bookmark)
+  return bookmark === undefined ? invalidBookmarkJson('invalid bookmark JSON') : codecOk(bookmark)
 }
 
 const parseBookmarkWire = (value: unknown): Bookmark | undefined => {
@@ -115,13 +119,13 @@ const parseBookmarkWire = (value: unknown): Bookmark | undefined => {
     : undefined
 }
 
-const decodeAddBookmarkInputWire = (value: AddBookmarkInputWire) => {
+const decodeAddBookmarkInputWire = (value: unknown) => {
   if (!isRecord(value) || typeof value.url !== 'string') return invalidBookmarkJson('invalid add bookmark input JSON')
 
-  if (value.tags === undefined) return ok({ url: value.url })
+  if (value.tags === undefined) return codecOk({ url: value.url })
 
   return isStringArray(value.tags)
-    ? ok({ url: value.url, tags: value.tags })
+    ? codecOk({ url: value.url, tags: value.tags })
     : invalidBookmarkJson('invalid add bookmark input JSON')
 }
 
@@ -132,7 +136,29 @@ const parseDate = (value: unknown): Date | undefined => {
 }
 
 const invalidBookmarkJson = (message: string) =>
-  fail(new InvalidBookmarkJson(message))
+  codecFail(new InvalidBookmarkJson(message))
+
+const encodeJson = (value: unknown): CodecResult<InvalidBookmarkJson, string> => {
+  try {
+    return codecOk(JSON.stringify(value))
+  } catch {
+    return invalidBookmarkJson('invalid bookmark JSON')
+  }
+}
+
+const parseJson = (text: string): CodecResult<InvalidBookmarkJson, unknown> => {
+  try {
+    return codecOk(JSON.parse(text) as unknown)
+  } catch {
+    return invalidBookmarkJson('invalid bookmark JSON')
+  }
+}
+
+const flatMapCodecResult = <E, A, B>(
+  result: CodecResult<E, A>,
+  f: (value: A) => CodecResult<E, B>
+): CodecResult<E, B> =>
+  result.tag === 'ok' ? f(result.value) : result
 
 const isMetadataStatus = (value: unknown): value is MetadataStatus =>
   isRecord(value) &&

--- a/examples/advanced/bookmarks/server.ts
+++ b/examples/advanced/bookmarks/server.ts
@@ -3,11 +3,11 @@ import { networkInterfaces } from 'node:os'
 import { dirname, join, normalize, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { unbounded } from '@briancavalier/fx/concurrent'
-import { assert as assertNoFail, catchAll, Fail, flatMap, fx, type Fx, map, ok, provide, returnAll, trySync } from '@briancavalier/fx'
+import { assert as assertNoFail, catchAll, Fail, flatMap, fx, type Fx, map, ok, provide, returnAll } from '@briancavalier/fx'
 
-import { decode, encode } from '@briancavalier/fx/codec'
+import { decodeOrFail, encodeOrFail, type Decode, type Encode } from '@briancavalier/fx/codec'
 import { bytes as readBytes } from '@briancavalier/fx/http-client'
-import { mount, route, routes, serve, type RouteContext, type Routes, type ServerEvent, type ServerListening, type ServerRequest, type ServerResponse } from '@briancavalier/fx/http-server'
+import { mount, route, routes, serve, transformRoutes, type RouteContext, type Routes, type ServerEvent, type ServerListening, type ServerRequest, type ServerResponse } from '@briancavalier/fx/http-server'
 import { info, withConsoleLog, type Log } from '@briancavalier/fx/log'
 import { nodeHttp, runNodeMain } from '@briancavalier/fx/platform-node'
 import { defaultRandom } from '@briancavalier/fx/random'
@@ -29,17 +29,13 @@ import {
   type FetchPageMetadata,
   type NextBookmarkId
 } from './domain.js'
-import { AddBookmarkInputJson, BookmarkJson, BookmarksJson, type AddBookmarkInputWire, InvalidBookmarkJson, withBookmarkCodecs } from './codec.js'
+import { AddBookmarkInputJson, BookmarkJson, BookmarksJson, InvalidBookmarkJson, withBookmarkCodecs } from './codec.js'
 import { sqliteBookmarkStore } from './store-sqlite.js'
 
 type ServerConfig = {
   readonly host: string
   readonly port: number
 }
-
-type JsonBody =
-  | { readonly tag: 'valid'; readonly value: unknown }
-  | { readonly tag: 'invalid' }
 
 type BookmarkRouteEffects =
   | BookmarkStore
@@ -48,13 +44,16 @@ type BookmarkRouteEffects =
   | Time
   | Log
 
+type BookmarkApiCodecEffects =
+  | Decode<typeof AddBookmarkInputJson>
+  | Encode<typeof BookmarkJson>
+  | Encode<typeof BookmarksJson>
+
 const HttpServerEvents = scope<Yielding<ServerEvent>>()('examples/advanced/bookmarks/HttpServerEvents')
 
-const createBookmark = (request: ServerRequest): Fx<BookmarkRouteEffects, ServerResponse<never>> => fx(function* () {
-  const body = yield* readJson(request)
-  if (body.tag === 'invalid') return json({ error: 'InvalidJson' }, 400)
-
-  const input = yield* withBookmarkCodecs(decode(AddBookmarkInputJson, body.value as AddBookmarkInputWire)).pipe(
+const createBookmark = (request: ServerRequest): Fx<BookmarkRouteEffects | BookmarkApiCodecEffects | Fail<InvalidBookmarkJson>, ServerResponse<never>> => fx(function* () {
+  const body = yield* readText(request)
+  const input = yield* decodeOrFail(AddBookmarkInputJson, body).pipe(
     returnAll
   )
   if (input instanceof InvalidBookmarkJson) return json({ error: 'InvalidBookmarkInput' }, 400)
@@ -62,7 +61,13 @@ const createBookmark = (request: ServerRequest): Fx<BookmarkRouteEffects, Server
   return yield* respond(addBookmark(input), bookmark => bookmarkResponse(bookmark, 201))
 })
 
-const apiRoutes = routes(
+function withApiCodecs<E, A>(program: Fx<E, A>): Fx<Exclude<E, BookmarkApiCodecEffects | Fail<InvalidBookmarkJson>>, A> {
+  return withBookmarkCodecs(program).pipe(
+    assertNoFail
+  ) as Fx<Exclude<E, BookmarkApiCodecEffects | Fail<InvalidBookmarkJson>>, A>
+}
+
+const apiRoutes = transformRoutes(withApiCodecs)(routes(
   route('GET', '/health', fx(function* () {
     return text('ok')
   })),
@@ -88,7 +93,7 @@ const apiRoutes = routes(
   route('POST', '/bookmarks/:id/metadata/refresh', fx(function* ({ request }: RouteContext<{ readonly id: string }>) {
     return yield* respond(refreshMetadata(request.params.id), bookmarkResponse)
   }))
-)
+))
 
 const browserDir = join(dirname(fileURLToPath(import.meta.url)), 'browser')
 
@@ -117,16 +122,16 @@ const server = fx(function* ({ host, port }: ServerConfig) {
   })
 })
 
-const respond = <E, A>(
+const respond = <E, A, SE>(
   program: Fx<E, A>,
-  success: (value: A) => Fx<never, ServerResponse<never>>
-): Fx<Exclude<E, Fail<BookmarkError>>, ServerResponse<never>> =>
+  success: (value: A) => Fx<SE, ServerResponse<never>>
+): Fx<Exclude<E, Fail<BookmarkError>> | SE, ServerResponse<never>> =>
   program.pipe(
     returnAll,
     flatMap(result => isBookmarkError(result)
       ? ok(bookmarkErrorResponse(result))
       : success(result))
-  ) as Fx<Exclude<E, Fail<BookmarkError>>, ServerResponse<never>>
+  ) as Fx<Exclude<E, Fail<BookmarkError>> | SE, ServerResponse<never>>
 
 const bookmarkQuery = (query: URLSearchParams): BookmarkQuery | undefined => {
   const status = query.get('status') ?? undefined
@@ -204,27 +209,27 @@ const json = (value: unknown, status = 200): ServerResponse<never> => ({
   body: { type: 'json', value }
 })
 
-const bookmarkResponse = (bookmark: Bookmark, status = 200): Fx<never, ServerResponse<never>> =>
-  withBookmarkCodecs(encode(BookmarkJson, bookmark)).pipe(
-    assertNoFail,
-    map(value => json(value, status))
+const jsonText = (value: string, status = 200): ServerResponse<never> => ({
+  status,
+  headers: [['content-type', 'application/json']],
+  body: { type: 'text', value }
+})
+
+const bookmarkResponse = (bookmark: Bookmark, status = 200): Fx<Encode<typeof BookmarkJson> | Fail<InvalidBookmarkJson>, ServerResponse<never>> =>
+  encodeOrFail(BookmarkJson, bookmark).pipe(
+    map(value => jsonText(value, status))
   )
 
-const bookmarksResponse = (bookmarks: readonly Bookmark[]): Fx<never, ServerResponse<never>> =>
-  withBookmarkCodecs(encode(BookmarksJson, bookmarks)).pipe(
-    assertNoFail,
-    map(json)
+const bookmarksResponse = (bookmarks: readonly Bookmark[]): Fx<Encode<typeof BookmarksJson> | Fail<InvalidBookmarkJson>, ServerResponse<never>> =>
+  encodeOrFail(BookmarksJson, bookmarks).pipe(
+    map(jsonText)
   )
 
-const readJson = (request: ServerRequest): Fx<never, JsonBody> =>
+const readText = (request: ServerRequest): Fx<never, string> =>
   readBytes({ status: 200, headers: [], body: request.body }).pipe(
     map((bytes: Uint8Array) => new TextDecoder().decode(bytes)),
-    flatMap(parseJsonBody),
-    catchAll(() => ok({ tag: 'invalid' } as const))
-  ) as Fx<never, JsonBody>
-
-const parseJsonBody = (body: string): Fx<Fail<unknown>, JsonBody> =>
-  trySync(() => ({ tag: 'valid', value: JSON.parse(body) }))
+    catchAll(() => ok(''))
+  ) as Fx<never, string>
 
 const logHttpServerEvent = (event: ServerEvent) => {
   switch (event.type) {

--- a/examples/intermediate/codec-json.ts
+++ b/examples/intermediate/codec-json.ts
@@ -1,5 +1,5 @@
-import { Fail, fail, flatMap, ok, returnFail, run, trySync } from '@briancavalier/fx'
-import { codecKey, CodecEncoded, CodecKey, decode, encode, withCodec } from '@briancavalier/fx/codec'
+import { Fail, flatMap, ok, returnFail, run } from '@briancavalier/fx'
+import { codecFail, codecKey, codecOk, CodecEncoded, CodecKey, decodeOrFail, encodeOrFail, withCodec } from '@briancavalier/fx/codec'
 
 type User = {
   readonly id: string
@@ -7,7 +7,7 @@ type User = {
   readonly createdAt: Date
 }
 
-const UserJson = codecKey<User, string>()('UserJson', {
+const UserJson = codecKey<User, string, InvalidUserJson>()('UserJson', {
   description: 'User encoded as JSON with createdAt as an ISO string'
 })
 
@@ -28,9 +28,9 @@ const invalidJson = JSON.stringify({
   createdAt: 'not-a-date'
 })
 
-const roundTrip = <K extends CodecKey<User, string>>(codec: K, input: CodecEncoded<K>) =>
-  decode(codec, input).pipe(
-    flatMap(user => encode(codec, { ...user, name: user.name.toUpperCase() }))
+const roundTrip = <K extends CodecKey<User, string, unknown, unknown>>(codec: K, input: CodecEncoded<K>) =>
+  decodeOrFail(codec, input).pipe(
+    flatMap(user => encodeOrFail(codec, { ...user, name: user.name.toUpperCase() }))
   )
 
 // The reusable program above only knows about the codec key. The concrete JSON
@@ -49,24 +49,32 @@ const decodeUser = (value: unknown) => {
     const createdAt = new Date(value.createdAt)
 
     return Number.isNaN(createdAt.getTime())
-      ? fail(new InvalidUserJson('createdAt must be an ISO date string'))
-      : ok({ id: value.id, name: value.name, createdAt })
+      ? codecFail(new InvalidUserJson('createdAt must be an ISO date string'))
+      : codecOk({ id: value.id, name: value.name, createdAt })
   }
 
-  return fail(new InvalidUserJson('expected User JSON object'))
+  return codecFail(new InvalidUserJson('expected User JSON object'))
 }
 
 const withUserJson = withCodec(UserJson, {
-  encode: user =>
-    trySync(() => JSON.stringify({
-      id: user.id,
-      name: user.name,
-      createdAt: user.createdAt.toISOString()
-    })),
-  decode: text =>
-    trySync(() => JSON.parse(text) as unknown).pipe(
-      flatMap(decodeUser)
-    )
+  encode: user => {
+    try {
+      return ok(codecOk(JSON.stringify({
+        id: user.id,
+        name: user.name,
+        createdAt: user.createdAt.toISOString()
+      })))
+    } catch {
+      return ok(codecFail(new InvalidUserJson('failed to encode user JSON')))
+    }
+  },
+  decode: text => {
+    try {
+      return ok(decodeUser(JSON.parse(text) as unknown))
+    } catch {
+      return ok(codecFail(new InvalidUserJson('failed to parse user JSON')))
+    }
+  }
 })
 
 const summarizeUserJson = (json: string) => {
@@ -85,7 +93,7 @@ const expectEncoded = (result: string | Fail<unknown>) => {
 }
 
 const encoded = roundTrip(UserJson, incomingJson).pipe(withUserJson, returnFail, run, expectEncoded)
-const invalid = decode(UserJson, invalidJson).pipe(withUserJson, returnFail, run)
+const invalid = decodeOrFail(UserJson, invalidJson).pipe(withUserJson, returnFail, run)
 
 console.log('codec ok', summarizeUserJson(encoded))
 console.log('codec invalid', summarizeFailure(invalid))

--- a/src/Codec.test.ts
+++ b/src/Codec.test.ts
@@ -1,17 +1,22 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { Fail, fail, returnFail } from './Fail.js'
+import { Fail, fail, returnAll, returnFail } from './Fail.js'
 import { Fx, fx, ok, run } from './Fx.js'
 
 import {
   codecKey,
+  codecFail,
+  codecOk,
   CodecEncoded,
+  CodecResult,
   CodecValue,
   Decode,
   decode,
+  decodeOrFail,
   Encode,
   encode,
+  encodeOrFail,
   withCodec,
   withDecoder,
   withEncoder
@@ -24,49 +29,83 @@ type User = {
 
 const UserJsonSymbol = Symbol('UserJson')
 const OtherUserJsonSymbol = Symbol('OtherUserJson')
-const UserJson = codecKey<User, string>()(UserJsonSymbol, {
+const UserJson = codecKey<User, string, never>()(UserJsonSymbol, {
   description: 'User encoded as JSON'
 })
-const OtherUserJson = codecKey<User, string>()(OtherUserJsonSymbol)
-const CountText = codecKey<number, string>()('CountText')
+const OtherUserJson = codecKey<User, string, never>()(OtherUserJsonSymbol)
+const CountText = codecKey<number, string, never>()('CountText')
 
 class InvalidCodec extends Error { }
 class EncodeUnavailable extends Error { }
 class DecodeUnavailable extends Error { }
 
+const CheckedUserJson = codecKey<User, string, DecodeUnavailable, EncodeUnavailable>()('CheckedUserJson')
+
 type EffectsOf<T> =
   T extends Fx<infer E, any> ? E : never
 
 describe('Codec', () => {
+  it('encode yields a codec result for a codec key', () => {
+    const encoded: Fx<Encode<typeof UserJson>, CodecResult<never, CodecEncoded<typeof UserJson>>> =
+      encode(UserJson, { id: 'u1', name: 'Ada' } satisfies CodecValue<typeof UserJson>)
+
+    assert.throws(() => run(encoded as any), /Unhandled effect in run/)
+  })
+
+  it('decode yields a codec result for a codec key', () => {
+    const decoded: Fx<Decode<typeof UserJson>, CodecResult<never, CodecValue<typeof UserJson>>> =
+      decode(UserJson, '{"id":"u1","name":"Ada"}' satisfies CodecEncoded<typeof UserJson>)
+
+    assert.throws(() => run(decoded as any), /Unhandled effect in run/)
+  })
+
   it('encode yields the encoded type for a codec key', () => {
     const encoded: Fx<Encode<typeof UserJson>, CodecEncoded<typeof UserJson>> =
-      encode(UserJson, { id: 'u1', name: 'Ada' } satisfies CodecValue<typeof UserJson>)
+      encodeOrFail(UserJson, { id: 'u1', name: 'Ada' } satisfies CodecValue<typeof UserJson>)
 
     assert.throws(() => run(encoded as any), /Unhandled effect in run/)
   })
 
   it('decode yields the value type for a codec key', () => {
     const decoded: Fx<Decode<typeof UserJson>, CodecValue<typeof UserJson>> =
-      decode(UserJson, '{"id":"u1","name":"Ada"}' satisfies CodecEncoded<typeof UserJson>)
+      decodeOrFail(UserJson, '{"id":"u1","name":"Ada"}' satisfies CodecEncoded<typeof UserJson>)
 
     assert.throws(() => run(decoded as any), /Unhandled effect in run/)
   })
 
   it('withCodec handles matching encode and decode keys', () => {
     const program = fx(function* () {
-      const user = yield* decode(UserJson, '{"id":"u1","name":"Ada"}')
-      return yield* encode(UserJson, { ...user, name: user.name.toUpperCase() })
+      const user = yield* decodeOrFail(UserJson, '{"id":"u1","name":"Ada"}')
+      return yield* encodeOrFail(UserJson, { ...user, name: user.name.toUpperCase() })
     })
 
     const actual = program.pipe(
       withCodec(UserJson, {
-        encode: user => ok(JSON.stringify(user)),
-        decode: json => ok(JSON.parse(json) as User)
+        encode: user => ok(codecOk(JSON.stringify(user))),
+        decode: json => ok(codecOk(JSON.parse(json) as User))
       }),
       run
     )
 
     assert.deepEqual(JSON.parse(actual), { id: 'u1', name: 'ADA' })
+  })
+
+  it('decode carries its declared failure type before a decoder is handled', () => {
+    const program = decodeOrFail(CheckedUserJson, '{"id":"u1","name":"Ada"}').pipe(
+      returnAll
+    )
+
+    const typed: Fx<Decode<typeof CheckedUserJson>, User | DecodeUnavailable> = program
+    assert.throws(() => run(typed as any), /Unhandled effect in run/)
+  })
+
+  it('encode carries its declared failure type before an encoder is handled', () => {
+    const program = encodeOrFail(CheckedUserJson, { id: 'u1', name: 'Ada' }).pipe(
+      returnAll
+    )
+
+    const typed: Fx<Encode<typeof CheckedUserJson>, string | EncodeUnavailable> = program
+    assert.throws(() => run(typed as any), /Unhandled effect in run/)
   })
 
   it('creates codec keys with string or symbol identity and metadata', () => {
@@ -77,13 +116,13 @@ describe('Codec', () => {
 
   it('preserves non-matching codec keys as unhandled effects', () => {
     const program = fx(function* () {
-      const user = yield* decode(UserJson, '{"id":"u1","name":"Ada"}')
-      const count = yield* decode(CountText, '1')
+      const user = yield* decodeOrFail(UserJson, '{"id":"u1","name":"Ada"}')
+      const count = yield* decodeOrFail(CountText, '1')
       return `${user.name}:${count}`
     }).pipe(
       withCodec(UserJson, {
-        encode: user => ok(JSON.stringify(user)),
-        decode: json => ok(JSON.parse(json) as User)
+        encode: user => ok(codecOk(JSON.stringify(user))),
+        decode: json => ok(codecOk(JSON.parse(json) as User))
       })
     )
 
@@ -92,8 +131,8 @@ describe('Codec', () => {
   })
 
   it('preserves distinct codec key identities with the same value and encoded types', () => {
-    const program = decode(OtherUserJson, '{"id":"u2","name":"Grace"}').pipe(
-      withDecoder(UserJson, json => ok(JSON.parse(json) as User))
+    const program = decodeOrFail(OtherUserJson, '{"id":"u2","name":"Grace"}').pipe(
+      withDecoder(UserJson, json => ok(codecOk(JSON.parse(json) as User)))
     )
 
     const residual: Fx<Decode<typeof OtherUserJson>, User> = program
@@ -110,7 +149,7 @@ describe('Codec', () => {
       codec
     const widened = widen(UserJson)
 
-    const program = decode(OtherUserJson, '{"id":"u2","name":"Grace"}').pipe(
+    const program = decodeOrFail(OtherUserJson, '{"id":"u2","name":"Grace"}').pipe(
       withDecoder(widened, () => fail(expected))
     )
 
@@ -119,25 +158,25 @@ describe('Codec', () => {
   })
 
   it('matches different codec key objects with the same identity', () => {
-    const SameCountText = codecKey<number, string>()('CountText', {
+    const SameCountText = codecKey<number, string, never>()('CountText', {
       description: 'Same codec identity with different metadata'
     })
 
-    const actual = decode(CountText, '41').pipe(
-      withDecoder(SameCountText, text => ok(Number(text))),
+    const actual = decodeOrFail(CountText, '41').pipe(
+      withDecoder(SameCountText, text => ok(codecOk(Number(text)))),
       run
     )
 
     assert.equal(actual, 41)
   })
 
-  it('propagates provider failures as Fail', () => {
-    const expected = new InvalidCodec('invalid user')
+  it('translates handler failure results to Fail', () => {
+    const expected = new DecodeUnavailable('invalid user')
 
-    const actual = decode(UserJson, '{}').pipe(
-      withCodec(UserJson, {
-        encode: user => ok(JSON.stringify(user)),
-        decode: () => fail(expected)
+    const actual = decodeOrFail(CheckedUserJson, '{}').pipe(
+      withCodec(CheckedUserJson, {
+        encode: user => ok(codecOk(JSON.stringify(user))),
+        decode: () => ok(codecFail(expected))
       }),
       returnFail,
       run
@@ -148,7 +187,7 @@ describe('Codec', () => {
   })
 
   it('withCodec keeps decode-only handler effects directional', () => {
-    const program = decode(UserJson, '{"id":"u1","name":"Ada"}').pipe(
+    const program = decodeOrFail(UserJson, '{"id":"u1","name":"Ada"}').pipe(
       withCodec(UserJson, {
         encode: () => fail(new EncodeUnavailable()),
         decode: json => fail(new DecodeUnavailable(json))
@@ -163,7 +202,7 @@ describe('Codec', () => {
   })
 
   it('withCodec keeps encode-only handler effects directional', () => {
-    const program = encode(UserJson, { id: 'u1', name: 'Ada' }).pipe(
+    const program = encodeOrFail(UserJson, { id: 'u1', name: 'Ada' }).pipe(
       withCodec(UserJson, {
         encode: user => fail(new EncodeUnavailable(user.name)),
         decode: () => fail(new DecodeUnavailable())
@@ -179,12 +218,12 @@ describe('Codec', () => {
 
   it('supports string codec keys', () => {
     const actual = fx(function* () {
-      const count = yield* decode(CountText, '41')
-      return yield* encode(CountText, count + 1)
+      const count = yield* decodeOrFail(CountText, '41')
+      return yield* encodeOrFail(CountText, count + 1)
     }).pipe(
       withCodec(CountText, {
-        encode: count => ok(String(count)),
-        decode: text => ok(Number(text))
+        encode: count => ok(codecOk(String(count))),
+        decode: text => ok(codecOk(Number(text)))
       }),
       run
     )
@@ -193,8 +232,8 @@ describe('Codec', () => {
   })
 
   it('withDecoder handles only matching decode keys', () => {
-    const actual = decode(UserJson, '{"id":"u1","name":"Ada"}').pipe(
-      withDecoder(UserJson, json => ok(JSON.parse(json) as User)),
+    const actual = decodeOrFail(UserJson, '{"id":"u1","name":"Ada"}').pipe(
+      withDecoder(UserJson, json => ok(codecOk(JSON.parse(json) as User))),
       run
     )
 
@@ -202,8 +241,8 @@ describe('Codec', () => {
   })
 
   it('withDecoder leaves matching encode keys visible', () => {
-    const program = encode(UserJson, { id: 'u1', name: 'Ada' }).pipe(
-      withDecoder(UserJson, json => ok(JSON.parse(json) as User))
+    const program = encodeOrFail(UserJson, { id: 'u1', name: 'Ada' }).pipe(
+      withDecoder(UserJson, json => ok(codecOk(JSON.parse(json) as User)))
     )
 
     const residual: Fx<Encode<typeof UserJson>, string> = program
@@ -211,8 +250,8 @@ describe('Codec', () => {
   })
 
   it('withEncoder handles only matching encode keys', () => {
-    const actual = encode(UserJson, { id: 'u1', name: 'Ada' }).pipe(
-      withEncoder(UserJson, user => ok(JSON.stringify(user))),
+    const actual = encodeOrFail(UserJson, { id: 'u1', name: 'Ada' }).pipe(
+      withEncoder(UserJson, user => ok(codecOk(JSON.stringify(user)))),
       run
     )
 
@@ -220,8 +259,8 @@ describe('Codec', () => {
   })
 
   it('withEncoder leaves matching decode keys visible', () => {
-    const program = decode(UserJson, '{"id":"u1","name":"Ada"}').pipe(
-      withEncoder(UserJson, user => ok(JSON.stringify(user)))
+    const program = decodeOrFail(UserJson, '{"id":"u1","name":"Ada"}').pipe(
+      withEncoder(UserJson, user => ok(codecOk(JSON.stringify(user))))
     )
 
     const residual: Fx<Decode<typeof UserJson>, User> = program

--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -1,6 +1,7 @@
 import { at } from './Breadcrumb.js'
 import { Effect, withOrigin } from './Effect.js'
-import { Fx } from './Fx.js'
+import { Fail, fail } from './Fail.js'
+import { flatMap, Fx, ok } from './Fx.js'
 import { handle } from './Handler.js'
 
 export const CodecKeyTypeId: unique symbol = Symbol('fx/Codec/key')
@@ -9,22 +10,24 @@ export interface CodecKeyMetadata {
   readonly description?: string
 }
 
-export type CodecKey<A, Encoded, Id extends string | symbol = string | symbol> =
+export type CodecKey<A, Encoded, DecodeFailure = unknown, EncodeFailure = DecodeFailure, Id extends string | symbol = string | symbol> =
   CodecKeyMetadata & {
   readonly [CodecKeyTypeId]: {
     readonly value: A
     readonly encoded: Encoded
+    readonly decodeFailure: DecodeFailure
+    readonly encodeFailure: EncodeFailure
   }
   readonly id: Id
 }
 
-export type AnyCodecKey = CodecKey<any, any, any>
+export type AnyCodecKey = CodecKey<any, any, any, any, any>
 
 /**
  * Create a codec key with a string or symbol identity and optional metadata.
  */
-export const codecKey = <A, Encoded>() =>
-  <const Id extends string | symbol>(id: Id, metadata: CodecKeyMetadata = {}): CodecKey<A, Encoded, Id> =>
+export const codecKey = <A, Encoded, DecodeFailure = unknown, EncodeFailure = DecodeFailure>() =>
+  <const Id extends string | symbol>(id: Id, metadata: CodecKeyMetadata = {}): CodecKey<A, Encoded, DecodeFailure, EncodeFailure, Id> =>
     Object.defineProperty({
       ...metadata,
       id
@@ -33,13 +36,32 @@ export const codecKey = <A, Encoded>() =>
       enumerable: false,
       writable: false,
       configurable: false
-    }) as CodecKey<A, Encoded, Id>
+    }) as unknown as CodecKey<A, Encoded, DecodeFailure, EncodeFailure, Id>
 
 export type CodecValue<K> =
-  K extends CodecKey<infer A, any, any> ? A : never
+  K extends CodecKey<infer A, any, any, any, any> ? A : never
 
 export type CodecEncoded<K> =
-  K extends CodecKey<any, infer Encoded, any> ? Encoded : never
+  K extends CodecKey<any, infer Encoded, any, any, any> ? Encoded : never
+
+export type CodecDecodeFailure<K> =
+  K extends CodecKey<any, any, infer DecodeFailure, any, any> ? DecodeFailure : never
+
+export type CodecEncodeFailure<K> =
+  K extends CodecKey<any, any, any, infer EncodeFailure, any> ? EncodeFailure : never
+
+type CodecFailure<F> =
+  [F] extends [never] ? never : Fail<F>
+
+export type CodecResult<E, A> =
+  | { readonly tag: 'ok'; readonly value: A }
+  | { readonly tag: 'fail'; readonly error: E }
+
+export const codecOk = <const A>(value: A): CodecResult<never, A> =>
+  ({ tag: 'ok', value })
+
+export const codecFail = <const E>(error: E): CodecResult<E, never> =>
+  ({ tag: 'fail', error })
 
 export type CodecImplementation<K extends AnyCodecKey, EncodeEffects = never, DecodeEffects = never> = {
   readonly encode: Encoder<K, EncodeEffects>
@@ -47,10 +69,10 @@ export type CodecImplementation<K extends AnyCodecKey, EncodeEffects = never, De
 }
 
 export type Encoder<K extends AnyCodecKey, E = never> =
-  (value: CodecValue<K>) => Fx<E, CodecEncoded<K>>
+  (value: CodecValue<K>) => Fx<E, CodecResult<CodecEncodeFailure<K>, CodecEncoded<K>>>
 
 export type Decoder<K extends AnyCodecKey, E = never> =
-  (encoded: CodecEncoded<K>) => Fx<E, CodecValue<K>>
+  (encoded: CodecEncoded<K>) => Fx<E, CodecResult<CodecDecodeFailure<K>, CodecValue<K>>>
 
 /**
  * Request encoding a value with a branded codec key.
@@ -58,7 +80,7 @@ export type Decoder<K extends AnyCodecKey, E = never> =
 export class Encode<const K extends AnyCodecKey> extends Effect('fx/Codec/Encode')<{
   readonly codec: K
   readonly value: CodecValue<K>
-}, CodecEncoded<K>> { }
+}, CodecResult<CodecEncodeFailure<K>, CodecEncoded<K>>> { }
 
 /**
  * Request decoding an encoded value with a branded codec key.
@@ -66,7 +88,7 @@ export class Encode<const K extends AnyCodecKey> extends Effect('fx/Codec/Encode
 export class Decode<const K extends AnyCodecKey> extends Effect('fx/Codec/Decode')<{
   readonly codec: K
   readonly encoded: CodecEncoded<K>
-}, CodecValue<K>> { }
+}, CodecResult<CodecDecodeFailure<K>, CodecValue<K>>> { }
 
 /**
  * Encode a value using the handler associated with the codec key.
@@ -74,8 +96,19 @@ export class Decode<const K extends AnyCodecKey> extends Effect('fx/Codec/Decode
 export const encode = <const K extends AnyCodecKey>(
   codec: K,
   value: CodecValue<K>
-): Fx<Encode<K>, CodecEncoded<K>> =>
+): Fx<Encode<K>, CodecResult<CodecEncodeFailure<K>, CodecEncoded<K>>> =>
   withOrigin(new Encode({ codec, value }), at('fx/Codec/encode', encode))
+
+/**
+ * Encode a value and translate codec failure results into Fail.
+ */
+export const encodeOrFail = <const K extends AnyCodecKey>(
+  codec: K,
+  value: CodecValue<K>
+): Fx<Encode<K> | CodecFailure<CodecEncodeFailure<K>>, CodecEncoded<K>> =>
+  encode(codec, value).pipe(
+    flatMap(codecResultOrFail)
+  )
 
 /**
  * Decode an encoded value using the handler associated with the codec key.
@@ -83,8 +116,19 @@ export const encode = <const K extends AnyCodecKey>(
 export const decode = <const K extends AnyCodecKey>(
   codec: K,
   encoded: CodecEncoded<K>
-): Fx<Decode<K>, CodecValue<K>> =>
+): Fx<Decode<K>, CodecResult<CodecDecodeFailure<K>, CodecValue<K>>> =>
   withOrigin(new Decode({ codec, encoded }), at('fx/Codec/decode', decode))
+
+/**
+ * Decode an encoded value and translate codec failure results into Fail.
+ */
+export const decodeOrFail = <const K extends AnyCodecKey>(
+  codec: K,
+  encoded: CodecEncoded<K>
+): Fx<Decode<K> | CodecFailure<CodecDecodeFailure<K>>, CodecValue<K>> =>
+  decode(codec, encoded).pipe(
+    flatMap(codecResultOrFail)
+  )
 
 export type WithCodec<E, K extends AnyCodecKey, EncodeEffects = never, DecodeEffects = never> =
   E extends Encode<infer EK> ? HandleKeyedCodecEffect<E, EK, K, EncodeEffects>
@@ -109,8 +153,8 @@ export const withEncoder = <const K extends AnyCodecKey, EncodeEffects = never>(
       handle(Encode, effect =>
         (Object.is(effect.arg.codec.id, codec.id)
           ? encode(effect.arg.value as CodecValue<K>)
-          : effect as Fx<typeof effect, CodecEncoded<typeof effect.arg.codec>>
-        ) as Fx<EncodeEffects | Encode<AnyCodecKey>, CodecEncoded<typeof effect.arg.codec>>)
+          : effect as Fx<typeof effect, CodecResult<CodecEncodeFailure<typeof effect.arg.codec>, CodecEncoded<typeof effect.arg.codec>>>
+        ) as Fx<EncodeEffects | Encode<AnyCodecKey>, CodecResult<CodecEncodeFailure<typeof effect.arg.codec>, CodecEncoded<typeof effect.arg.codec>>>)
     ) as Fx<WithEncoder<E, K, EncodeEffects>, A>
 
 /**
@@ -125,8 +169,8 @@ export const withDecoder = <const K extends AnyCodecKey, DecodeEffects = never>(
       handle(Decode, effect =>
         (Object.is(effect.arg.codec.id, codec.id)
           ? decode(effect.arg.encoded as CodecEncoded<K>)
-          : effect as Fx<typeof effect, CodecValue<typeof effect.arg.codec>>
-        ) as Fx<DecodeEffects | Decode<AnyCodecKey>, CodecValue<typeof effect.arg.codec>>)
+          : effect as Fx<typeof effect, CodecResult<CodecDecodeFailure<typeof effect.arg.codec>, CodecValue<typeof effect.arg.codec>>>
+        ) as Fx<DecodeEffects | Decode<AnyCodecKey>, CodecResult<CodecDecodeFailure<typeof effect.arg.codec>, CodecValue<typeof effect.arg.codec>>>)
     ) as Fx<WithDecoder<E, K, DecodeEffects>, A>
 
 /**
@@ -151,3 +195,8 @@ type IsExact<A, B> =
   [A] extends [B]
     ? [B] extends [A] ? true : false
     : false
+
+const codecResultOrFail = <const E, const A>(result: CodecResult<E, A>): Fx<CodecFailure<E>, A> =>
+  result.tag === 'ok'
+    ? ok(result.value)
+    : fail(result.error) as unknown as Fx<CodecFailure<E>, A>


### PR DESCRIPTION
## Summary

- make codec handlers answer with CodecResult values and add encodeOrFail/decodeOrFail to translate codec failures into Fail
- refactor the bookmarks example so JSON parsing/stringifying lives in bookmark codecs while HTTP stream/text reading stays at the transport boundary
- apply bookmark codecs at server/client boundaries, document the bookmarks example, and explain the hand-rolled codec implementation

## Validation

- corepack pnpm build
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm lint