### PR TITLE
Preserve effect inference in package declarations

### DIFF
--- a/examples/advanced/incident-collector/domain.test.ts
+++ b/examples/advanced/incident-collector/domain.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { bounded, defaultAll, firstSuccess } from '@briancavalier/fx/concurrent'
-import { type Async, type Fx, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
+import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
 import { withScope } from '@briancavalier/fx/scope'
@@ -127,7 +127,7 @@ describe('incident collector example', () => {
       returnAll
     )
 
-    const runnable: Fx<Async | Interrupt, unknown> = handled
+    const runnable: Fx<Async | HandlerCapture<string> | Interrupt, unknown> = handled
     void runnable
   })
 })

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -1,5 +1,5 @@
 import { all, race, type All, type Race } from '@briancavalier/fx/concurrent'
-import { Effect, fail, type Fail, fx, type Fx, handle, type Interrupt, ok } from '@briancavalier/fx'
+import { Effect, fail, type Fail, fx, type Fx, handle, type HandlerCapture, type Interrupt, ok } from '@briancavalier/fx'
 
 import { managed, scope, using, usingManaged, type Finally, type Managed } from '@briancavalier/fx/scope'
 
@@ -71,6 +71,8 @@ export type IncidentCollectorEffects =
   | Finally<typeof BundleScope>
   | Finally<typeof CollectorScope, Log>
   | Interrupt
+  | HandlerCapture<'fx/Concurrent/All'>
+  | HandlerCapture<'fx/Concurrent/Race'>
   | Fail<IncidentCollectorError>
 
 /**

--- a/examples/advanced/tool-agent/domain.test.ts
+++ b/examples/advanced/tool-agent/domain.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { bounded, defaultAll } from '@briancavalier/fx/concurrent'
-import { type Async, type Fx, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
+import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
 import { collectFrom, withScope } from '@briancavalier/fx/scope'
@@ -149,7 +149,7 @@ describe('tool agent example', () => {
       collectFrom(AgentEvents)
     )
 
-    const runnable: Fx<Async | Interrupt, unknown> = handled
+    const runnable: Fx<Async | HandlerCapture<string> | Interrupt, unknown> = handled
     void runnable
   })
 })

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -1,5 +1,5 @@
 import { type All, all } from '@briancavalier/fx/concurrent'
-import { Effect, fail, type Fail, fx, type Fx, type Interrupt } from '@briancavalier/fx'
+import { Effect, fail, type Fail, fx, type Fx, type HandlerCapture, type Interrupt } from '@briancavalier/fx'
 
 import { scope, type Finally, type Managed, usingManaged, type YieldFrom, type Yielding } from '@briancavalier/fx/scope'
 import { info, type Log } from '@briancavalier/fx/log'
@@ -69,8 +69,9 @@ export type ToolAgentEffects =
   | StartAgentSession
   | Log
   | Time
-  | Finally<typeof AgentSessionScope, YieldFrom<typeof AgentEvents>>
   | Interrupt
+  | HandlerCapture<'fx/Concurrent/All'>
+  | Finally<typeof AgentSessionScope, YieldFrom<typeof AgentEvents>>
   | Fail<AgentError>
 
 /**

--- a/examples/intermediate/scoped-state.ts
+++ b/examples/intermediate/scoped-state.ts
@@ -1,4 +1,4 @@
-import { consoleLog, defaultConsole, fx, runPromise, trySync } from '@briancavalier/fx'
+import { consoleLog, defaultConsole, fx, ok, runPromise } from '@briancavalier/fx'
 import { scope, withScope } from '@briancavalier/fx/scope'
 import { getState, modifyState, type Stateful, withStateInit } from '@briancavalier/fx/state'
 
@@ -26,7 +26,7 @@ const program = fx(function* () {
 
 await program.pipe(
   withScope(SessionState),
-  withStateInit(SessionState, trySync(() => ({ requests: 0, lastRoute: 'none' }))),
+  withStateInit(SessionState, ok({ requests: 0, lastRoute: 'none' })),
   defaultConsole,
   runPromise
 ).then(console.log)

--- a/examples/package-import-inference.test.ts
+++ b/examples/package-import-inference.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { Effect, fx, ScopedEffect, type Fx } from '@briancavalier/fx'
+import { scope, type AnyScope } from '@briancavalier/fx/scope'
+
+type EffectOf<T> = T extends Fx<infer E, unknown> ? E : never
+type IsAny<T> = 0 extends 1 & T ? true : false
+
+describe('package import inference', () => {
+  it('preserves Effect instance types through package declarations', () => {
+    class AskName extends Effect('test/package-import-inference/AskName')<string, string> { }
+
+    const program = fx(function* () {
+      return yield* new AskName('name')
+    })
+
+    const effectIsAny: IsAny<EffectOf<typeof program>> = false
+    const effectIsAskName: EffectOf<typeof program> extends AskName ? true : false = true
+
+    // @ts-expect-error AskName remains visible until a handler removes it.
+    const runnable: Fx<never, string> = program
+
+    assert.equal(effectIsAny, false)
+    assert.equal(effectIsAskName, true)
+    void runnable
+  })
+
+  it('preserves ScopedEffect instance types through package declarations', () => {
+    const Scope = scope('test/package-import-inference/ScopedAsk')
+    class ScopedAsk<const S extends AnyScope> extends ScopedEffect('test/package-import-inference/ScopedAsk')<S, string, string> { }
+
+    const program = fx(function* () {
+      return yield* new ScopedAsk(Scope, 'name')
+    })
+
+    const effectIsAny: IsAny<EffectOf<typeof program>> = false
+    const effectIsScopedAsk: EffectOf<typeof program> extends ScopedAsk<typeof Scope> ? true : false = true
+
+    // @ts-expect-error ScopedAsk remains visible until a scoped handler removes it.
+    const runnable: Fx<never, string> = program
+
+    assert.equal(effectIsAny, false)
+    assert.equal(effectIsScopedAsk, true)
+    void runnable
+  })
+})

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -20,6 +20,34 @@ export interface AnyEffect {
   readonly arg: unknown
 }
 
+export interface EffectInstance<Id, A, R> extends AnyEffect, Pipeable {
+  readonly _fxEffectId: Id
+  readonly arg: A
+  readonly R: R
+
+  returning<RR extends R>(): Fx<this, RR>
+  [Symbol.iterator](): Iterator<this, R, any>
+}
+
+export interface EffectClass<Id> extends EffectType {
+  readonly _fxEffectId: Id
+  new<A, R = unknown>(arg: A): EffectInstance<Id, A, R>
+  is<E extends EffectType>(this: E, x: unknown): x is InstanceType<E>
+}
+
+export interface ScopedEffectInstance<Id, Scope extends AnyScope, A, R> extends EffectInstance<Id, A, R> {
+  readonly scope: Scope
+}
+
+export interface ScopedEffectClass<Id> extends EffectType {
+  readonly _fxEffectId: Id
+  new<const Scope extends AnyScope, A = void, R = unknown>(
+    scope: Scope,
+    arg: A
+  ): ScopedEffectInstance<Id, Scope, A, R>
+  is<E extends EffectType>(this: E, x: unknown): x is InstanceType<E>
+}
+
 export interface EffectOrigin {
   readonly [EffectOriginTypeId]: TraceOrigin
 }
@@ -40,7 +68,7 @@ export interface EffectOrigin {
  * const user = yield* findUser('user-1')
  * ```
  */
