### PR TITLE
[codex] Add mapAll concurrency helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,18 @@ Low-value wrappers:
 - Prefer local readable duplication over extracting a generic helper from a single use.
 - If a wrapper is kept for a non-obvious reason, leave a short comment or add a focused test that makes the reason visible.
 
+Type assertions and inference:
+- Treat `as` assertions as a last resort. First write the direct expression and
+  run `corepack pnpm typecheck`.
+- Keep assertions only when TypeScript cannot express the intended type without
+  them. Prefer explicit return types, generic constraints, `satisfies`, or typed
+  local intermediates before asserting.
+- Do not use broad result assertions to paper over `E` unions, `Fail`,
+  handler-capture effects, or public inference issues.
+- If an assertion remains, make it local and narrow. For non-obvious assertions,
+  document the TypeScript limitation or runtime invariant that makes it sound.
+- Add focused type-level tests when an assertion protects public API inference.
+
 Development guidance:
 - Prefer existing patterns in `src/Fx.ts`, `src/Effect.ts`, and `src/Handler.ts`.
 - Implementation modules are not automatically public. Public package API is

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -1,4 +1,4 @@
-import { all, race, type All, type Race } from '@briancavalier/fx/concurrent'
+import { all, mapAll, race, type All, type Race } from '@briancavalier/fx/concurrent'
 import { Effect, fail, type Fail, fx, type Fx, handle, type HandlerCapture, type Interrupt, ok } from '@briancavalier/fx'
 
 import { managed, scope, using, usingManaged, type Finally, type Managed } from '@briancavalier/fx/scope'
@@ -256,7 +256,7 @@ export const createIncidentCollectorFixture = (options: FixtureOptions = {}) => 
 }
 
 const collectServiceLogs = (bundle: Bundle, services: readonly ServiceName[]) => withCollector('logs', fx(function* () {
-  const logs = yield* all(services.map(service => collectOneServiceLog(bundle, service)))
+  const logs = yield* mapAll(services, service => collectOneServiceLog(bundle, service))
   return logs
 }))
 

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -1,4 +1,4 @@
-import { type All, all } from '@briancavalier/fx/concurrent'
+import { type All, mapAll } from '@briancavalier/fx/concurrent'
 import { Effect, fail, type Fail, fx, type Fx, type HandlerCapture, type Interrupt } from '@briancavalier/fx'
 
 import { scope, type Finally, type Managed, usingManaged, type YieldFrom, type Yielding } from '@briancavalier/fx/scope'
@@ -107,7 +107,7 @@ export const runAgent = (
     return yield* fail({ tag: 'ModelError', reason: 'model returned a summary when a plan was requested' })
   }
 
