### PR TITLE
[codex] Fix benchmark harness and runtime trace regressions

### DIFF
--- a/benchmarks/results/2026-05-26-benchmark-harness-and-trace-regressions.md
+++ b/benchmarks/results/2026-05-26-benchmark-harness-and-trace-regressions.md
@@ -1,0 +1,86 @@
+# Benchmark Harness Fix And Trace Regression Investigation
+
+- Date: 2026-05-26
+- Worktree: `/private/tmp/fx-benchmark-harness-regressions`
+- Branch: `codex/benchmark-harness-regressions`
+- Base SHA: `192e251`
+- Node: `v24.14.0`
+- Platform: `darwin 25.3.0 arm64`
+
+## Summary
+
+- Fixed `pnpm benchmark:runtime-loops` after scope and task lifecycle API changes.
+- Investigated the trace labels/off regressions from `benchmarks/results/2026-05-25-weekly-benchmarks.md`.
+- Found the main regression point at `fefff46` (`Finalize scopes on task interruption`).
+- Kept the cleanup semantics and removed an avoidable runtime-boundary cost instead: `run`, `runTask`, and `runFork` now handle the default empty environment directly instead of wrapping every runtime execution in `provideAll({})`.
+
+## Harness Fix
+
+`benchmarks/runtime-loops.ts` had two stale API assumptions:
+
+- `scope(name)` now creates a scope token; the handler is `withScope(scopeToken)`.
+- `Task` interruption is now `task.interrupt()`, replacing the old disposal helpers used by the benchmark.
+
+The benchmark now runs successfully and preserves existing benchmark names for historical comparison.
+
+## Regression Root Cause
+
+The trace regression was not primarily trace-policy-specific. `run` and `runTask` always wrapped programs with `provideAll({})`, which adds a general handler around every runtime execution. After `fefff46`, handlers and controls gained generator `try/finally` cleanup paths so interrupted tasks can drain yielded cleanup effects. That semantic fix made the previously cheap default environment wrapper visible in hot paths.
+
+The fix keeps cleanup draining intact and handles `Get` at the runtime boundary:
+
+- `run` resumes `Get` effects with `{}` directly.
+- `runFork` resumes `Get` effects with `{}` directly.
+- `runTask` no longer wraps the program with `provideAll({})`.
+
+## Commit Sweep
+
+Selected rows from the same-machine commit sweep:
+
+| Commit | pure runtime baseline | handled fail labels | handled fail off | successful assertPromise labels | successful assertPromise off |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `35db822` | 135 | 573 | 530 | 937 | 884 |
+| `5ae689b` | 133 | 735 | 548 | 970 | 942 |
+| `fefff46` | 1186 | 2334 | 5531 | 3410 | 2878 |
+| `192e251` before fix | 1178 | 2137 | 2045 | 2722 | 2188 |
+| candidate final | 235 | 2500 | 1913 | 1594 | 1126 |
+
+## Trace Results
+
+Compared against the current pre-fix run from this worktree:
+
+| Case | Before ns/op | After ns/op | Change |
+| --- | ---: | ---: | ---: |
+| pure runtime baseline | 1178 | 235 | -80.1% |
+| successful assertPromise labels | 2722 | 1594 | -41.4% |
+| successful assertPromise off | 2188 | 1126 | -48.5% |
+| nested fork failure labels | 61647 | 59942 | -2.8% |
+| nested fork failure off | 57430 | 50637 | -11.8% |
+| handled fail | 6655 | 6047 | -9.1% |
+| prebuilt handled fail | 3842 | 1701 | -55.7% |
+| handled fail labels | 2137 | 2500 | +17.0% |
+| handled fail off | 2045 | 1913 | -6.5% |
+
+Compared against the saved `2026-05-07-trace-policy-and-fast-paths.md` artifact, the runtime-boundary rows are back near or better than the old artifact:
+
+| Case | Saved ns/op | After ns/op | Change |
+| --- | ---: | ---: | ---: |
+| pure runtime baseline | 233 | 235 | +0.9% |
+| successful assertPromise labels | 1670 | 1594 | -4.6% |
+| successful assertPromise off | 1579 | 1126 | -28.7% |
+| nested fork failure labels | 63256 | 59942 | -5.2% |
+| nested fork failure off | 59227 | 50637 | -14.5% |
+
+## Remaining Regression
+
+`handled fail labels` and `handled fail off` remain slower than the May 7 artifact. Those rows are synchronous `control(Fail, ...)` paths, not runtime-boundary `runTask` paths. They still pay the handler/control cleanup-drain overhead introduced for interrupted-finalizer correctness. A follow-up should investigate whether `Handler` and `Control` can avoid generator `try/finally` cost on normal completion without giving up cleanup draining on runtime `return()`.
+
+## Validation
+
+- `corepack pnpm benchmark:trace`: pass
+- `corepack pnpm benchmark:runtime-context`: pass
+- `corepack pnpm benchmark:runtime-loops`: pass
+- `corepack pnpm build`: pass
+- `corepack pnpm lint`: pass
+- `corepack pnpm test`: pass
+- `corepack pnpm typecheck`: pass after `build` generated package declarations for example package imports

--- a/benchmarks/runtime-loops.ts
+++ b/benchmarks/runtime-loops.ts
@@ -10,7 +10,7 @@ import { fx, ok, run, runPromise, runTask } from '../src/Fx.js'
 import { control, handle } from '../src/Handler.js'
 import { captureHandlers, closeHandlerCapture, mapCapturedHandlers, withHandlerContext } from '../src/HandlerCapture.js'
 import { uninterruptible } from '../src/Interrupt.js'
-import { scope } from '../src/Scope.js'
+import { scope, withScope } from '../src/Scope.js'
 import { wait } from '../src/Task.js'
 import { setTraceCapturePolicy } from '../src/Trace.js'
 import { Handler as InternalHandler } from '../src/internal/Handler.js'
@@ -66,10 +66,12 @@ const forkFanout16 = forkFanout(16)
 const allFanout16 = all(fanoutValues(16))
 const raceFanout16 = race(fanoutValues(16))
 const blocked = assertPromise<void>(() => new Promise(() => { }))
+const InterruptScope = scope('benchmark/runtime-loops/Interrupt')
+const ScopeFinalizer = scope('benchmark/runtime-loops/ScopeFinalizer')
 const blockedWithFinalizer = fx(function* () {
-  yield* andFinally('benchmark/runtime-loops/Interrupt', ok(undefined))
+  yield* andFinally(InterruptScope, ok(undefined))
   return yield* blocked
-}).pipe(scope('benchmark/runtime-loops/Interrupt'))
+}).pipe(withScope(InterruptScope))
 
 const handlerContextDepths = [0, 1, 4, 8, 16] as const
 const captureFanouts = [1, 4, 16, 64] as const