-export const Effect = <const T extends string>(id: T) => class <A, R = unknown> implements AnyEffect, Pipeable {
+export const Effect = <const T extends string>(id: T): EffectClass<T> => class <A, R = unknown> implements EffectInstance<T, A, R> {
   public readonly _fxTypeId: typeof EffectTypeId = EffectTypeId;
   public readonly _fxEffectId = id;
   public static readonly _fxEffectId = id;
@@ -58,7 +86,7 @@ export const Effect = <const T extends string>(id: T) => class <A, R = unknown> 
   [Symbol.iterator](): Iterator<this, R, any> {
     return new Once<this, R>(this)
   }
-}
+} as EffectClass<T>
 
 /**
  * Define an effect type whose requests are associated with a named scope.
@@ -80,11 +108,11 @@ export const ScopedEffect = <const T extends string>(id: T) => class <
   const Scope extends AnyScope,
   A = void,
   R = unknown
-> extends Effect(id)<A, R> {
+> extends Effect(id)<A, R> implements ScopedEffectInstance<T, Scope, A, R> {
   constructor(public readonly scope: Scope, arg: A) {
     super(arg)
   }
-}
+} as ScopedEffectClass<T>
 
 export const isEffect = <E>(e: E): e is E & AnyEffect =>
   !!e && (e as any)._fxTypeId === EffectTypeId

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -39,6 +39,7 @@ export {
   type HandleReturn,
   type HandleScoped
 } from '../Handler.js'
+export { HandlerCapture, type CapturedHandler } from '../HandlerCapture.js'
 export {
   assert,
   catchAll,


### PR DESCRIPTION
## Summary
- preserve Effect and ScopedEffect instance yield types in emitted package declarations
- expose HandlerCapture from the root entrypoint so public examples can name residual concurrent handler capture effects
- fix newly visible example type rows and add package-import inference regression tests

## Validation
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm lint