-  const results = yield* all(plan.toolCalls.map(runTool))
+  const results = yield* mapAll(plan.toolCalls, runTool)
   const summary = yield* askModel({ type: 'summarize', task, results })
   if (summary.type !== 'summary') {
     return yield* fail({ tag: 'ModelError', reason: 'model returned a plan when a summary was requested' })

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,6 +19,10 @@ Rules for changes:
 - Prefer this module order: effect declaration, public constructors/combinators, public handlers, exported support types, internal handler functions, internal helper types/functions.
 - Effect constructor/combinator docs should describe the requested effect. Avoid promising semantics that are determined by handlers.
 - Handler docs should describe the interpretation that handler provides.
+- Public constructors and combinators should trust existing typed primitives
+  such as `all`, `race`, `ok`, `fail`, `handle`, and `flatMap`. Do not add
+  assertions around delegating wrappers unless `corepack pnpm typecheck` proves
+  they are necessary.
 - Prefer pipeable constructors for higher-order effects, e.g. `fx.pipe(retry(options))` or `fx.pipe(timeout(RequestScope, options))`.
 - Prefer options objects once an effect constructor has more than one meaningful option or likely future extension point.
 - For higher-order scoped effects, preserve effect typing through the request and handler. If failures cross fork/race/task boundaries, convert them to data before racing unless runtime semantics explicitly preserve typed failures.

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { RaceAllFailed, all, bounded, defaultAll, firstSettled, firstSuccess, fork, forkEach, race, unbounded } from './Concurrent.js'
+import { RaceAllFailed, all, bounded, defaultAll, firstSettled, firstSuccess, fork, forkEach, mapAll, race, unbounded } from './Concurrent.js'
 import { andFinally, andFinallyExit } from './Finalization.js'
 import { bracket, flatMap, fx, ok, runPromise } from './Fx.js'
 import { handle } from './Handler.js'
@@ -401,6 +401,148 @@ describe('Fork', () => {
       )
 
       assert.deepEqual(result, [1, 'two'])
+    })
+
+    it('maps iterable items to child values in input order', async () => {
+      const result = await mapAll([3, 1, 2], n => asyncValue(n * 2)).pipe(
+        defaultAll,
+        unbounded,
+        runPromise
+      )
+
+      assert.deepEqual(result, [6, 2, 4])
+    })
+
+    it('passes the zero-based index to the mapper', async () => {
+      const indexes = [] as number[]
+
+      const result = await mapAll(['a', 'b', 'c'], (value, index) => {
+        indexes.push(index)
+        return ok(`${index}:${value}`)
+      }).pipe(
+        defaultAll,
+        unbounded,
+        runPromise
+      )
+
+      assert.deepEqual(indexes, [0, 1, 2])
+      assert.deepEqual(result, ['0:a', '1:b', '2:c'])
+    })
+
+    it('supports general iterables', async () => {
+      function* values() {
+        yield 1
+        yield 2
+        yield 3
+      }
+
+      const result = await mapAll(values(), n => ok(n + 10)).pipe(
+        defaultAll,
+        unbounded,
+        runPromise
+      )
+
+      assert.deepEqual(result, [11, 12, 13])
+    })
+
+    it('starts mapped children concurrently', async () => {
+      const events = [] as string[]
+      const child = (n: number) => fx(function* () {
+        events.push(`start ${n}`)
+        yield* asyncValue(undefined)
+        events.push(`end ${n}`)
+        return n
+      })
+
+      const result = await mapAll([1, 2, 3], child).pipe(
+        defaultAll,
+        unbounded,
+        runPromise
+      )
+
+      assert.deepEqual(result, [1, 2, 3])
+      assert.deepEqual(events.slice(0, 3), ['start 1', 'start 2', 'start 3'])
+    })
+
+    it('respects bounded scheduling for mapped children', async () => {
+      const events = [] as string[]
+      const child = (n: number) => fx(function* () {
+        events.push(`start ${n}`)
+        yield* asyncValue(undefined)
+        events.push(`end ${n}`)
+        return n
+      })
+
+      const result = await mapAll([1, 2, 3], child).pipe(
+        defaultAll,
+        bounded(1),
+        runPromise
+      )
+
+      assert.deepEqual(result, [1, 2, 3])
+      assert.deepEqual(events, ['start 1', 'end 1', 'start 2', 'end 2', 'start 3', 'end 3'])
+    })
+
+    it('cancels mapped siblings when a child fails', async () => {
+      const cause = new Error('mapAll failed')
+      let cancelled = false
+      const slow = assertPromise<void>(signal => new Promise(resolve => {
+        signal.addEventListener('abort', () => {
+          cancelled = true
+          resolve()
+        }, { once: true })
+      }))
+      const child = (n: number) => n === 1
+        ? slow
+        : fx(function* () {
+          yield* asyncValue(undefined)
+          yield* fail(cause)
+        })
+
+      const result = await mapAll([1, 2], child).pipe(
+        defaultAll,
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.equal(cancelled, true)
+    })
+
+    it('runs mapped children with handlers between mapAll and defaultAll', async () => {
+      class CurrentValue extends Effect('test/Fork/MapAllCurrentValue')<void, string> { }
+
+      const result = await mapAll([1], () => new CurrentValue()).pipe(
+        handle(CurrentValue, () => ok('handled')),
+        defaultAll,
+        unbounded,
+        runPromise
+      )
+
+      assert.deepEqual(result, ['handled'])
+    })
+
+    it('types mapAll as a value array and preserves child Fail errors', async () => {
+      const cause = new Error('mapAll typed failure')
+      const result = await fx(function* () {
+        const values = yield* mapAll([1, 2], n => n === 1 ? ok(n) : fail(cause))
+        const array: readonly number[] = values
+        // @ts-expect-error mapAll returns values directly, not a Task.
+        const task: Task<readonly number[], Fail<Error>> = values
+        void task
+        return array
+      }).pipe(
+        defaultAll,
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const error: Error = result.arg
+      assert.equal(error.cause, cause)
     })
   })
 

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -524,6 +524,25 @@ describe('Fork', () => {
       assert.deepEqual(result, ['handled'])
     })
 