@@ -172,7 +174,7 @@ const cases: readonly BenchmarkCase[] = [
   ),
   ...handlerContextDepths.map(depth =>
     benchmark(`scope finalizer registration depth ${depth}`, 'scope', CaptureIterations, 500, () => {
-      finalizerProgram(depth).pipe(scope('benchmark/runtime-loops/ScopeFinalizer'), run)
+      finalizerProgram(depth).pipe(withScope(ScopeFinalizer), run)
     })
   ),
   ...handlerContextDepths.map(depth =>
@@ -230,8 +232,7 @@ const cases: readonly BenchmarkCase[] = [
   benchmark('dispose blocked fork', 'interrupt', InterruptIterations, 100, async () => {
     await fx(function* () {
       const task = yield* fork(blocked)
-      task[Symbol.dispose]()
-      yield* assertPromise(() => task._disposeAndWait())
+      yield* assertPromise(() => task.interrupt())
     }).pipe(unbounded, runPromise)
   })
 ]
@@ -359,14 +360,14 @@ function directHandlerStack(depth: number) {
 
 function applyScopes(f: Fx<unknown, unknown>, depth: number) {
   let current = f as Fx<any, any>
-  for (let i = 0; i < depth; i++) current = current.pipe(scope(`benchmark/runtime-loops/Scope/${i}`))
+  for (let i = 0; i < depth; i++) current = current.pipe(withScope(scope(`benchmark/runtime-loops/Scope/${i}`)))
   return current as Fx<any, any>
 }
 
 function finalizerProgram(count: number) {
   return fx(function* () {
     for (let i = 0; i < count; i++) {
-      yield* andFinally('benchmark/runtime-loops/ScopeFinalizer', ok(undefined))
+      yield* andFinally(ScopeFinalizer, ok(undefined))
     }
   })
 }
@@ -414,8 +415,7 @@ function applyHandlers(f: Fx<unknown, unknown>, handlers: readonly ((fx: Fx<any,
 
 async function disposeTask(f: Fx<any, unknown>) {
   const task = runTask(f)
-  task[Symbol.dispose]()
-  await task._disposeAndWait()
+  await task.interrupt()
 }
 
 function gitSha(): string {

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -9,6 +9,7 @@ import { Task, wait as waitTask } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
 import { Semaphore } from './internal/Semaphore.js'
+import { currentForkRuntime, createForkRuntime } from './internal/forkRuntime.js'
 import { acquireAndRunFork } from './internal/runFork.js'
 import { currentRuntimeContext } from './internal/runtimeContext.js'
 
@@ -255,7 +256,7 @@ export const unbounded = bounded(Infinity)
 
 const runForkWith = (s: Semaphore) =>
   (fork: Fork): Fx<never, Task<unknown, unknown>> =>
-    ok(acquireAndRunFork(fork.arg, s))
+    ok(acquireAndRunFork(fork.arg, s, currentForkRuntime() ?? createForkRuntime()))
 
 const childFrameKind = (trace: Trace | undefined) =>
   trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -237,6 +237,25 @@ describe('Fx', () => {
         count: 2
       })
     })
+
+    it('isolates default environments across nested runtime entrypoints', async () => {
+      const inner = fx(function* () {
+        const env = yield* get<{ count?: number }>()
+        env.count = (env.count ?? 0) + 1
+        return env.count
+      })
+
+      const actual = await runTask(fx(function* () {
+        const env = yield* get<{ count?: number }>()
+        env.count = 1
+
+        const innerCount = yield* assertPromise(() => runTask(inner).promise)
+        const after = yield* get<{ count?: number }>()
+        return { innerCount, outerCount: after.count }
+      })).promise
+
+      assert.deepEqual(actual, { innerCount: 1, outerCount: 1 })
+    })
   })
 
   describe('runPromise', () => {

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -1,11 +1,13 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
+import { fork, unbounded } from './Concurrent.js'
 import { Effect } from './Effect.js'
 import { get, provideAll } from './Env.js'
 import { Fail, returnFail } from './Fail.js'
 import { assertSync, flatMap, fx, ok, run, runPromise, runTask, trySync } from './Fx.js'
 import { control, handle } from './Handler.js'
+import { wait } from './Task.js'
 import { getTrace } from './Trace.js'
 
 describe('Fx', () => {
@@ -190,12 +192,16 @@ describe('Fx', () => {
       const optional = fx(function* ({ name }: { readonly name?: string }) {
         return name ?? 'anonymous'
       })
+      const mixed = required.pipe(flatMap(() => optional))
 
       // @ts-expect-error required env remains unhandled at the runtime boundary
       runTask(required)
+      // @ts-expect-error mixed env still includes a required branch
+      runTask(mixed)
 
       assert.equal(await runTask(optional).promise, 'anonymous')
       assert.equal(await runTask(required.pipe(provideAll({ name: 'Brian' }))).promise, 'Brian')
+      assert.equal(await runTask(mixed.pipe(provideAll({ name: 'Brian' }))).promise, 'Brian')
     })
 
     it('reuses one default environment object across gets', async () => {
@@ -207,6 +213,29 @@ describe('Fx', () => {
       })).promise
 
       assert.deepEqual(actual, { same: true, count: 1 })
+    })
+
+    it('shares one default environment object across forked tasks', async () => {
+      const actual = await runTask(fx(function* () {
+        const parent = yield* get<{ count?: number }>()
+        parent.count = 1
+
+        const child = yield* fork(fx(function* () {
+          const env = yield* get<{ count?: number }>()
+          env.count = (env.count ?? 0) + 1
+          return { sameAsParent: env === parent, count: env.count }
+        }))
+
+        const childResult = yield* wait(child)
+        const after = yield* get<{ count?: number }>()
+        return { childResult, sameAfterWait: after === parent, count: after.count }
+      }).pipe(unbounded)).promise
+
+      assert.deepEqual(actual, {
+        childResult: { sameAsParent: true, count: 2 },
+        sameAfterWait: true,
+        count: 2
+      })
     })
   })
 
@@ -261,12 +290,16 @@ describe('Fx', () => {
       const optional = fx(function* ({ name }: { readonly name?: string }) {
         return name ?? 'anonymous'
       })
+      const mixed = required.pipe(flatMap(() => optional))
 
       // @ts-expect-error required env remains unhandled at the runtime boundary
       await runPromise(required)
+      // @ts-expect-error mixed env still includes a required branch
+      await runPromise(mixed)
 
       assert.equal(await runPromise(optional), 'anonymous')
       assert.equal(await runPromise(required.pipe(provideAll({ name: 'Brian' }))), 'Brian')
+      assert.equal(await runPromise(mixed.pipe(provideAll({ name: 'Brian' }))), 'Brian')
     })
   })
 
@@ -278,12 +311,16 @@ describe('Fx', () => {
       const optional = fx(function* ({ name }: { readonly name?: string }) {
         return name ?? 'anonymous'
       })
+      const mixed = required.pipe(flatMap(() => optional))
 
       // @ts-expect-error required env remains unhandled at the runtime boundary
       run(required)
+      // @ts-expect-error mixed env still includes a required branch
+      run(mixed)
 
       assert.equal(run(optional), 'anonymous')
       assert.equal(run(required.pipe(provideAll({ name: 'Brian' }))), 'Brian')
+      assert.equal(run(mixed.pipe(provideAll({ name: 'Brian' }))), 'Brian')
     })
 
     it('reuses one default environment object across gets', () => {

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -182,6 +182,21 @@ describe('Fx', () => {
           && e.cause === cause
       )
     })
+
+    it('requires required environment to be provided before running', async () => {
+      const required = fx(function* ({ name }: { readonly name: string }) {
+        return name
+      })
+      const optional = fx(function* ({ name }: { readonly name?: string }) {
+        return name ?? 'anonymous'
+      })
+
+      // @ts-expect-error required env remains unhandled at the runtime boundary
+      runTask(required)
+
+      assert.equal(await runTask(optional).promise, 'anonymous')
+      assert.equal(await runTask(required.pipe(provideAll({ name: 'Brian' }))).promise, 'Brian')
+    })
   })
 
   describe('runPromise', () => {
@@ -226,6 +241,38 @@ describe('Fx', () => {
         && firstLine(e).includes('fx/runPromise')
         && e.message === 'Unhandled exception in forked task'
         && e.cause === cause)
+    })
+
+    it('requires required environment to be provided before running', async () => {
+      const required = fx(function* ({ name }: { readonly name: string }) {
+        return name
+      })
+      const optional = fx(function* ({ name }: { readonly name?: string }) {
+        return name ?? 'anonymous'
+      })
+
+      // @ts-expect-error required env remains unhandled at the runtime boundary
+      await runPromise(required)
+
+      assert.equal(await runPromise(optional), 'anonymous')
+      assert.equal(await runPromise(required.pipe(provideAll({ name: 'Brian' }))), 'Brian')
+    })
+  })
+
+  describe('run', () => {
+    it('requires required environment to be provided before running', () => {
+      const required = fx(function* ({ name }: { readonly name: string }) {
+        return name
+      })
+      const optional = fx(function* ({ name }: { readonly name?: string }) {
+        return name ?? 'anonymous'
+      })
+
+      // @ts-expect-error required env remains unhandled at the runtime boundary
+      run(required)
+
+      assert.equal(run(optional), 'anonymous')
+      assert.equal(run(required.pipe(provideAll({ name: 'Brian' }))), 'Brian')
     })
   })
 })