+    it('preserves the mapAll call site in indexed child task failure traces', async () => {
+      const cause = new Error('mapAll traced failure')
+
+      const result = await mapAll([cause], error => fx(function* () {
+        yield* fail(error)
+      })).pipe(
+        defaultAll,
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.match(firstLine(result.arg), /fx\/Fail\/fail/)
+      assert.match(result.arg.stack ?? '', /Concurrent\.test\.ts/)
+      assert.deepEqual(traceMessages(result.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
+      assert.equal((result.arg as Error).cause, cause)
+    })
+
     it('types mapAll as a value array and preserves child Fail errors', async () => {
       const cause = new Error('mapAll typed failure')
       const result = await fx(function* () {

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -135,7 +135,7 @@ export const mapAll = <const A, const E, const B>(
   options?: TraceOptions
 ): Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]> => {
   const trace = traceOrigin(options, 'fx/Concurrent/mapAll', mapAll, 'all')
-  return all(Array.from(items, f) as readonly Fx<E, B>[], trace) as Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]>
+  return all(Array.from(items, f), trace)
 }
 
 /**

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -120,6 +120,23 @@ export const all = <const Fxs extends readonly Fx<unknown, unknown>[]>(
 }
 
 /**
+ * Map an iterable to child computations and run them concurrently in input
+ * order.
+ *
+ * Pair `mapAll` with {@link defaultAll} and a fork scheduler such as
+ * {@link bounded} or {@link unbounded}.
+ *
+ * @example
+ * const users = yield* mapAll(userIds, id => fetchUser(id))
+ */
+export const mapAll = <const A, const E, const B>(
+  items: Iterable<A>,
+  f: (item: A, index: number) => Fx<E, B>,
+  options?: TraceOptions
+): Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]> =>
+  all(Array.from(items, f) as readonly Fx<E, B>[], options) as Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]>
+
+/**
  * Request that a tuple of Fx computations race in a structured scope.
  *
  * Pair `race` with {@link firstSettled} for first-settled semantics or

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -133,8 +133,10 @@ export const mapAll = <const A, const E, const B>(
   items: Iterable<A>,
   f: (item: A, index: number) => Fx<E, B>,
   options?: TraceOptions
-): Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]> =>
-  all(Array.from(items, f) as readonly Fx<E, B>[], options) as Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]>
+): Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]> => {
+  const trace = traceOrigin(options, 'fx/Concurrent/mapAll', mapAll, 'all')
+  return all(Array.from(items, f) as readonly Fx<E, B>[], trace) as Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]>
+}
 
 /**
  * Request that a tuple of Fx computations race in a structured scope.


### PR DESCRIPTION
## Summary

- Add `mapAll` to `@briancavalier/fx/concurrent` as the iterable-shaped sibling of `all`.
- Implement it as a small wrapper over `all(Array.from(...))`, preserving existing `defaultAll`, `bounded`, cancellation, handler-capture, and trace semantics.
- Update the tool-agent and incident-collector examples where dynamic collections previously used `all(items.map(...))`.

## Validation

- `node --import tsx --test src/Concurrent.test.ts`
- `node --import tsx --test examples/advanced/tool-agent/domain.test.ts`
- `node --import tsx --test examples/advanced/incident-collector/domain.test.ts`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`