--- a/src/Fx.test.ts
+++ b/src/Fx.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
-import { provideAll } from './Env.js'
+import { get, provideAll } from './Env.js'
 import { Fail, returnFail } from './Fail.js'
 import { assertSync, flatMap, fx, ok, run, runPromise, runTask, trySync } from './Fx.js'
 import { control, handle } from './Handler.js'
@@ -197,6 +197,17 @@ describe('Fx', () => {
       assert.equal(await runTask(optional).promise, 'anonymous')
       assert.equal(await runTask(required.pipe(provideAll({ name: 'Brian' }))).promise, 'Brian')
     })
+
+    it('reuses one default environment object across gets', async () => {
+      const actual = await runTask(fx(function* () {
+        const a = yield* get<{ count?: number }>()
+        a.count = (a.count ?? 0) + 1
+        const b = yield* get<{ count?: number }>()
+        return { same: a === b, count: b.count }
+      })).promise
+
+      assert.deepEqual(actual, { same: true, count: 1 })
+    })
   })
 
   describe('runPromise', () => {
@@ -273,6 +284,17 @@ describe('Fx', () => {
 
       assert.equal(run(optional), 'anonymous')
       assert.equal(run(required.pipe(provideAll({ name: 'Brian' }))), 'Brian')
+    })
+
+    it('reuses one default environment object across gets', () => {
+      const actual = run(fx(function* () {
+        const a = yield* get<{ count?: number }>()
+        a.count = (a.count ?? 0) + 1
+        const b = yield* get<{ count?: number }>()
+        return { same: a === b, count: b.count }
+      }))
+
+      assert.deepEqual(actual, { same: true, count: 1 })
     })
   })
 })

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -179,6 +179,7 @@ export function run<const E extends Interrupt | Get<Record<PropertyKey, unknown>
   return f.pipe(f => {
     const i = f[Symbol.iterator]()
     const masks = new InterruptMaskState()
+    const defaultEnv = {}
     let ir = i.next()
     const step = (ir: IteratorResult<Interrupt | Get<Record<PropertyKey, unknown>>, R>) => {
       while (!ir.done) {
@@ -189,7 +190,7 @@ export function run<const E extends Interrupt | Get<Record<PropertyKey, unknown>
           masks.unmask(ir.value.arg)
           ir = i.next()
         } else if (Get.is(ir.value)) {
-          ir = i.next({})
+          ir = i.next(defaultEnv)
         } else if (isEffect(ir.value)) {
           throw new Error('Unhandled effect in run')
         } else {

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -1,6 +1,6 @@
 import { Async } from './Async.js'
 import { at } from './Breadcrumb.js'
-import { Get, get, provideAll } from './Env.js'
+import { Get, get } from './Env.js'
 import { Fail, assert } from './Fail.js'
 import { HandlerCapture } from './HandlerCapture.js'
 import { uninterruptibleMask } from './Interrupt.js'
@@ -125,8 +125,8 @@ export const flatten = <const E1, const E2, const A>(x: Fx<E1, Fx<E2, A>>): Fx<E
  * Use `runTask` when the caller needs to dispose the running computation or wait
  * for cleanup. All non-runtime effects must be handled before calling it.
  */
-export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt, R>, options: RunForkOptions = {}): Task<R, never> => {
-  return runFork(f.pipe(provideAll({})), {
+export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, R>, options: RunForkOptions = {}): Task<R, never> => {
+  return runFork(f, {
     ...options,
     origin: options.origin ?? at('fx/runTask', runTask)
   })
@@ -138,7 +138,7 @@ export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrup
  * This discards explicit cancellation. Use {@link runTask} when the caller needs
  * to cancel or wait for disposal.
  */
-export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt, R>, options: RunForkOptions = {}): Promise<R> => {
+export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, R>, options: RunForkOptions = {}): Promise<R> => {
   return runTask(f, {
     ...options,
     origin: options.origin ?? at('fx/runPromise', runPromise)
@@ -152,12 +152,12 @@ export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Inter
  * {@link Interrupt}. Use {@link runPromise} or {@link runTask} for async
  * programs.
  */
-export const run = <const R>(f: Fx<Interrupt, R>): R =>
-  f.pipe(provideAll({}), f => {
+export const run = <const R>(f: Fx<Interrupt | Get<Record<PropertyKey, unknown>>, R>): R =>
+  f.pipe(f => {
     const i = f[Symbol.iterator]()
     const masks = new InterruptMaskState()
     let ir = i.next()
-    const step = (ir: IteratorResult<Interrupt, R>) => {
+    const step = (ir: IteratorResult<Interrupt | Get<Record<PropertyKey, unknown>>, R>) => {
       while (!ir.done) {
         if (InterruptMaskBegin.is(ir.value)) {
           masks.mask(ir.value.arg)
@@ -165,6 +165,8 @@ export const run = <const R>(f: Fx<Interrupt, R>): R =>
         } else if (InterruptMaskEnd.is(ir.value)) {
           masks.unmask(ir.value.arg)
           ir = i.next()
+        } else if (Get.is(ir.value)) {
+          ir = i.next({})
         } else if (isEffect(ir.value)) {
           throw new Error('Unhandled effect in run')
         } else {

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -119,13 +119,29 @@ export const tap = <const A, const E2>(f: (a: A) => Fx<E2, void>) =>
 export const flatten = <const E1, const E2, const A>(x: Fx<E1, Fx<E2, A>>): Fx<E1 | E2, A> =>
   x.pipe(flatMap(x => x))
 
+type RuntimeEnv<E> =
+  Extract<E, Get<Record<PropertyKey, unknown>>> extends Get<infer A>
+    ? A
+    : never
+
+type MissingRuntimeEnvArgs<E> =
+  [RuntimeEnv<E>] extends [never]
+    ? []
+    : {} extends RuntimeEnv<E>
+      ? []
+      : ['runtime entrypoint missing required environment']
+
 /**
  * Execute a runtime-ready Fx and return a cancellable {@link Task}.
  *
  * Use `runTask` when the caller needs to dispose the running computation or wait
  * for cleanup. All non-runtime effects must be handled before calling it.
  */
-export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, R>, options: RunForkOptions = {}): Task<R, never> => {
+export function runTask<const E extends Async | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, const R>(
+  f: Fx<E, R>,
+  options: RunForkOptions = {},
+  ..._missingEnv: MissingRuntimeEnvArgs<E>
+): Task<R, never> {
   return runFork(f, {
     ...options,
     origin: options.origin ?? at('fx/runTask', runTask)
@@ -138,11 +154,15 @@ export const runTask = <const R>(f: Fx<Async | HandlerCapture<string> | Interrup
  * This discards explicit cancellation. Use {@link runTask} when the caller needs
  * to cancel or wait for disposal.
  */
-export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, R>, options: RunForkOptions = {}): Promise<R> => {
+export function runPromise<const E extends Async | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, const R>(
+  f: Fx<E, R>,
+  options: RunForkOptions = {},
+  ..._missingEnv: MissingRuntimeEnvArgs<E>
+): Promise<R> {
   return runTask(f, {
     ...options,
     origin: options.origin ?? at('fx/runPromise', runPromise)
-  }).promise
+  }, ..._missingEnv).promise
 }
 
 /**
@@ -152,8 +172,11 @@ export const runPromise = <const R>(f: Fx<Async | HandlerCapture<string> | Inter
  * {@link Interrupt}. Use {@link runPromise} or {@link runTask} for async
  * programs.
  */
-export const run = <const R>(f: Fx<Interrupt | Get<Record<PropertyKey, unknown>>, R>): R =>
-  f.pipe(f => {
+export function run<const E extends Interrupt | Get<Record<PropertyKey, unknown>>, const R>(
+  f: Fx<E, R>,
+  ..._missingEnv: MissingRuntimeEnvArgs<E>
+): R {
+  return f.pipe(f => {
     const i = f[Symbol.iterator]()
     const masks = new InterruptMaskState()
     let ir = i.next()
@@ -185,6 +208,7 @@ export const run = <const R>(f: Fx<Interrupt | Get<Record<PropertyKey, unknown>>
     if (!isEffect(ir.value)) masks.assertBalanced()
     return ir.value as R
   })
+}
 
 /**
  * Acquire a resource, use it, and release it even if use fails or is

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -119,17 +119,17 @@ export const tap = <const A, const E2>(f: (a: A) => Fx<E2, void>) =>
 export const flatten = <const E1, const E2, const A>(x: Fx<E1, Fx<E2, A>>): Fx<E1 | E2, A> =>
   x.pipe(flatMap(x => x))
 
-type RuntimeEnv<E> =
-  Extract<E, Get<Record<PropertyKey, unknown>>> extends Get<infer A>
-    ? A
+type RequiredRuntimeEnv<E> =
+  Extract<E, Get<Record<PropertyKey, unknown>>> extends infer G
+    ? G extends Get<infer A>
+      ? {} extends A ? never : A
+      : never
     : never
 
 type MissingRuntimeEnvArgs<E> =
-  [RuntimeEnv<E>] extends [never]
+  [RequiredRuntimeEnv<E>] extends [never]
     ? []
-    : {} extends RuntimeEnv<E>
-      ? []
-      : ['runtime entrypoint missing required environment']
+    : ['runtime entrypoint missing required environment']
 
 /**
  * Execute a runtime-ready Fx and return a cancellable {@link Task}.

--- a/src/NodeRuntime.ts
+++ b/src/NodeRuntime.ts
@@ -21,14 +21,14 @@ export type NodeRuntimeEffects =
   | Interrupt
   | HandlerCapture<string>
 
-export const runNodeMain = <const E extends NodeRuntimeEffects>(
-  program: Fx<E, void>,
+export const runNodeMain = (
+  program: Fx<NodeRuntimeEffects, void>,
   options?: RunNodeOptions
 ): Promise<void> =>
   runNodePromise(program, options)
 
-export const runNodePromise = <const E extends NodeRuntimeEffects>(
-  program: Fx<E, void>,
+export const runNodePromise = (
+  program: Fx<NodeRuntimeEffects, void>,
   {
     process: nodeProcess = globalNodeProcess(),
     signals = ['SIGINT', 'SIGTERM']

--- a/src/internal/forkRuntime.ts
+++ b/src/internal/forkRuntime.ts
@@ -1,0 +1,20 @@
+export interface ForkRuntime {
+  readonly defaultEnv: Record<PropertyKey, unknown>
+}
+
+let activeForkRuntime: ForkRuntime | undefined
+
+export const createForkRuntime = (): ForkRuntime => ({ defaultEnv: {} })
+
+export const currentForkRuntime = (): ForkRuntime | undefined =>
+  activeForkRuntime
+
+export const withActiveForkRuntime = <A>(forkRuntime: ForkRuntime, f: () => A): A => {
+  const previous = activeForkRuntime
+  activeForkRuntime = forkRuntime
+  try {
+    return f()
+  } finally {
+    activeForkRuntime = previous
+  }
+}

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -12,10 +12,12 @@ import { attachTrace, captureAppendTrace, capturePrependTrace, captureTrace, get
 import type { Trace, TraceFrameMetadata, TraceOptions } from '../Trace.js'
 import { Semaphore } from './Semaphore.js'
 import { DisposableSet } from './disposable.js'
+import { createForkRuntime, withActiveForkRuntime } from './forkRuntime.js'
+import type { ForkRuntime } from './forkRuntime.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
 import { withInterpretedReturn } from './iteratorClose.js'
 import type { RuntimeContext } from './runtimeContext.js'
-import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withDefaultEnv, withInterruptionReason } from './runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
 
 export type RunForkOptions = TraceOptions & {
   readonly maxConcurrency?: number
@@ -26,14 +28,13 @@ const EnvEffectId = 'fx/Env'
 export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, const A>(f: Fx<E, A>, options: RunForkOptions = {}): Task<A, Extract<E, Fail<any>>> => {
   const disposables = new InterruptState()
   const disposed = Promise.withResolvers<void>()
-  const parentRuntimeContext = currentRuntimeContext()
-  const defaultEnv = parentRuntimeContext?.defaultEnv ?? {}
-  const runtimeContext = withDefaultEnv(parentRuntimeContext, defaultEnv)
+  const runtimeContext = currentRuntimeContext()
+  const forkRuntime = createForkRuntime()
   const origin = options.origin ?? at('fx/runFork', runFork)
   const trace = options.trace ?? captureTraceWithContext(runtimeContext, origin, undefined, { kind: 'run' })
   const maxConcurrency = options.maxConcurrency ?? Infinity
 
-  const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, disposed, origin, trace, runtimeContext, defaultEnv)
+  const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, disposed, origin, trace, runtimeContext, forkRuntime)
     .finally(() => {
       disposables.interruptActive()
       disposed.resolve()
@@ -45,22 +46,21 @@ export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCa
 export const acquireAndRunFork = (
   f: ForkContext,
   s: Semaphore,
+  forkRuntime: ForkRuntime,
   context: readonly CapturedHandler[] = [],
-  runtimeContext: RuntimeContext | undefined = currentRuntimeContext(),
-  defaultEnv: Record<PropertyKey, unknown> = runtimeContext?.defaultEnv ?? {}
+  runtimeContext: RuntimeContext | undefined = currentRuntimeContext()
 ): Task<unknown, unknown> => {
   const disposables = new InterruptState()
   const disposed = Promise.withResolvers<void>()
-  const forkRuntimeContext = withDefaultEnv(runtimeContext, defaultEnv)
 
   const promise = acquire(s, disposables, disposed,
-    () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, forkRuntimeContext, defaultEnv)
+    () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, runtimeContext, forkRuntime)
       .finally(() => {
         disposables.interruptActive()
         disposed.resolve()
       }))
 
-  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), forkRuntimeContext, disposed.promise)
+  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
 }
 
 const runForkInternal = <const E, const A>(
@@ -72,7 +72,7 @@ const runForkInternal = <const E, const A>(
   origin: Breadcrumb,
   trace: Trace | undefined,
   runtimeContext: RuntimeContext | undefined,
-  defaultEnv: Record<PropertyKey, unknown>
+  forkRuntime: ForkRuntime
 ): Promise<A> => {
   let rejectUnhandled: (e: UnhandledForkError) => void = () => { }
   const unhandled = new Promise<never>((_, reject) => {
@@ -80,7 +80,7 @@ const runForkInternal = <const E, const A>(
   })
   unhandled.catch(() => { })
 
-  return runForkLoop(f, context, semaphore, disposables, disposed, origin, trace, unhandled, e => rejectUnhandled(new UnhandledForkError(e)), runtimeContext, defaultEnv)
+  return runForkLoop(f, context, semaphore, disposables, disposed, origin, trace, unhandled, e => rejectUnhandled(new UnhandledForkError(e)), runtimeContext, forkRuntime)
 }
 
 const runForkLoop = async <const E, const A>(
@@ -94,25 +94,25 @@ const runForkLoop = async <const E, const A>(
   unhandled: Promise<never>,
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
-  defaultEnv: Record<PropertyKey, unknown>
+  forkRuntime: ForkRuntime
 ): Promise<A> => {
   let interrupting: Promise<void> | undefined
 
   try {
-    const i = iteratorWithRuntimeContext(f, runtimeContext)
+    const i = iteratorWithRuntime(f, runtimeContext, forkRuntime)
     const interrupt = async (
       cleanupMasks: readonly InterruptMaskBegin['arg'][] = disposables.maskSnapshot(),
       reason: unknown = disposables.interruptionReason
     ): Promise<A> => {
       if (interrupting === undefined) {
-        interrupting = closeInterruptedIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed, defaultEnv, cleanupMasks, reason)
+        interrupting = closeInterruptedIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed, forkRuntime, cleanupMasks, reason)
         interrupting.catch(() => { })
       }
       await interrupting
       return await never()
     }
     disposables.setInterrupt(interrupt)
-    return await runIterator(nextWithRuntimeContext(i, runtimeContext), i, context, semaphore, disposables, origin, trace, unhandled, rejectUnhandled, runtimeContext, defaultEnv, interrupt)
+    return await runIterator(nextWithRuntime(i, runtimeContext, forkRuntime), i, context, semaphore, disposables, origin, trace, unhandled, rejectUnhandled, runtimeContext, forkRuntime, interrupt)
   } catch (e) {
     if (e instanceof ForkError) {
       if (disposables.interruptRequested) disposed.reject(e)
@@ -135,15 +135,15 @@ const closeInterruptedIterator = async <const E, const A>(
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
   disposed: PromiseWithResolvers<void>,
-  defaultEnv: Record<PropertyKey, unknown>,
+  forkRuntime: ForkRuntime,
   cleanupMasks: readonly InterruptMaskBegin['arg'][],
   reason: unknown
 ): Promise<void> => {
   const cleanup = new InterruptState(cleanupMasks)
   const cleanupContext = withInterruptionReason(runtimeContext, reason)
   try {
-    const ir = returnWithRuntimeContext(i, cleanupContext)
-    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, cleanupContext, defaultEnv)
+    const ir = returnWithRuntime(i, cleanupContext, forkRuntime)
+    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, cleanupContext, forkRuntime)
     disposed.resolve()
   } catch (e) {
     disposed.reject(e)
@@ -164,7 +164,7 @@ const runIterator = async <const E, const A>(
   unhandled: Promise<never>,
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
-  defaultEnv: Record<PropertyKey, unknown>,
+  forkRuntime: ForkRuntime,
   interrupt?: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<A>
 ): Promise<A> => {
   while (!ir.done) {
@@ -185,12 +185,12 @@ const runIterator = async <const E, const A>(
       }
       // stop if the scope was interrupted while we were waiting
       if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt)
-      ir = resumeWithRuntimeContext(i, effectContext, a)
+      ir = resumeWithRuntime(i, effectContext, forkRuntime, a)
     } else if (Fork.is(ir.value)) {
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
       const forkOrigin = ir.value.arg.origin
       const forkTrace = capturePrependTraceWithContext(effectContext, forkOrigin, trace, forkFrameMetadata(ir.value.arg.trace))
-      const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext, defaultEnv)
+      const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, forkRuntime, context, effectContext)
       disposables.addTask(t)
       t.promise
         .finally(() => disposables.removeTask(t))
@@ -202,19 +202,19 @@ const runIterator = async <const E, const A>(
             )
           })
         })
-      ir = resumeWithRuntimeContext(i, effectContext, t)
+      ir = resumeWithRuntime(i, effectContext, forkRuntime, t)
     } else if (HandlerCapture.is(ir.value)) {
-      ir = resumeWithRuntimeContext(i, runtimeContext, context)
+      ir = resumeWithRuntime(i, runtimeContext, forkRuntime, context)
     } else if (InterruptMaskBegin.is(ir.value)) {
       disposables.mask(ir.value.arg)
-      ir = resumeWithRuntimeContext(i, runtimeContext, undefined)
+      ir = resumeWithRuntime(i, runtimeContext, forkRuntime, undefined)
     } else if (InterruptMaskEnd.is(ir.value)) {
       const masksAtInterruptDelivery = disposables.maskSnapshot()
       disposables.unmask(ir.value.arg)
       if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt, masksAtInterruptDelivery)
-      ir = resumeWithRuntimeContext(i, runtimeContext, undefined)
+      ir = resumeWithRuntime(i, runtimeContext, forkRuntime, undefined)
     } else if (isEffect(ir.value) && ir.value._fxEffectId === EnvEffectId) {
-      ir = resumeWithRuntimeContext(i, runtimeContext, defaultEnv)
+      ir = resumeWithRuntime(i, runtimeContext, forkRuntime, forkRuntime.defaultEnv)
     } else if (Fail.is(ir.value)) {
       const causeTrace = getTrace(ir.value.arg)
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
@@ -403,39 +403,44 @@ const taskWithRuntimeContext = <A, E>(
     ? new Task<A, E>(promise, interruptTask, runtimeContext, interrupted)
     : withActiveRuntimeContext(runtimeContext, () => new Task<A, E>(promise, interruptTask, runtimeContext, interrupted))
 
-const iteratorWithRuntimeContext = <E, A>(
+const iteratorWithRuntime = <E, A>(
   f: Fx<E, A>,
-  runtimeContext?: RuntimeContext
+  runtimeContext: RuntimeContext | undefined,
+  forkRuntime: ForkRuntime
 ): Iterator<E, A, unknown> =>
-  runtimeContext === undefined
-    ? f[Symbol.iterator]()
-    : withActiveRuntimeContext(runtimeContext, () => f[Symbol.iterator]())
+  withRuntimeState(runtimeContext, forkRuntime, () => f[Symbol.iterator]())
 
-const nextWithRuntimeContext = <E, A>(
-  iterator: Iterator<E, A, unknown>,
-  runtimeContext?: RuntimeContext
-): IteratorResult<E, A> =>
+const withRuntimeState = <A>(
+  runtimeContext: RuntimeContext | undefined,
+  forkRuntime: ForkRuntime,
+  f: () => A
+): A =>
   runtimeContext === undefined
-    ? iterator.next()
-    : withActiveRuntimeContext(runtimeContext, () => iterator.next())
+    ? withActiveForkRuntime(forkRuntime, f)
+    : withActiveRuntimeContext(runtimeContext, () => withActiveForkRuntime(forkRuntime, f))
 
-const resumeWithRuntimeContext = <E, A>(
+const nextWithRuntime = <E, A>(
   iterator: Iterator<E, A, unknown>,
   runtimeContext: RuntimeContext | undefined,
+  forkRuntime: ForkRuntime
+): IteratorResult<E, A> =>
+  withRuntimeState(runtimeContext, forkRuntime, () => iterator.next())
+
+const resumeWithRuntime = <E, A>(
+  iterator: Iterator<E, A, unknown>,
+  runtimeContext: RuntimeContext | undefined,
+  forkRuntime: ForkRuntime,
   value: unknown
 ): IteratorResult<E, A> =>
-  runtimeContext === undefined
-    ? iterator.next(value)
-    : withActiveRuntimeContext(runtimeContext, () => iterator.next(value))
+  withRuntimeState(runtimeContext, forkRuntime, () => iterator.next(value))
 
-const returnWithRuntimeContext = <E, A>(
+const returnWithRuntime = <E, A>(
   iterator: Iterator<E, A, unknown>,
-  runtimeContext?: RuntimeContext
+  runtimeContext: RuntimeContext | undefined,
+  forkRuntime: ForkRuntime
 ): IteratorResult<E, A> =>
-  runtimeContext === undefined
-    ? withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A })
-    : withActiveRuntimeContext(runtimeContext, () =>
-      withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A }))
+  withRuntimeState(runtimeContext, forkRuntime, () =>
+    withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A }))
 
 const never = <A>(): Promise<A> => new Promise(() => { })
 

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -86,6 +86,7 @@ const runForkLoop = async <const E, const A>(
   runtimeContext?: RuntimeContext
 ): Promise<A> => {
   let interrupting: Promise<void> | undefined
+  const defaultEnv = {}
 
   try {
     const i = iteratorWithRuntimeContext(f, runtimeContext)
@@ -94,14 +95,14 @@ const runForkLoop = async <const E, const A>(
       reason: unknown = disposables.interruptionReason
     ): Promise<A> => {
       if (interrupting === undefined) {
-        interrupting = closeInterruptedIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed, cleanupMasks, reason)
+        interrupting = closeInterruptedIterator(i, context, semaphore, origin, trace, unhandled, rejectUnhandled, runtimeContext, disposed, defaultEnv, cleanupMasks, reason)
         interrupting.catch(() => { })
       }
       await interrupting
       return await never()
     }
     disposables.setInterrupt(interrupt)
-    return await runIterator(nextWithRuntimeContext(i, runtimeContext), i, context, semaphore, disposables, origin, trace, unhandled, rejectUnhandled, runtimeContext, interrupt)
+    return await runIterator(nextWithRuntimeContext(i, runtimeContext), i, context, semaphore, disposables, origin, trace, unhandled, rejectUnhandled, runtimeContext, defaultEnv, interrupt)
   } catch (e) {
     if (e instanceof ForkError) {
       if (disposables.interruptRequested) disposed.reject(e)
@@ -124,6 +125,7 @@ const closeInterruptedIterator = async <const E, const A>(
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
   disposed: PromiseWithResolvers<void>,
+  defaultEnv: Record<PropertyKey, unknown>,
   cleanupMasks: readonly InterruptMaskBegin['arg'][],
   reason: unknown
 ): Promise<void> => {
@@ -131,7 +133,7 @@ const closeInterruptedIterator = async <const E, const A>(
   const cleanupContext = withInterruptionReason(runtimeContext, reason)
   try {
     const ir = returnWithRuntimeContext(i, cleanupContext)
-    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, cleanupContext)
+    await runIterator(ir, i, context, semaphore, cleanup, origin, trace, unhandled, rejectUnhandled, cleanupContext, defaultEnv)
     disposed.resolve()
   } catch (e) {
     disposed.reject(e)
@@ -152,6 +154,7 @@ const runIterator = async <const E, const A>(
   unhandled: Promise<never>,
   rejectUnhandled: (e: unknown) => void,
   runtimeContext: RuntimeContext | undefined,
+  defaultEnv: Record<PropertyKey, unknown>,
   interrupt?: (masks?: readonly InterruptMaskBegin['arg'][], reason?: unknown) => Promise<A>
 ): Promise<A> => {
   while (!ir.done) {
@@ -201,7 +204,7 @@ const runIterator = async <const E, const A>(
       if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt, masksAtInterruptDelivery)
       ir = resumeWithRuntimeContext(i, runtimeContext, undefined)
     } else if (isEffect(ir.value) && ir.value._fxEffectId === EnvEffectId) {
-      ir = resumeWithRuntimeContext(i, runtimeContext, {})
+      ir = resumeWithRuntimeContext(i, runtimeContext, defaultEnv)
     } else if (Fail.is(ir.value)) {
       const causeTrace = getTrace(ir.value.arg)
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -1,5 +1,7 @@
 import { Async } from '../Async.js'
 import { Breadcrumb, at } from '../Breadcrumb.js'
+import type { Get } from '../Env.js'
+import { isEffect } from '../Effect.js'
 import { Fail } from '../Fail.js'
 import { Fork, ForkContext } from '../Concurrent.js'
 import { Fx } from '../Fx.js'
@@ -19,7 +21,9 @@ export type RunForkOptions = TraceOptions & {
   readonly maxConcurrency?: number
 }
 
-export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCapture<string> | Interrupt, const A>(f: Fx<E, A>, options: RunForkOptions = {}): Task<A, Extract<E, Fail<any>>> => {
+const EnvEffectId = 'fx/Env'
+
+export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, const A>(f: Fx<E, A>, options: RunForkOptions = {}): Task<A, Extract<E, Fail<any>>> => {
   const disposables = new InterruptState()
   const disposed = Promise.withResolvers<void>()
   const runtimeContext = currentRuntimeContext()
@@ -196,6 +200,8 @@ const runIterator = async <const E, const A>(
       disposables.unmask(ir.value.arg)
       if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt, masksAtInterruptDelivery)
       ir = resumeWithRuntimeContext(i, runtimeContext, undefined)
+    } else if (isEffect(ir.value) && ir.value._fxEffectId === EnvEffectId) {
+      ir = resumeWithRuntimeContext(i, runtimeContext, {})
     } else if (Fail.is(ir.value)) {
       const causeTrace = getTrace(ir.value.arg)
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -15,7 +15,7 @@ import { DisposableSet } from './disposable.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
 import { withInterpretedReturn } from './iteratorClose.js'
 import type { RuntimeContext } from './runtimeContext.js'
-import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withDefaultEnv, withInterruptionReason } from './runtimeContext.js'
 
 export type RunForkOptions = TraceOptions & {
   readonly maxConcurrency?: number
@@ -26,12 +26,14 @@ const EnvEffectId = 'fx/Env'
 export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCapture<string> | Interrupt | Get<Record<PropertyKey, unknown>>, const A>(f: Fx<E, A>, options: RunForkOptions = {}): Task<A, Extract<E, Fail<any>>> => {
   const disposables = new InterruptState()
   const disposed = Promise.withResolvers<void>()
-  const runtimeContext = currentRuntimeContext()
+  const parentRuntimeContext = currentRuntimeContext()
+  const defaultEnv = parentRuntimeContext?.defaultEnv ?? {}
+  const runtimeContext = withDefaultEnv(parentRuntimeContext, defaultEnv)
   const origin = options.origin ?? at('fx/runFork', runFork)
   const trace = options.trace ?? captureTraceWithContext(runtimeContext, origin, undefined, { kind: 'run' })
   const maxConcurrency = options.maxConcurrency ?? Infinity
 
-  const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, disposed, origin, trace, runtimeContext)
+  const promise = runForkInternal(f, [], new Semaphore(maxConcurrency), disposables, disposed, origin, trace, runtimeContext, defaultEnv)
     .finally(() => {
       disposables.interruptActive()
       disposed.resolve()
@@ -40,18 +42,25 @@ export const runFork = <const E extends Async | Fork | Fail<unknown> | HandlerCa
   return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
 }
 
-export const acquireAndRunFork = (f: ForkContext, s: Semaphore, context: readonly CapturedHandler[] = [], runtimeContext: RuntimeContext | undefined = currentRuntimeContext()): Task<unknown, unknown> => {
+export const acquireAndRunFork = (
+  f: ForkContext,
+  s: Semaphore,
+  context: readonly CapturedHandler[] = [],
+  runtimeContext: RuntimeContext | undefined = currentRuntimeContext(),
+  defaultEnv: Record<PropertyKey, unknown> = runtimeContext?.defaultEnv ?? {}
+): Task<unknown, unknown> => {
   const disposables = new InterruptState()
   const disposed = Promise.withResolvers<void>()
+  const forkRuntimeContext = withDefaultEnv(runtimeContext, defaultEnv)
 
   const promise = acquire(s, disposables, disposed,
-    () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, runtimeContext)
+    () => runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, forkRuntimeContext, defaultEnv)
       .finally(() => {
         disposables.interruptActive()
         disposed.resolve()
       }))
 
-  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
+  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), forkRuntimeContext, disposed.promise)
 }
 
 const runForkInternal = <const E, const A>(
@@ -62,7 +71,8 @@ const runForkInternal = <const E, const A>(
   disposed: PromiseWithResolvers<void>,
   origin: Breadcrumb,
   trace: Trace | undefined,
-  runtimeContext?: RuntimeContext
+  runtimeContext: RuntimeContext | undefined,
+  defaultEnv: Record<PropertyKey, unknown>
 ): Promise<A> => {
   let rejectUnhandled: (e: UnhandledForkError) => void = () => { }
   const unhandled = new Promise<never>((_, reject) => {
@@ -70,7 +80,7 @@ const runForkInternal = <const E, const A>(
   })
   unhandled.catch(() => { })
 
-  return runForkLoop(f, context, semaphore, disposables, disposed, origin, trace, unhandled, e => rejectUnhandled(new UnhandledForkError(e)), runtimeContext)
+  return runForkLoop(f, context, semaphore, disposables, disposed, origin, trace, unhandled, e => rejectUnhandled(new UnhandledForkError(e)), runtimeContext, defaultEnv)
 }
 
 const runForkLoop = async <const E, const A>(
@@ -83,10 +93,10 @@ const runForkLoop = async <const E, const A>(
   trace: Trace | undefined,
   unhandled: Promise<never>,
   rejectUnhandled: (e: unknown) => void,
-  runtimeContext?: RuntimeContext
+  runtimeContext: RuntimeContext | undefined,
+  defaultEnv: Record<PropertyKey, unknown>
 ): Promise<A> => {
   let interrupting: Promise<void> | undefined
-  const defaultEnv = {}
 
   try {
     const i = iteratorWithRuntimeContext(f, runtimeContext)
@@ -180,7 +190,7 @@ const runIterator = async <const E, const A>(
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
       const forkOrigin = ir.value.arg.origin
       const forkTrace = capturePrependTraceWithContext(effectContext, forkOrigin, trace, forkFrameMetadata(ir.value.arg.trace))
-      const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext)
+      const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext, defaultEnv)
       disposables.addTask(t)
       t.promise
         .finally(() => disposables.removeTask(t))

--- a/src/internal/runtimeContext.ts
+++ b/src/internal/runtimeContext.ts
@@ -6,14 +6,13 @@ import { Pipeable, pipeThis } from './pipe.js'
 
 /**
  * Internal diagnostic runtime context. This currently carries trace capture
- * policy and other interpreter-owned execution evidence across runtime
- * boundaries; it is not a general service or capability container.
+ * policy across runtime boundaries; it is not a general service or capability
+ * container.
  */
 export interface RuntimeContext {
   readonly traceCapturePolicy?: TraceCapturePolicy
   readonly activeScopes?: readonly ActiveScopeDiagnostic[]
   readonly interruptionReason?: unknown
-  readonly defaultEnv?: Record<PropertyKey, unknown>
 }
 
 export interface ActiveScopeDiagnostic {
@@ -88,14 +87,6 @@ export const withInterruptionReason = (
   reason: unknown
 ): RuntimeContext | undefined =>
   reason === undefined ? context : { ...context, interruptionReason: reason }
-
-export const withDefaultEnv = (
-  context: RuntimeContext | undefined,
-  defaultEnv: Record<PropertyKey, unknown>
-): RuntimeContext =>
-  context?.defaultEnv === defaultEnv
-    ? context
-    : { ...context, defaultEnv }
 
 export const withActiveScope = <E, A>(scope: ActiveScopeDiagnostic, fx: Fx<E, A>): Fx<E, A> => {
   const scopes = activeScopes()

--- a/src/internal/runtimeContext.ts
+++ b/src/internal/runtimeContext.ts
@@ -6,13 +6,14 @@ import { Pipeable, pipeThis } from './pipe.js'
 
 /**
  * Internal diagnostic runtime context. This currently carries trace capture
- * policy across interpreter/runtime boundaries; it is not a general service
- * or capability container.
+ * policy and other interpreter-owned execution evidence across runtime
+ * boundaries; it is not a general service or capability container.
  */
 export interface RuntimeContext {
   readonly traceCapturePolicy?: TraceCapturePolicy
   readonly activeScopes?: readonly ActiveScopeDiagnostic[]
   readonly interruptionReason?: unknown
+  readonly defaultEnv?: Record<PropertyKey, unknown>
 }
 
 export interface ActiveScopeDiagnostic {
@@ -87,6 +88,14 @@ export const withInterruptionReason = (
   reason: unknown
 ): RuntimeContext | undefined =>
   reason === undefined ? context : { ...context, interruptionReason: reason }
+
+export const withDefaultEnv = (
+  context: RuntimeContext | undefined,
+  defaultEnv: Record<PropertyKey, unknown>
+): RuntimeContext =>
+  context?.defaultEnv === defaultEnv
+    ? context
+    : { ...context, defaultEnv }
 
 export const withActiveScope = <E, A>(scope: ActiveScopeDiagnostic, fx: Fx<E, A>): Fx<E, A> => {
   const scopes = activeScopes()


### PR DESCRIPTION
## Summary

- fix the `benchmark:runtime-loops` harness after scope/token and task lifecycle API changes
- remove avoidable runtime-boundary `provideAll({})` overhead from `run`, `runTask`, and `runFork`
- save the regression investigation and benchmark evidence under `benchmarks/results/2026-05-26-benchmark-harness-and-trace-regressions.md`

## Root Cause

The broken `runtime-loops` benchmark was using stale APIs:

- `scope(name)` now creates a scope token and must be paired with `withScope(...)`
- task cancellation/disposal in the benchmark needed `task.interrupt()` instead of the old disposal helper path

The trace regressions were not mainly in trace-policy logic. `run` and `runTask` always wrapped execution in `provideAll({})`, which adds a general handler frame around every runtime execution. After `fefff46` added cleanup-drain semantics for interrupted finalizers, that default environment wrapper became visible in hot paths. This change keeps the cleanup semantics and handles the default empty environment directly at the runtime boundary.

## Impact

- `benchmark:runtime-loops` runs again and preserves existing case names for historical comparisons.
- `pure runtime baseline` returns from about `1178 ns/op` to about `235 ns/op` in the investigated worktree.
- `successful assertPromise labels/off` recover most of the regression signal from the weekly benchmark run.
- `handled fail labels/off` remains slower than the older May 7 artifact; the investigation note isolates that to synchronous `control(Fail, ...)` cleanup-drain overhead and leaves it as follow-up work.

## Validation

- `corepack pnpm benchmark:trace`
- `corepack pnpm benchmark:runtime-context`
- `corepack pnpm benchmark:runtime-loops`
- `corepack pnpm build`
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
