### PR TITLE
[codex] Prototype cooperative concurrency runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .pnpm-store/
+.benchmarks/
 dist/
 experiments/
 /AGENT_STATUS.md

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -286,7 +286,7 @@ function mixedAsyncAndYielding() {
   ])
 }
 
-function explicitForkFanout(children: readonly Fx<unknown, unknown>[]) {
+function explicitForkFanout(children: readonly Fx<any, unknown>[]) {
   return fx(function* () {
     const tasks = []
     for (const child of children) tasks.push(yield* fork(child))
@@ -388,7 +388,7 @@ function formatMarkdown(fairness: readonly FairnessSummary[], results: readonly 
     `- Worktree: ${worktreeState()}`,
     `- Node: ${process.version}`,
     `- Platform: ${platform()} ${release()} ${arch()}`,
-    '- Command: `pnpm benchmark:cooperative-all`',
+    `- Command: \`${benchmarkCommand()}\``,
     '',
     '## Semantic Checks',
     '',
@@ -429,6 +429,12 @@ function gitSha(): string {
   } catch {
     return 'unknown'
   }
+}
+
+function benchmarkCommand(): string {
+  return process.env.npm_lifecycle_event === undefined
+    ? 'node benchmarks/cooperative-all'
+    : `pnpm ${process.env.npm_lifecycle_event}`
 }
 
 function worktreeState(): string {

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -4,7 +4,7 @@ import { arch, platform, release } from 'node:os'
 import { performance } from 'node:perf_hooks'
 
 import { assertPromise } from '../src/Async.js'
-import { all, cooperativeAll, cooperativeStructured, defaultAll, firstSettled, firstSuccess, race, unbounded } from '../src/Concurrent.js'
+import { all, firstSettled, firstSuccess, race, withCoopConcurrency, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
 import { fail, returnFail } from '../src/Fail.js'
 import { andFinally } from '../src/Finalization.js'
@@ -51,104 +51,80 @@ const CleanupScope = scope('benchmark/cooperative-all/Cleanup')
 await runSemanticChecks()
 
 const fairness = [
-  await measureFairness('defaultAll + unbounded', f => f.pipe(defaultAll, unbounded)),
-  await measureFairness('cooperativeAll budget 1', f => f.pipe(cooperativeAll({ yieldBudget: 1 }))),
-  await measureFairness('cooperativeStructured budget 1', f => f.pipe(cooperativeStructured({ yieldBudget: 1 }))),
-  await measureFairness('cooperativeAll budget 8', f => f.pipe(cooperativeAll({ yieldBudget: 8 }))),
-  await measureFairness('cooperativeAll budget 64', f => f.pipe(cooperativeAll({ yieldBudget: 64 })))
+  await measureFairness('withUnboundedConcurrency', f => f.pipe(withUnboundedConcurrency)),
+  await measureFairness('withCoopConcurrency budget 1', f => f.pipe(withCoopConcurrency({ yieldBudget: 1 }))),
+  await measureFairness('withCoopConcurrency budget 8', f => f.pipe(withCoopConcurrency({ yieldBudget: 8 }))),
+  await measureFairness('withCoopConcurrency budget 64', f => f.pipe(withCoopConcurrency({ yieldBudget: 64 })))
 ]
 
 const results = await runBenchmarks([
-  benchmark('defaultAll + unbounded ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
-    await all(okChildren(Fanout)).pipe(defaultAll, unbounded, runPromise)
+  benchmark('withUnboundedConcurrency ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+    await all(okChildren(Fanout)).pipe(withUnboundedConcurrency, runPromise)
   }),
-  benchmark('cooperativeAll ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
-    await all(okChildren(Fanout)).pipe(cooperativeAll(), runPromise)
+  benchmark('withCoopConcurrency ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+    await all(okChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
   }),
-  benchmark('cooperativeStructured ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
-    await all(okChildren(Fanout)).pipe(cooperativeStructured(), runPromise)
+  benchmark('withUnboundedConcurrency async fanout 16', 'async fanout', FastIterations, 100, async () => {
+    await all(asyncChildren(Fanout)).pipe(withUnboundedConcurrency, runPromise)
   }),
-  benchmark('defaultAll + unbounded async fanout 16', 'async fanout', FastIterations, 100, async () => {
-    await all(asyncChildren(Fanout)).pipe(defaultAll, unbounded, runPromise)
+  benchmark('withCoopConcurrency async fanout 16', 'async fanout', FastIterations, 100, async () => {
+    await all(asyncChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
   }),
-  benchmark('cooperativeAll async fanout 16', 'async fanout', FastIterations, 100, async () => {
-    await all(asyncChildren(Fanout)).pipe(cooperativeAll(), runPromise)
+  benchmark('withUnboundedConcurrency yielding 16x16', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('cooperativeStructured async fanout 16', 'async fanout', FastIterations, 100, async () => {
-    await all(asyncChildren(Fanout)).pipe(cooperativeStructured(), runPromise)
+  benchmark('withCoopConcurrency yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), runPromise)
   }),
-  benchmark('defaultAll + unbounded yielding 16x16', 'yielding fanout', YieldingIterations, 50, async () => {
-    await yieldingAll().pipe(defaultAll, handleStep(), unbounded, runPromise)
+  benchmark('withCoopConcurrency yielding 16x16 budget 8', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(withCoopConcurrency({ yieldBudget: 8 }), handleStep(), runPromise)
   }),
-  benchmark('cooperativeAll yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
-    await yieldingAll().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), runPromise)
+  benchmark('withCoopConcurrency yielding 16x16 budget 64', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(withCoopConcurrency({ yieldBudget: 64 }), handleStep(), runPromise)
   }),
-  benchmark('cooperativeStructured yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
-    await yieldingAll().pipe(cooperativeStructured({ yieldBudget: 1 }), handleStep(), runPromise)
+  benchmark('withUnboundedConcurrency mixed parked async', 'mixed async', YieldingIterations, 50, async () => {
+    await mixedAsyncAndYielding().pipe(handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('cooperativeAll yielding 16x16 budget 8', 'yielding fanout', YieldingIterations, 50, async () => {
-    await yieldingAll().pipe(cooperativeAll({ yieldBudget: 8 }), handleStep(), runPromise)
+  benchmark('withCoopConcurrency mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
+    await mixedAsyncAndYielding().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), runPromise)
   }),
-  benchmark('cooperativeAll yielding 16x16 budget 64', 'yielding fanout', YieldingIterations, 50, async () => {
-    await yieldingAll().pipe(cooperativeAll({ yieldBudget: 64 }), handleStep(), runPromise)
+  benchmark('firstSettled + withUnboundedConcurrency nested race', 'nested race', YieldingIterations, 50, async () => {
+    await nestedRace().pipe(firstSettled, handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('defaultAll + unbounded mixed parked async', 'mixed async', YieldingIterations, 50, async () => {
-    await mixedAsyncAndYielding().pipe(defaultAll, handleStep(), unbounded, runPromise)
+  benchmark('withCoopConcurrency nested race', 'nested race', YieldingIterations, 50, async () => {
+    await nestedRace().pipe(firstSettled, withCoopConcurrency(), handleStep(), runPromise)
   }),
-  benchmark('cooperativeAll mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
-    await mixedAsyncAndYielding().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), runPromise)
+  benchmark('firstSuccess + withUnboundedConcurrency nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
+    await nestedFirstSuccess().pipe(firstSuccess, handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('cooperativeStructured mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
-    await mixedAsyncAndYielding().pipe(cooperativeStructured({ yieldBudget: 1 }), handleStep(), runPromise)
+  benchmark('withCoopConcurrency nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
+    await nestedFirstSuccess().pipe(firstSuccess, withCoopConcurrency(), handleStep(), runPromise)
   }),
-  benchmark('defaultAll + firstSettled + unbounded nested race', 'nested race', YieldingIterations, 50, async () => {
-    await nestedRace().pipe(firstSettled, defaultAll, handleStep(), unbounded, runPromise)
+  benchmark('withUnboundedConcurrency cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+    await cleanupFailureProgram().pipe(withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
   }),
-  benchmark('cooperativeStructured nested race', 'nested race', YieldingIterations, 50, async () => {
-    await nestedRace().pipe(cooperativeStructured(), handleStep(), runPromise)
-  }),
-  benchmark('defaultAll + firstSuccess + unbounded nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
-    await nestedFirstSuccess().pipe(firstSuccess, defaultAll, handleStep(), unbounded, runPromise)
-  }),
-  benchmark('cooperativeStructured nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
-    await nestedFirstSuccess().pipe(cooperativeStructured({ racePolicy: 'firstSuccess' }), handleStep(), runPromise)
-  }),
-  benchmark('defaultAll + unbounded cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
-    await cleanupFailureProgram().pipe(defaultAll, withScope(CleanupScope), returnFail, unbounded, runPromise)
-  }),
-  benchmark('cooperativeAll cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
-    await cleanupFailureProgram().pipe(cooperativeAll(), withScope(CleanupScope), returnFail, runPromise)
-  }),
-  benchmark('cooperativeStructured cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
-    await cleanupFailureProgram().pipe(cooperativeStructured(), withScope(CleanupScope), returnFail, runPromise)
+  benchmark('withCoopConcurrency cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+    await cleanupFailureProgram().pipe(withCoopConcurrency(), withScope(CleanupScope), returnFail, runPromise)
   })
 ])
 
 console.log(formatMarkdown(fairness, results))
 
 async function runSemanticChecks(): Promise<void> {
-  const defaultResult = await parityProgram().pipe(defaultAll, handleStep(), withScope(CleanupScope), returnFail, unbounded, runPromise)
-  const cooperativeResult = await parityProgram().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
-  const structuredResult = await parityProgram().pipe(cooperativeStructured({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
+  const defaultResult = await parityProgram().pipe(handleStep(), withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
+  const cooperativeResult = await parityProgram().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
 
   assert.deepEqual(defaultResult, cooperativeResult)
-  assert.deepEqual(defaultResult, structuredResult)
 
-  const defaultFailure = await cleanupFailureProgram().pipe(defaultAll, withScope(CleanupScope), returnFail, unbounded, runPromise)
-  const cooperativeFailure = await cleanupFailureProgram().pipe(cooperativeAll(), withScope(CleanupScope), returnFail, runPromise)
-  const structuredFailure = await cleanupFailureProgram().pipe(cooperativeStructured(), withScope(CleanupScope), returnFail, runPromise)
+  const defaultFailure = await cleanupFailureProgram().pipe(withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
+  const cooperativeFailure = await cleanupFailureProgram().pipe(withCoopConcurrency(), withScope(CleanupScope), returnFail, runPromise)
 
   assert.equal(defaultFailure.constructor, cooperativeFailure.constructor)
-  assert.equal(defaultFailure.constructor, structuredFailure.constructor)
   assert.ok('arg' in defaultFailure && 'arg' in cooperativeFailure)
-  assert.ok('arg' in structuredFailure)
   assert.ok(defaultFailure.arg instanceof AggregateError)
   assert.ok(cooperativeFailure.arg instanceof AggregateError)
-  assert.ok(structuredFailure.arg instanceof AggregateError)
   assert.equal(defaultFailure.arg.message, cooperativeFailure.arg.message)
-  assert.equal(defaultFailure.arg.message, structuredFailure.arg.message)
   assert.equal(defaultFailure.arg.errors.length, cooperativeFailure.arg.errors.length)
-  assert.equal(defaultFailure.arg.errors.length, structuredFailure.arg.errors.length)
 }
 
 function benchmark(

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -17,8 +17,6 @@ import type { Fx } from '../src/Fx.js'
 interface BenchmarkCase {
   readonly name: string
   readonly group: string
-  readonly iterations: number
-  readonly warmup: number
   readonly run: () => Promise<void>
 }
 
@@ -26,9 +24,13 @@ interface Result {
   readonly name: string
   readonly group: string
   readonly iterations: number
-  readonly totalMs: number
   readonly opsPerSecond: number
-  readonly nsPerOp: number
+  readonly samples: readonly number[]
+  readonly medianNsPerOp: number
+  readonly minNsPerOp: number
+  readonly p75NsPerOp: number
+  readonly maxNsPerOp: number
+  readonly spread: number
   readonly relativeToGroupBaseline: number
 }
 
@@ -44,9 +46,12 @@ class Step extends Effect('benchmark/cooperative-all/Step')<{ readonly id: numbe
 
 const Fanout = 16
 const StepsPerChild = 16
-const FastIterations = 1_000
-const YieldingIterations = 250
-const CleanupIterations = 250
+const Samples = 7
+const WarmupIterations = 3
+const TargetSampleMs = 250
+const CalibrationTargetMs = TargetSampleMs / 2
+const MaxCalibrationIterations = 65_536
+const NoiseSpreadThreshold = 1.25
 const CleanupScope = scope('benchmark/cooperative-all/Cleanup')
 
 await runSemanticChecks()
@@ -59,58 +64,58 @@ const fairness = [
 ]
 
 const results = await runBenchmarks([
-  benchmark('withUnboundedConcurrency ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+  benchmark('withUnboundedConcurrency ok fanout 16', 'ok fanout', async () => {
     await all(okChildren(Fanout)).pipe(withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+  benchmark('withCoopConcurrency ok fanout 16', 'ok fanout', async () => {
     await all(okChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
   }),
-  benchmark('withUnboundedConcurrency async fanout 16', 'async fanout', FastIterations, 100, async () => {
+  benchmark('withUnboundedConcurrency async fanout 16', 'async fanout', async () => {
     await all(asyncChildren(Fanout)).pipe(withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency async fanout 16', 'async fanout', FastIterations, 100, async () => {
+  benchmark('withCoopConcurrency async fanout 16', 'async fanout', async () => {
     await all(asyncChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
   }),
-  benchmark('withUnboundedConcurrency explicit fork fanout 16', 'explicit fork fanout', FastIterations, 100, async () => {
+  benchmark('withUnboundedConcurrency explicit fork fanout 16', 'explicit fork fanout', async () => {
     await explicitForkFanout(okChildren(Fanout)).pipe(withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency explicit fork fanout 16', 'explicit fork fanout', FastIterations, 100, async () => {
+  benchmark('withCoopConcurrency explicit fork fanout 16', 'explicit fork fanout', async () => {
     await explicitForkFanout(okChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
   }),
-  benchmark('withUnboundedConcurrency yielding 16x16', 'yielding fanout', YieldingIterations, 50, async () => {
+  benchmark('withUnboundedConcurrency yielding 16x16', 'yielding fanout', async () => {
     await yieldingAll().pipe(handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
+  benchmark('withCoopConcurrency yielding 16x16 budget 1', 'yielding fanout', async () => {
     await yieldingAll().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), runPromise)
   }),
-  benchmark('withCoopConcurrency yielding 16x16 budget 8', 'yielding fanout', YieldingIterations, 50, async () => {
+  benchmark('withCoopConcurrency yielding 16x16 budget 8', 'yielding fanout', async () => {
     await yieldingAll().pipe(withCoopConcurrency({ yieldBudget: 8 }), handleStep(), runPromise)
   }),
-  benchmark('withCoopConcurrency yielding 16x16 budget 64', 'yielding fanout', YieldingIterations, 50, async () => {
+  benchmark('withCoopConcurrency yielding 16x16 budget 64', 'yielding fanout', async () => {
     await yieldingAll().pipe(withCoopConcurrency({ yieldBudget: 64 }), handleStep(), runPromise)
   }),
-  benchmark('withUnboundedConcurrency mixed parked async', 'mixed async', YieldingIterations, 50, async () => {
+  benchmark('withUnboundedConcurrency mixed parked async', 'mixed async', async () => {
     await mixedAsyncAndYielding().pipe(handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
+  benchmark('withCoopConcurrency mixed parked async budget 1', 'mixed async', async () => {
     await mixedAsyncAndYielding().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), runPromise)
   }),
-  benchmark('firstSettled + withUnboundedConcurrency nested race', 'nested race', YieldingIterations, 50, async () => {
+  benchmark('firstSettled + withUnboundedConcurrency nested race', 'nested race', async () => {
     await nestedRace().pipe(firstSettled, handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency nested race', 'nested race', YieldingIterations, 50, async () => {
+  benchmark('withCoopConcurrency nested race', 'nested race', async () => {
     await nestedRace().pipe(firstSettled, withCoopConcurrency(), handleStep(), runPromise)
   }),
-  benchmark('firstSuccess + withUnboundedConcurrency nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
+  benchmark('firstSuccess + withUnboundedConcurrency nested firstSuccess', 'nested firstSuccess', async () => {
     await nestedFirstSuccess().pipe(firstSuccess, handleStep(), withUnboundedConcurrency, runPromise)
   }),
-  benchmark('withCoopConcurrency nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
+  benchmark('withCoopConcurrency nested firstSuccess', 'nested firstSuccess', async () => {
     await nestedFirstSuccess().pipe(firstSuccess, withCoopConcurrency(), handleStep(), runPromise)
   }),
-  benchmark('withUnboundedConcurrency cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+  benchmark('withUnboundedConcurrency cancel cleanup', 'cleanup', async () => {
     await cleanupFailureProgram().pipe(withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
   }),
-  benchmark('withCoopConcurrency cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+  benchmark('withCoopConcurrency cancel cleanup', 'cleanup', async () => {
     await cleanupFailureProgram().pipe(withCoopConcurrency(), withScope(CleanupScope), returnFail, runPromise)
   })
 ])
@@ -137,44 +142,105 @@ async function runSemanticChecks(): Promise<void> {
 function benchmark(
   name: string,
   group: string,
-  iterations: number,
-  warmup: number,
   run: () => Promise<void>
 ): BenchmarkCase {
-  return { name, group, iterations, warmup, run }
+  return { name, group, run }
 }
 
 async function runBenchmarks(benchmarks: readonly BenchmarkCase[]): Promise<readonly Result[]> {
-  const rawResults: Omit<Result, 'relativeToGroupBaseline'>[] = []
+  const groups = groupedBenchmarks(benchmarks)
+  const rawResults = new Map<BenchmarkCase, { iterations: number, samples: number[] }>()
 
   for (const b of benchmarks) {
-    for (let i = 0; i < b.warmup; i++) await b.run()
+    await warmup(b)
+    rawResults.set(b, { iterations: await calibrateIterations(b), samples: [] })
+  }
 
-    const start = performance.now()
-    for (let i = 0; i < b.iterations; i++) await b.run()
-    const totalMs = performance.now() - start
-    const opsPerSecond = b.iterations / (totalMs / 1_000)
-    const nsPerOp = (totalMs * 1_000_000) / b.iterations
-
-    rawResults.push({
-      name: b.name,
-      group: b.group,
-      iterations: b.iterations,
-      totalMs,
-      opsPerSecond,
-      nsPerOp
-    })
+  for (const group of groups) {
+    for (let sample = 0; sample < Samples; sample++) {
+      const ordered = sample % 2 === 0
+        ? group
+        : [...group.slice(1), group[0]]
+      for (const b of ordered) {
+        const result = rawResults.get(b)!
+        result.samples.push(await sampleNsPerOp(b, result.iterations))
+      }
+    }
   }
 
   const baselines = new Map<string, number>()
-  for (const result of rawResults) {
-    if (!baselines.has(result.group)) baselines.set(result.group, result.nsPerOp)
-  }
+  const results = benchmarks.map(b => {
+    const raw = rawResults.get(b)!
+    const samples = [...raw.samples].sort((a, b) => a - b)
+    const minNsPerOp = samples[0]
+    const maxNsPerOp = samples[samples.length - 1]
+    const medianNsPerOp = percentile(samples, 0.5)
+    const p75NsPerOp = percentile(samples, 0.75)
+    const spread = maxNsPerOp / minNsPerOp
+    const result: Omit<Result, 'relativeToGroupBaseline'> = {
+      name: b.name,
+      group: b.group,
+      iterations: raw.iterations,
+      opsPerSecond: 1_000_000_000 / medianNsPerOp,
+      samples,
+      medianNsPerOp,
+      minNsPerOp,
+      p75NsPerOp,
+      maxNsPerOp,
+      spread
+    }
+    if (!baselines.has(result.group)) baselines.set(result.group, result.medianNsPerOp)
+    return result
+  })
 
-  return rawResults.map(result => ({
+  return results.map(result => ({
     ...result,
-    relativeToGroupBaseline: result.nsPerOp / (baselines.get(result.group) ?? result.nsPerOp)
+    relativeToGroupBaseline: result.medianNsPerOp / (baselines.get(result.group) ?? result.medianNsPerOp)
   }))
+}
+
+function groupedBenchmarks(benchmarks: readonly BenchmarkCase[]): readonly BenchmarkCase[][] {
+  const groups = [] as BenchmarkCase[][]
+  const byName = new Map<string, BenchmarkCase[]>()
+  for (const b of benchmarks) {
+    let group = byName.get(b.group)
+    if (group === undefined) {
+      group = []
+      byName.set(b.group, group)
+      groups.push(group)
+    }
+    group.push(b)
+  }
+  return groups
+}
+
+async function warmup(b: BenchmarkCase): Promise<void> {
+  for (let i = 0; i < WarmupIterations; i++) await b.run()
+}
+
+async function calibrateIterations(b: BenchmarkCase): Promise<number> {
+  let iterations = 1
+  while (true) {
+    const totalMs = await timeIterations(b, iterations)
+    if (totalMs >= CalibrationTargetMs || iterations >= MaxCalibrationIterations) return iterations
+    iterations *= 2
+  }
+}
+
+async function sampleNsPerOp(b: BenchmarkCase, iterations: number): Promise<number> {
+  const totalMs = await timeIterations(b, iterations)
+  return (totalMs * 1_000_000) / iterations
+}
+
+async function timeIterations(b: BenchmarkCase, iterations: number): Promise<number> {
+  const start = performance.now()
+  for (let i = 0; i < iterations; i++) await b.run()
+  return performance.now() - start
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+  const index = Math.ceil(sorted.length * p) - 1
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))]
 }
 
 async function measureFairness(
@@ -338,15 +404,21 @@ function formatMarkdown(fairness: readonly FairnessSummary[], results: readonly 
     '',
     '## Performance',
     '',
-    '| Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |',
-    '| --- | ---: | ---: | ---: | ---: | ---: |',
+    'Relative values use median ns/op; noisy rows have max/min > 1.25.',
+    '',
+    '| Case | Samples | Iterations/sample | Ops/sec | Median ns/op | Min ns/op | P75 ns/op | Max ns/op | Relative to group baseline | Noise |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
     ...results.map(result => [
       `| ${result.name}`,
+      result.samples.length.toLocaleString(),
       result.iterations.toLocaleString(),
-      result.totalMs.toFixed(2),
       result.opsPerSecond.toFixed(0),
-      result.nsPerOp.toFixed(0),
-      `${result.relativeToGroupBaseline.toFixed(2)}x |`
+      result.medianNsPerOp.toFixed(0),
+      result.minNsPerOp.toFixed(0),
+      result.p75NsPerOp.toFixed(0),
+      result.maxNsPerOp.toFixed(0),
+      `${result.relativeToGroupBaseline.toFixed(2)}x`,
+      `${result.spread <= NoiseSpreadThreshold ? 'ok' : 'noisy'} |`
     ].join(' | '))
   ].join('\n')
 }

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -4,7 +4,7 @@ import { arch, platform, release } from 'node:os'
 import { performance } from 'node:perf_hooks'
 
 import { assertPromise } from '../src/Async.js'
-import { all, cooperativeAll, defaultAll, unbounded } from '../src/Concurrent.js'
+import { all, cooperativeAll, cooperativeStructured, defaultAll, firstSettled, firstSuccess, race, unbounded } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
 import { fail, returnFail } from '../src/Fail.js'
 import { andFinally } from '../src/Finalization.js'
@@ -53,6 +53,7 @@ await runSemanticChecks()
 const fairness = [
   await measureFairness('defaultAll + unbounded', f => f.pipe(defaultAll, unbounded)),
   await measureFairness('cooperativeAll budget 1', f => f.pipe(cooperativeAll({ yieldBudget: 1 }))),
+  await measureFairness('cooperativeStructured budget 1', f => f.pipe(cooperativeStructured({ yieldBudget: 1 }))),
   await measureFairness('cooperativeAll budget 8', f => f.pipe(cooperativeAll({ yieldBudget: 8 }))),
   await measureFairness('cooperativeAll budget 64', f => f.pipe(cooperativeAll({ yieldBudget: 64 })))
 ]
@@ -64,17 +65,26 @@ const results = await runBenchmarks([
   benchmark('cooperativeAll ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
     await all(okChildren(Fanout)).pipe(cooperativeAll(), runPromise)
   }),
+  benchmark('cooperativeStructured ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+    await all(okChildren(Fanout)).pipe(cooperativeStructured(), runPromise)
+  }),
   benchmark('defaultAll + unbounded async fanout 16', 'async fanout', FastIterations, 100, async () => {
     await all(asyncChildren(Fanout)).pipe(defaultAll, unbounded, runPromise)
   }),
   benchmark('cooperativeAll async fanout 16', 'async fanout', FastIterations, 100, async () => {
     await all(asyncChildren(Fanout)).pipe(cooperativeAll(), runPromise)
   }),
+  benchmark('cooperativeStructured async fanout 16', 'async fanout', FastIterations, 100, async () => {
+    await all(asyncChildren(Fanout)).pipe(cooperativeStructured(), runPromise)
+  }),
   benchmark('defaultAll + unbounded yielding 16x16', 'yielding fanout', YieldingIterations, 50, async () => {
     await yieldingAll().pipe(defaultAll, handleStep(), unbounded, runPromise)
   }),
   benchmark('cooperativeAll yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
     await yieldingAll().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), runPromise)
+  }),
+  benchmark('cooperativeStructured yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(cooperativeStructured({ yieldBudget: 1 }), handleStep(), runPromise)
   }),
   benchmark('cooperativeAll yielding 16x16 budget 8', 'yielding fanout', YieldingIterations, 50, async () => {
     await yieldingAll().pipe(cooperativeAll({ yieldBudget: 8 }), handleStep(), runPromise)
@@ -88,11 +98,29 @@ const results = await runBenchmarks([
   benchmark('cooperativeAll mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
     await mixedAsyncAndYielding().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), runPromise)
   }),
+  benchmark('cooperativeStructured mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
+    await mixedAsyncAndYielding().pipe(cooperativeStructured({ yieldBudget: 1 }), handleStep(), runPromise)
+  }),
+  benchmark('defaultAll + firstSettled + unbounded nested race', 'nested race', YieldingIterations, 50, async () => {
+    await nestedRace().pipe(firstSettled, defaultAll, handleStep(), unbounded, runPromise)
+  }),
+  benchmark('cooperativeStructured nested race', 'nested race', YieldingIterations, 50, async () => {
+    await nestedRace().pipe(cooperativeStructured(), handleStep(), runPromise)
+  }),
+  benchmark('defaultAll + firstSuccess + unbounded nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
+    await nestedFirstSuccess().pipe(firstSuccess, defaultAll, handleStep(), unbounded, runPromise)
+  }),
+  benchmark('cooperativeStructured nested firstSuccess', 'nested firstSuccess', YieldingIterations, 50, async () => {
+    await nestedFirstSuccess().pipe(cooperativeStructured({ racePolicy: 'firstSuccess' }), handleStep(), runPromise)
+  }),
   benchmark('defaultAll + unbounded cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
     await cleanupFailureProgram().pipe(defaultAll, withScope(CleanupScope), returnFail, unbounded, runPromise)
   }),
   benchmark('cooperativeAll cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
     await cleanupFailureProgram().pipe(cooperativeAll(), withScope(CleanupScope), returnFail, runPromise)
+  }),
+  benchmark('cooperativeStructured cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+    await cleanupFailureProgram().pipe(cooperativeStructured(), withScope(CleanupScope), returnFail, runPromise)
   })
 ])
 
@@ -101,18 +129,26 @@ console.log(formatMarkdown(fairness, results))
 async function runSemanticChecks(): Promise<void> {
   const defaultResult = await parityProgram().pipe(defaultAll, handleStep(), withScope(CleanupScope), returnFail, unbounded, runPromise)
   const cooperativeResult = await parityProgram().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
+  const structuredResult = await parityProgram().pipe(cooperativeStructured({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
 
   assert.deepEqual(defaultResult, cooperativeResult)
+  assert.deepEqual(defaultResult, structuredResult)
 
   const defaultFailure = await cleanupFailureProgram().pipe(defaultAll, withScope(CleanupScope), returnFail, unbounded, runPromise)
   const cooperativeFailure = await cleanupFailureProgram().pipe(cooperativeAll(), withScope(CleanupScope), returnFail, runPromise)
+  const structuredFailure = await cleanupFailureProgram().pipe(cooperativeStructured(), withScope(CleanupScope), returnFail, runPromise)
 
   assert.equal(defaultFailure.constructor, cooperativeFailure.constructor)
+  assert.equal(defaultFailure.constructor, structuredFailure.constructor)
   assert.ok('arg' in defaultFailure && 'arg' in cooperativeFailure)
+  assert.ok('arg' in structuredFailure)
   assert.ok(defaultFailure.arg instanceof AggregateError)
   assert.ok(cooperativeFailure.arg instanceof AggregateError)
+  assert.ok(structuredFailure.arg instanceof AggregateError)
   assert.equal(defaultFailure.arg.message, cooperativeFailure.arg.message)
+  assert.equal(defaultFailure.arg.message, structuredFailure.arg.message)
   assert.equal(defaultFailure.arg.errors.length, cooperativeFailure.arg.errors.length)
+  assert.equal(defaultFailure.arg.errors.length, structuredFailure.arg.errors.length)
 }
 
 function benchmark(
@@ -198,6 +234,28 @@ function mixedAsyncAndYielding() {
   return all([
     assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('async')))),
     ...Array.from({ length: 7 }, (_, id) => yieldingChild(id, StepsPerChild))
+  ])
+}
+
+function nestedRace() {
+  return all([
+    race([
+      assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('slow')))),
+      ok('fast')
+    ]),
+    yieldingChild(0, 2)
+  ])
+}
+
+function nestedFirstSuccess() {
+  return all([
+    race([
+      fx(function* () {
+        yield* fail(new Error('primary failed'))
+      }),
+      assertPromise(() => Promise.resolve('replica'))
+    ]),
+    yieldingChild(0, 2)
   ])
 }
 

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -1,0 +1,317 @@
+import * as assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { arch, platform, release } from 'node:os'
+import { performance } from 'node:perf_hooks'
+
+import { assertPromise } from '../src/Async.js'
+import { all, cooperativeAll, defaultAll, unbounded } from '../src/Concurrent.js'
+import { Effect } from '../src/Effect.js'
+import { fail, returnFail } from '../src/Fail.js'
+import { andFinally } from '../src/Finalization.js'
+import { fx, ok, runPromise } from '../src/Fx.js'
+import { handle } from '../src/Handler.js'
+import { scope, withScope } from '../src/Scope.js'
+import type { Fx } from '../src/Fx.js'
+
+interface BenchmarkCase {
+  readonly name: string
+  readonly group: string
+  readonly iterations: number
+  readonly warmup: number
+  readonly run: () => Promise<void>
+}
+
+interface Result {
+  readonly name: string
+  readonly group: string
+  readonly iterations: number
+  readonly totalMs: number
+  readonly opsPerSecond: number
+  readonly nsPerOp: number
+  readonly relativeToGroupBaseline: number
+}
+
+interface FairnessSummary {
+  readonly name: string
+  readonly totalSteps: number
+  readonly maxConsecutiveSteps: number
+  readonly firstStepPositions: readonly number[]
+  readonly firstStepSpread: number
+}
+
+class Step extends Effect('benchmark/cooperative-all/Step')<{ readonly id: number, readonly step: number }, void> { }
+
+const Fanout = 16
+const StepsPerChild = 16
+const FastIterations = 1_000
+const YieldingIterations = 250
+const CleanupIterations = 250
+const CleanupScope = scope('benchmark/cooperative-all/Cleanup')
+
+await runSemanticChecks()
+
+const fairness = [
+  await measureFairness('defaultAll + unbounded', f => f.pipe(defaultAll, unbounded)),
+  await measureFairness('cooperativeAll budget 1', f => f.pipe(cooperativeAll({ yieldBudget: 1 }))),
+  await measureFairness('cooperativeAll budget 8', f => f.pipe(cooperativeAll({ yieldBudget: 8 }))),
+  await measureFairness('cooperativeAll budget 64', f => f.pipe(cooperativeAll({ yieldBudget: 64 })))
+]
+
+const results = await runBenchmarks([
+  benchmark('defaultAll + unbounded ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+    await all(okChildren(Fanout)).pipe(defaultAll, unbounded, runPromise)
+  }),
+  benchmark('cooperativeAll ok fanout 16', 'ok fanout', FastIterations, 100, async () => {
+    await all(okChildren(Fanout)).pipe(cooperativeAll(), runPromise)
+  }),
+  benchmark('defaultAll + unbounded async fanout 16', 'async fanout', FastIterations, 100, async () => {
+    await all(asyncChildren(Fanout)).pipe(defaultAll, unbounded, runPromise)
+  }),
+  benchmark('cooperativeAll async fanout 16', 'async fanout', FastIterations, 100, async () => {
+    await all(asyncChildren(Fanout)).pipe(cooperativeAll(), runPromise)
+  }),
+  benchmark('defaultAll + unbounded yielding 16x16', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(defaultAll, handleStep(), unbounded, runPromise)
+  }),
+  benchmark('cooperativeAll yielding 16x16 budget 1', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), runPromise)
+  }),
+  benchmark('cooperativeAll yielding 16x16 budget 8', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(cooperativeAll({ yieldBudget: 8 }), handleStep(), runPromise)
+  }),
+  benchmark('cooperativeAll yielding 16x16 budget 64', 'yielding fanout', YieldingIterations, 50, async () => {
+    await yieldingAll().pipe(cooperativeAll({ yieldBudget: 64 }), handleStep(), runPromise)
+  }),
+  benchmark('defaultAll + unbounded mixed parked async', 'mixed async', YieldingIterations, 50, async () => {
+    await mixedAsyncAndYielding().pipe(defaultAll, handleStep(), unbounded, runPromise)
+  }),
+  benchmark('cooperativeAll mixed parked async budget 1', 'mixed async', YieldingIterations, 50, async () => {
+    await mixedAsyncAndYielding().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), runPromise)
+  }),
+  benchmark('defaultAll + unbounded cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+    await cleanupFailureProgram().pipe(defaultAll, withScope(CleanupScope), returnFail, unbounded, runPromise)
+  }),
+  benchmark('cooperativeAll cancel cleanup', 'cleanup', CleanupIterations, 50, async () => {
+    await cleanupFailureProgram().pipe(cooperativeAll(), withScope(CleanupScope), returnFail, runPromise)
+  })
+])
+
+console.log(formatMarkdown(fairness, results))
+
+async function runSemanticChecks(): Promise<void> {
+  const defaultResult = await parityProgram().pipe(defaultAll, handleStep(), withScope(CleanupScope), returnFail, unbounded, runPromise)
+  const cooperativeResult = await parityProgram().pipe(cooperativeAll({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
+
+  assert.deepEqual(defaultResult, cooperativeResult)
+
+  const defaultFailure = await cleanupFailureProgram().pipe(defaultAll, withScope(CleanupScope), returnFail, unbounded, runPromise)
+  const cooperativeFailure = await cleanupFailureProgram().pipe(cooperativeAll(), withScope(CleanupScope), returnFail, runPromise)
+
+  assert.equal(defaultFailure.constructor, cooperativeFailure.constructor)
+  assert.ok('arg' in defaultFailure && 'arg' in cooperativeFailure)
+  assert.ok(defaultFailure.arg instanceof AggregateError)
+  assert.ok(cooperativeFailure.arg instanceof AggregateError)
+  assert.equal(defaultFailure.arg.message, cooperativeFailure.arg.message)
+  assert.equal(defaultFailure.arg.errors.length, cooperativeFailure.arg.errors.length)
+}
+
+function benchmark(
+  name: string,
+  group: string,
+  iterations: number,
+  warmup: number,
+  run: () => Promise<void>
+): BenchmarkCase {
+  return { name, group, iterations, warmup, run }
+}
+
+async function runBenchmarks(benchmarks: readonly BenchmarkCase[]): Promise<readonly Result[]> {
+  const rawResults: Omit<Result, 'relativeToGroupBaseline'>[] = []
+
+  for (const b of benchmarks) {
+    for (let i = 0; i < b.warmup; i++) await b.run()
+
+    const start = performance.now()
+    for (let i = 0; i < b.iterations; i++) await b.run()
+    const totalMs = performance.now() - start
+    const opsPerSecond = b.iterations / (totalMs / 1_000)
+    const nsPerOp = (totalMs * 1_000_000) / b.iterations
+
+    rawResults.push({
+      name: b.name,
+      group: b.group,
+      iterations: b.iterations,
+      totalMs,
+      opsPerSecond,
+      nsPerOp
+    })
+  }
+
+  const baselines = new Map<string, number>()
+  for (const result of rawResults) {
+    if (!baselines.has(result.group)) baselines.set(result.group, result.nsPerOp)
+  }
+
+  return rawResults.map(result => ({
+    ...result,
+    relativeToGroupBaseline: result.nsPerOp / (baselines.get(result.group) ?? result.nsPerOp)
+  }))
+}
+
+async function measureFairness(
+  name: string,
+  handler: (f: Fx<any, readonly number[]>) => Fx<any, readonly number[]>
+): Promise<FairnessSummary> {
+  const events = [] as { readonly id: number, readonly step: number }[]
+
+  await yieldingAll().pipe(
+    handler,
+    handle(Step, step => fx(function* () {
+      events.push(step.arg)
+    })),
+    runPromise
+  )
+
+  return {
+    name,
+    totalSteps: events.length,
+    maxConsecutiveSteps: maxConsecutive(events),
+    firstStepPositions: firstStepPositions(events, Fanout),
+    firstStepSpread: firstStepSpread(events, Fanout)
+  }
+}
+
+function yieldingAll() {
+  return all(Array.from({ length: Fanout }, (_, id) => yieldingChild(id, StepsPerChild)))
+}
+
+function yieldingChild(id: number, steps: number) {
+  return fx(function* () {
+    for (let step = 0; step < steps; step++) {
+      yield* new Step({ id, step })
+    }
+    return id
+  })
+}
+
+function mixedAsyncAndYielding() {
+  return all([
+    assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('async')))),
+    ...Array.from({ length: 7 }, (_, id) => yieldingChild(id, StepsPerChild))
+  ])
+}
+
+function parityProgram() {
+  return all([
+    ok(1),
+    assertPromise(() => Promise.resolve('async')),
+    yieldingChild(1, 2)
+  ])
+}
+
+function cleanupFailureProgram() {
+  const primary = new Error('primary')
+  const release = new Error('release')
+  const slow = fx(function* () {
+    yield* andFinally(CleanupScope, fail(release))
+    yield* assertPromise<void>(signal => new Promise(resolve => {
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    }))
+  })
+  const bad = fx(function* () {
+    yield* assertPromise(() => Promise.resolve())
+    yield* fail(primary)
+  })
+  return all([slow, bad])
+}
+
+function okChildren(length: number) {
+  return Array.from({ length }, (_, i) => ok(i))
+}
+
+function asyncChildren(length: number) {
+  return Array.from({ length }, (_, i) => assertPromise(() => Promise.resolve(i)))
+}
+
+function handleStep() {
+  return handle(Step, () => ok(undefined))
+}
+
+function maxConsecutive(events: readonly { readonly id: number }[]): number {
+  let max = 0
+  let current = 0
+  let previous: number | undefined
+  for (const event of events) {
+    current = event.id === previous ? current + 1 : 1
+    previous = event.id
+    max = Math.max(max, current)
+  }
+  return max
+}
+
+function firstStepPositions(events: readonly { readonly id: number }[], fanout: number): readonly number[] {
+  const positions = Array.from({ length: fanout }, () => -1)
+  for (let i = 0; i < events.length; i++) {
+    if (positions[events[i].id] < 0) positions[events[i].id] = i
+  }
+  return positions
+}
+
+function firstStepSpread(events: readonly { readonly id: number }[], fanout: number): number {
+  const positions = firstStepPositions(events, fanout)
+  return Math.max(...positions) - Math.min(...positions)
+}
+
+function formatMarkdown(fairness: readonly FairnessSummary[], results: readonly Result[]): string {
+  return [
+    '# Cooperative All Evaluation',
+    '',
+    `- Date: ${new Date().toISOString()}`,
+    `- Git SHA: ${gitSha()}`,
+    `- Worktree: ${worktreeState()}`,
+    `- Node: ${process.version}`,
+    `- Platform: ${platform()} ${release()} ${arch()}`,
+    '- Command: `pnpm benchmark:cooperative-all`',
+    '',
+    '## Semantic Checks',
+    '',
+    '- Parity success/failure checks: pass',
+    '',
+    '## Fairness',
+    '',
+    '| Case | Total steps | Max consecutive same-child steps | First-step spread |',
+    '| --- | ---: | ---: | ---: |',
+    ...fairness.map(result =>
+      `| ${result.name} | ${result.totalSteps} | ${result.maxConsecutiveSteps} | ${result.firstStepSpread} |`
+    ),
+    '',
+    '## Performance',
+    '',
+    '| Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+    ...results.map(result => [
+      `| ${result.name}`,
+      result.iterations.toLocaleString(),
+      result.totalMs.toFixed(2),
+      result.opsPerSecond.toFixed(0),
+      result.nsPerOp.toFixed(0),
+      `${result.relativeToGroupBaseline.toFixed(2)}x |`
+    ].join(' | '))
+  ].join('\n')
+}
+
+function gitSha(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+function worktreeState(): string {
+  try {
+    return execFileSync('git', ['status', '--short'], { encoding: 'utf8' }).trim() || 'clean'
+  } catch {
+    return 'unknown'
+  }
+}

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -4,13 +4,14 @@ import { arch, platform, release } from 'node:os'
 import { performance } from 'node:perf_hooks'
 
 import { assertPromise } from '../src/Async.js'
-import { all, firstSettled, firstSuccess, race, withCoopConcurrency, withUnboundedConcurrency } from '../src/Concurrent.js'
+import { all, firstSettled, firstSuccess, fork, race, withCoopConcurrency, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
 import { fail, returnFail } from '../src/Fail.js'
 import { andFinally } from '../src/Finalization.js'
 import { fx, ok, runPromise } from '../src/Fx.js'
 import { handle } from '../src/Handler.js'
 import { scope, withScope } from '../src/Scope.js'
+import { wait } from '../src/Task.js'
 import type { Fx } from '../src/Fx.js'
 
 interface BenchmarkCase {
@@ -69,6 +70,12 @@ const results = await runBenchmarks([
   }),
   benchmark('withCoopConcurrency async fanout 16', 'async fanout', FastIterations, 100, async () => {
     await all(asyncChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
+  }),
+  benchmark('withUnboundedConcurrency explicit fork fanout 16', 'explicit fork fanout', FastIterations, 100, async () => {
+    await explicitForkFanout(okChildren(Fanout)).pipe(withUnboundedConcurrency, runPromise)
+  }),
+  benchmark('withCoopConcurrency explicit fork fanout 16', 'explicit fork fanout', FastIterations, 100, async () => {
+    await explicitForkFanout(okChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
   }),
   benchmark('withUnboundedConcurrency yielding 16x16', 'yielding fanout', YieldingIterations, 50, async () => {
     await yieldingAll().pipe(handleStep(), withUnboundedConcurrency, runPromise)
@@ -211,6 +218,16 @@ function mixedAsyncAndYielding() {
     assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('async')))),
     ...Array.from({ length: 7 }, (_, id) => yieldingChild(id, StepsPerChild))
   ])
+}
+
+function explicitForkFanout(children: readonly Fx<unknown, unknown>[]) {
+  return fx(function* () {
+    const tasks = []
+    for (const child of children) tasks.push(yield* fork(child))
+    const results = []
+    for (const task of tasks) results.push(yield* wait(task))
+    return results
+  })
 }
 
 function nestedRace() {

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,8 +1,14 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-27T14:17:33.513Z
-- Git SHA: 2eca93e
-- Worktree: dirty
+- Date: 2026-05-27T15:05:52.557Z
+- Git SHA: 549f212
+- Worktree: M benchmarks/cooperative-all.ts
+ M examples/advanced/bookmarks/browser/assets/src/Concurrent.js
+ M examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+ M examples/advanced/incident-collector/cli.ts
+ M src/Concurrent.test.ts
+ M src/Concurrent.ts
+ M src/internal/withCoopConcurrency.ts
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
 - Command: `pnpm benchmark:cooperative-all`
@@ -24,19 +30,21 @@
 
 | Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| withUnboundedConcurrency ok fanout 16 | 1,000 | 251.26 | 3980 | 251265 | 1.00x |
-| withCoopConcurrency ok fanout 16 | 1,000 | 71.87 | 13915 | 71865 | 0.29x |
-| withUnboundedConcurrency async fanout 16 | 1,000 | 411.36 | 2431 | 411364 | 1.00x |
-| withCoopConcurrency async fanout 16 | 1,000 | 297.91 | 3357 | 297905 | 0.72x |
-| withUnboundedConcurrency yielding 16x16 | 250 | 76.45 | 3270 | 305797 | 1.00x |
-| withCoopConcurrency yielding 16x16 budget 1 | 250 | 57.56 | 4344 | 230226 | 0.75x |
-| withCoopConcurrency yielding 16x16 budget 8 | 250 | 54.53 | 4585 | 218106 | 0.71x |
-| withCoopConcurrency yielding 16x16 budget 64 | 250 | 54.50 | 4588 | 217983 | 0.71x |
-| withUnboundedConcurrency mixed parked async | 250 | 51.43 | 4861 | 205725 | 1.00x |
-| withCoopConcurrency mixed parked async budget 1 | 250 | 50.53 | 4947 | 202123 | 0.98x |
-| firstSettled + withUnboundedConcurrency nested race | 250 | 62.91 | 3974 | 251650 | 1.00x |
-| withCoopConcurrency nested race | 250 | 23.85 | 10480 | 95419 | 0.38x |
-| firstSuccess + withUnboundedConcurrency nested firstSuccess | 250 | 72.86 | 3431 | 291422 | 1.00x |
-| withCoopConcurrency nested firstSuccess | 250 | 47.09 | 5309 | 188367 | 0.65x |
-| withUnboundedConcurrency cancel cleanup | 250 | 78.22 | 3196 | 312899 | 1.00x |
-| withCoopConcurrency cancel cleanup | 250 | 60.69 | 4120 | 242742 | 0.78x |
+| withUnboundedConcurrency ok fanout 16 | 1,000 | 254.00 | 3937 | 254003 | 1.00x |
+| withCoopConcurrency ok fanout 16 | 1,000 | 93.39 | 10708 | 93385 | 0.37x |
+| withUnboundedConcurrency async fanout 16 | 1,000 | 415.13 | 2409 | 415129 | 1.00x |
+| withCoopConcurrency async fanout 16 | 1,000 | 334.67 | 2988 | 334671 | 0.81x |
+| withUnboundedConcurrency explicit fork fanout 16 | 1,000 | 711.33 | 1406 | 711333 | 1.00x |
+| withCoopConcurrency explicit fork fanout 16 | 1,000 | 898.21 | 1113 | 898210 | 1.26x |
+| withUnboundedConcurrency yielding 16x16 | 250 | 76.74 | 3258 | 306944 | 1.00x |
+| withCoopConcurrency yielding 16x16 budget 1 | 250 | 133.06 | 1879 | 532248 | 1.73x |
+| withCoopConcurrency yielding 16x16 budget 8 | 250 | 81.62 | 3063 | 326487 | 1.06x |
+| withCoopConcurrency yielding 16x16 budget 64 | 250 | 75.40 | 3316 | 301600 | 0.98x |
+| withUnboundedConcurrency mixed parked async | 250 | 51.89 | 4818 | 207556 | 1.00x |
+| withCoopConcurrency mixed parked async budget 1 | 250 | 88.34 | 2830 | 353376 | 1.70x |
+| firstSettled + withUnboundedConcurrency nested race | 250 | 63.89 | 3913 | 255554 | 1.00x |
+| withCoopConcurrency nested race | 250 | 26.71 | 9361 | 106823 | 0.42x |
+| firstSuccess + withUnboundedConcurrency nested firstSuccess | 250 | 73.29 | 3411 | 293153 | 1.00x |
+| withCoopConcurrency nested firstSuccess | 250 | 51.20 | 4883 | 204806 | 0.70x |
+| withUnboundedConcurrency cancel cleanup | 250 | 79.38 | 3149 | 317516 | 1.00x |
+| withCoopConcurrency cancel cleanup | 250 | 76.94 | 3249 | 307762 | 0.97x |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,13 +1,8 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-26T23:00:08.550Z
-- Git SHA: a7bbca9
-- Worktree: M benchmarks/cooperative-all.ts
- M examples/advanced/diagnostics.ts
- M examples/advanced/incident-collector/cli.ts
- M src/Concurrent.test.ts
- M src/Concurrent.ts
- M src/Trace.test.ts
+- Date: 2026-05-27T14:17:33.513Z
+- Git SHA: 2eca93e
+- Worktree: dirty
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
 - Command: `pnpm benchmark:cooperative-all`
@@ -20,34 +15,28 @@
 
 | Case | Total steps | Max consecutive same-child steps | First-step spread |
 | --- | ---: | ---: | ---: |
-| defaultAll + unbounded | 256 | 16 | 240 |
-| cooperativeAll budget 1 | 256 | 1 | 15 |
-| cooperativeStructured budget 1 | 256 | 1 | 15 |
-| cooperativeAll budget 8 | 256 | 8 | 120 |
-| cooperativeAll budget 64 | 256 | 16 | 240 |
+| withUnboundedConcurrency | 256 | 16 | 240 |
+| withCoopConcurrency budget 1 | 256 | 1 | 15 |
+| withCoopConcurrency budget 8 | 256 | 8 | 120 |
+| withCoopConcurrency budget 64 | 256 | 16 | 240 |
 
 ## Performance
 
 | Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| defaultAll + unbounded ok fanout 16 | 1,000 | 254.00 | 3937 | 253999 | 1.00x |
-| cooperativeAll ok fanout 16 | 1,000 | 71.14 | 14056 | 71142 | 0.28x |
-| cooperativeStructured ok fanout 16 | 1,000 | 75.39 | 13265 | 75386 | 0.30x |
-| defaultAll + unbounded async fanout 16 | 1,000 | 425.67 | 2349 | 425674 | 1.00x |
-| cooperativeAll async fanout 16 | 1,000 | 291.35 | 3432 | 291352 | 0.68x |
-| cooperativeStructured async fanout 16 | 1,000 | 291.79 | 3427 | 291789 | 0.69x |
-| defaultAll + unbounded yielding 16x16 | 250 | 89.26 | 2801 | 357021 | 1.00x |
-| cooperativeAll yielding 16x16 budget 1 | 250 | 59.76 | 4183 | 239041 | 0.67x |
-| cooperativeStructured yielding 16x16 budget 1 | 250 | 66.26 | 3773 | 265041 | 0.74x |
-| cooperativeAll yielding 16x16 budget 8 | 250 | 54.64 | 4576 | 218543 | 0.61x |
-| cooperativeAll yielding 16x16 budget 64 | 250 | 54.82 | 4560 | 219281 | 0.61x |
-| defaultAll + unbounded mixed parked async | 250 | 56.65 | 4413 | 226585 | 1.00x |
-| cooperativeAll mixed parked async budget 1 | 250 | 53.22 | 4697 | 212892 | 0.94x |
-| cooperativeStructured mixed parked async budget 1 | 250 | 54.16 | 4616 | 216623 | 0.96x |
-| defaultAll + firstSettled + unbounded nested race | 250 | 53.31 | 4689 | 213245 | 1.00x |
-| cooperativeStructured nested race | 250 | 40.70 | 6142 | 162807 | 0.76x |
-| defaultAll + firstSuccess + unbounded nested firstSuccess | 250 | 56.33 | 4438 | 225311 | 1.00x |
-| cooperativeStructured nested firstSuccess | 250 | 38.29 | 6528 | 153179 | 0.68x |
-| defaultAll + unbounded cancel cleanup | 250 | 79.42 | 3148 | 317672 | 1.00x |
-| cooperativeAll cancel cleanup | 250 | 69.47 | 3599 | 277865 | 0.87x |
-| cooperativeStructured cancel cleanup | 250 | 75.76 | 3300 | 303038 | 0.95x |
+| withUnboundedConcurrency ok fanout 16 | 1,000 | 251.26 | 3980 | 251265 | 1.00x |
+| withCoopConcurrency ok fanout 16 | 1,000 | 71.87 | 13915 | 71865 | 0.29x |
+| withUnboundedConcurrency async fanout 16 | 1,000 | 411.36 | 2431 | 411364 | 1.00x |
+| withCoopConcurrency async fanout 16 | 1,000 | 297.91 | 3357 | 297905 | 0.72x |
+| withUnboundedConcurrency yielding 16x16 | 250 | 76.45 | 3270 | 305797 | 1.00x |
+| withCoopConcurrency yielding 16x16 budget 1 | 250 | 57.56 | 4344 | 230226 | 0.75x |
+| withCoopConcurrency yielding 16x16 budget 8 | 250 | 54.53 | 4585 | 218106 | 0.71x |
+| withCoopConcurrency yielding 16x16 budget 64 | 250 | 54.50 | 4588 | 217983 | 0.71x |
+| withUnboundedConcurrency mixed parked async | 250 | 51.43 | 4861 | 205725 | 1.00x |
+| withCoopConcurrency mixed parked async budget 1 | 250 | 50.53 | 4947 | 202123 | 0.98x |
+| firstSettled + withUnboundedConcurrency nested race | 250 | 62.91 | 3974 | 251650 | 1.00x |
+| withCoopConcurrency nested race | 250 | 23.85 | 10480 | 95419 | 0.38x |
+| firstSuccess + withUnboundedConcurrency nested firstSuccess | 250 | 72.86 | 3431 | 291422 | 1.00x |
+| withCoopConcurrency nested firstSuccess | 250 | 47.09 | 5309 | 188367 | 0.65x |
+| withUnboundedConcurrency cancel cleanup | 250 | 78.22 | 3196 | 312899 | 1.00x |
+| withCoopConcurrency cancel cleanup | 250 | 60.69 | 4120 | 242742 | 0.78x |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,12 +1,9 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-27T15:53:19.155Z
-- Git SHA: 178b079
-- Worktree: M .gitignore
- M benchmarks/cooperative-all.ts
- M benchmarks/results/2026-05-26-cooperative-all-evaluation.md
- M package.json
-?? tsconfig.benchmarks.json
+- Date: 2026-05-27T16:04:33.447Z
+- Git SHA: 2f24d49
+- Worktree: M examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+ M src/internal/withCoopConcurrency.ts
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
 - Command: `pnpm benchmark:cooperative-all:js`
@@ -30,21 +27,21 @@ Relative values use median ns/op; noisy rows have max/min > 1.25.
 
 | Case | Samples | Iterations/sample | Ops/sec | Median ns/op | Min ns/op | P75 ns/op | Max ns/op | Relative to group baseline | Noise |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| withUnboundedConcurrency ok fanout 16 | 7 | 256 | 1429 | 699794 | 389345 | 827833 | 1027380 | 1.00x | noisy |
-| withCoopConcurrency ok fanout 16 | 7 | 1,024 | 5213 | 191839 | 163922 | 235337 | 277906 | 0.27x | noisy |
-| withUnboundedConcurrency async fanout 16 | 7 | 128 | 999 | 1000840 | 767979 | 1246573 | 1384482 | 1.00x | noisy |
-| withCoopConcurrency async fanout 16 | 7 | 128 | 1586 | 630542 | 508196 | 1168176 | 1533040 | 0.63x | noisy |
-| withUnboundedConcurrency explicit fork fanout 16 | 7 | 128 | 642 | 1558152 | 1382815 | 1794227 | 1809416 | 1.00x | noisy |
-| withCoopConcurrency explicit fork fanout 16 | 7 | 128 | 456 | 2194337 | 1606428 | 2461571 | 3813409 | 1.41x | noisy |
-| withUnboundedConcurrency yielding 16x16 | 7 | 256 | 1233 | 810775 | 531315 | 1026831 | 1078655 | 1.00x | noisy |
-| withCoopConcurrency yielding 16x16 budget 1 | 7 | 256 | 1051 | 951915 | 730461 | 1189937 | 1289765 | 1.17x | noisy |
-| withCoopConcurrency yielding 16x16 budget 8 | 7 | 256 | 1478 | 676763 | 577612 | 751533 | 797900 | 0.83x | noisy |
-| withCoopConcurrency yielding 16x16 budget 64 | 7 | 256 | 1385 | 722214 | 519691 | 867792 | 1127790 | 0.89x | noisy |
-| withUnboundedConcurrency mixed parked async | 7 | 512 | 2422 | 412805 | 353401 | 529743 | 969536 | 1.00x | noisy |
-| withCoopConcurrency mixed parked async budget 1 | 7 | 512 | 1997 | 500689 | 430688 | 532626 | 739699 | 1.21x | noisy |
-| firstSettled + withUnboundedConcurrency nested race | 7 | 256 | 1602 | 624407 | 539767 | 648144 | 1019465 | 1.00x | noisy |
-| withCoopConcurrency nested race | 7 | 512 | 3969 | 251983 | 199441 | 339557 | 435078 | 0.40x | noisy |
-| firstSuccess + withUnboundedConcurrency nested firstSuccess | 7 | 256 | 1569 | 637505 | 607538 | 710729 | 1401519 | 1.00x | noisy |
-| withCoopConcurrency nested firstSuccess | 7 | 512 | 2250 | 444404 | 336311 | 471651 | 504660 | 0.70x | noisy |
-| withUnboundedConcurrency cancel cleanup | 7 | 128 | 1576 | 634333 | 476223 | 870445 | 1220737 | 1.00x | noisy |
-| withCoopConcurrency cancel cleanup | 7 | 256 | 1894 | 528081 | 394323 | 673861 | 903845 | 0.83x | noisy |
+| withUnboundedConcurrency ok fanout 16 | 7 | 256 | 1762 | 567545 | 482995 | 772960 | 1149967 | 1.00x | noisy |
+| withCoopConcurrency ok fanout 16 | 7 | 1,024 | 5830 | 171537 | 125990 | 220181 | 255567 | 0.30x | noisy |
+| withUnboundedConcurrency async fanout 16 | 7 | 128 | 963 | 1038446 | 795456 | 1286805 | 1395427 | 1.00x | noisy |
+| withCoopConcurrency async fanout 16 | 7 | 256 | 1298 | 770231 | 629769 | 889606 | 1048148 | 0.74x | noisy |
+| withUnboundedConcurrency explicit fork fanout 16 | 7 | 64 | 501 | 1994850 | 1437461 | 2183201 | 2339361 | 1.00x | noisy |
+| withCoopConcurrency explicit fork fanout 16 | 7 | 128 | 507 | 1971643 | 1583415 | 2106479 | 3475435 | 0.99x | noisy |
+| withUnboundedConcurrency yielding 16x16 | 7 | 256 | 1059 | 943975 | 627867 | 1076568 | 1087195 | 1.00x | noisy |
+| withCoopConcurrency yielding 16x16 budget 1 | 7 | 256 | 1163 | 859488 | 743255 | 972677 | 2678375 | 0.91x | noisy |
+| withCoopConcurrency yielding 16x16 budget 8 | 7 | 256 | 1454 | 687735 | 615735 | 829282 | 1272101 | 0.73x | noisy |
+| withCoopConcurrency yielding 16x16 budget 64 | 7 | 128 | 1275 | 784560 | 520299 | 840314 | 1737747 | 0.83x | noisy |
+| withUnboundedConcurrency mixed parked async | 7 | 256 | 1767 | 565785 | 430473 | 738436 | 1010726 | 1.00x | noisy |
+| withCoopConcurrency mixed parked async budget 1 | 7 | 256 | 1882 | 531463 | 478978 | 821670 | 1146725 | 0.94x | noisy |
+| firstSettled + withUnboundedConcurrency nested race | 7 | 256 | 1784 | 560581 | 445633 | 825560 | 830177 | 1.00x | noisy |
+| withCoopConcurrency nested race | 7 | 512 | 3997 | 250178 | 178129 | 314780 | 391877 | 0.45x | noisy |
+| firstSuccess + withUnboundedConcurrency nested firstSuccess | 7 | 128 | 1132 | 883439 | 562211 | 1068859 | 1201798 | 1.00x | noisy |
+| withCoopConcurrency nested firstSuccess | 7 | 512 | 2309 | 433176 | 384115 | 576156 | 697450 | 0.49x | noisy |
+| withUnboundedConcurrency cancel cleanup | 7 | 256 | 1316 | 759804 | 533263 | 799053 | 923808 | 1.00x | noisy |
+| withCoopConcurrency cancel cleanup | 7 | 256 | 1868 | 535312 | 410142 | 686722 | 798265 | 0.70x | noisy |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,9 +1,8 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-27T15:30:21.116Z
-- Git SHA: 8894dc8
-- Worktree: M examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
- M src/internal/withCoopConcurrency.ts
+- Date: 2026-05-27T15:45:42.285Z
+- Git SHA: 491b0ca
+- Worktree: M benchmarks/cooperative-all.ts
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
 - Command: `pnpm benchmark:cooperative-all`
@@ -23,23 +22,25 @@
 
 ## Performance
 
-| Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| withUnboundedConcurrency ok fanout 16 | 1,000 | 1605.63 | 623 | 1605628 | 1.00x |
-| withCoopConcurrency ok fanout 16 | 1,000 | 395.85 | 2526 | 395851 | 0.25x |
-| withUnboundedConcurrency async fanout 16 | 1,000 | 1866.01 | 536 | 1866007 | 1.00x |
-| withCoopConcurrency async fanout 16 | 1,000 | 1380.77 | 724 | 1380765 | 0.74x |
-| withUnboundedConcurrency explicit fork fanout 16 | 1,000 | 3298.14 | 303 | 3298137 | 1.00x |
-| withCoopConcurrency explicit fork fanout 16 | 1,000 | 2657.80 | 376 | 2657801 | 0.81x |
-| withUnboundedConcurrency yielding 16x16 | 250 | 196.02 | 1275 | 784069 | 1.00x |
-| withCoopConcurrency yielding 16x16 budget 1 | 250 | 400.53 | 624 | 1602120 | 2.04x |
-| withCoopConcurrency yielding 16x16 budget 8 | 250 | 234.34 | 1067 | 937357 | 1.20x |
-| withCoopConcurrency yielding 16x16 budget 64 | 250 | 192.71 | 1297 | 770850 | 0.98x |
-| withUnboundedConcurrency mixed parked async | 250 | 138.19 | 1809 | 552772 | 1.00x |
-| withCoopConcurrency mixed parked async budget 1 | 250 | 211.81 | 1180 | 847224 | 1.53x |
-| firstSettled + withUnboundedConcurrency nested race | 250 | 172.91 | 1446 | 691639 | 1.00x |
-| withCoopConcurrency nested race | 250 | 85.14 | 2936 | 340577 | 0.49x |
-| firstSuccess + withUnboundedConcurrency nested firstSuccess | 250 | 199.99 | 1250 | 799960 | 1.00x |
-| withCoopConcurrency nested firstSuccess | 250 | 117.89 | 2121 | 471577 | 0.59x |
-| withUnboundedConcurrency cancel cleanup | 250 | 172.75 | 1447 | 691011 | 1.00x |
-| withCoopConcurrency cancel cleanup | 250 | 169.59 | 1474 | 678360 | 0.98x |
+Relative values use median ns/op; noisy rows have max/min > 1.25.
+
+| Case | Samples | Iterations/sample | Ops/sec | Median ns/op | Min ns/op | P75 ns/op | Max ns/op | Relative to group baseline | Noise |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| withUnboundedConcurrency ok fanout 16 | 7 | 512 | 1617 | 618583 | 589344 | 944461 | 952843 | 1.00x | noisy |
+| withCoopConcurrency ok fanout 16 | 7 | 512 | 4491 | 222651 | 198463 | 255605 | 276647 | 0.36x | noisy |
+| withUnboundedConcurrency async fanout 16 | 7 | 128 | 939 | 1065070 | 755930 | 1250553 | 1382945 | 1.00x | noisy |
+| withCoopConcurrency async fanout 16 | 7 | 256 | 1268 | 788459 | 594976 | 1138728 | 1378940 | 0.74x | noisy |
+| withUnboundedConcurrency explicit fork fanout 16 | 7 | 64 | 583 | 1715222 | 1519904 | 2138153 | 3019964 | 1.00x | noisy |
+| withCoopConcurrency explicit fork fanout 16 | 7 | 64 | 467 | 2143388 | 1869129 | 2601603 | 3947670 | 1.25x | noisy |
+| withUnboundedConcurrency yielding 16x16 | 7 | 128 | 1332 | 750997 | 676244 | 777983 | 779274 | 1.00x | ok |
+| withCoopConcurrency yielding 16x16 budget 1 | 7 | 128 | 794 | 1258682 | 1124880 | 1413323 | 2625518 | 1.68x | noisy |
+| withCoopConcurrency yielding 16x16 budget 8 | 7 | 256 | 1405 | 711498 | 639358 | 1050178 | 1164359 | 0.95x | noisy |
+| withCoopConcurrency yielding 16x16 budget 64 | 7 | 256 | 1196 | 835895 | 589977 | 875376 | 922024 | 1.11x | noisy |
+| withUnboundedConcurrency mixed parked async | 7 | 256 | 2019 | 495187 | 392712 | 519083 | 913018 | 1.00x | noisy |
+| withCoopConcurrency mixed parked async budget 1 | 7 | 256 | 1337 | 748013 | 677658 | 995126 | 2966284 | 1.51x | noisy |
+| firstSettled + withUnboundedConcurrency nested race | 7 | 256 | 1348 | 741595 | 674321 | 800532 | 802748 | 1.00x | ok |
+| withCoopConcurrency nested race | 7 | 512 | 3174 | 315097 | 262359 | 416512 | 618288 | 0.42x | noisy |
+| firstSuccess + withUnboundedConcurrency nested firstSuccess | 7 | 256 | 1219 | 820651 | 737237 | 897775 | 1337599 | 1.00x | noisy |
+| withCoopConcurrency nested firstSuccess | 7 | 256 | 1927 | 518932 | 398069 | 590304 | 641366 | 0.63x | noisy |
+| withUnboundedConcurrency cancel cleanup | 7 | 128 | 1528 | 654531 | 557817 | 791813 | 965751 | 1.00x | noisy |
+| withCoopConcurrency cancel cleanup | 7 | 256 | 1543 | 647905 | 482473 | 885705 | 970192 | 0.99x | noisy |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,11 +1,15 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-27T15:45:42.285Z
-- Git SHA: 491b0ca
-- Worktree: M benchmarks/cooperative-all.ts
+- Date: 2026-05-27T15:53:19.155Z
+- Git SHA: 178b079
+- Worktree: M .gitignore
+ M benchmarks/cooperative-all.ts
+ M benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+ M package.json
+?? tsconfig.benchmarks.json
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
-- Command: `pnpm benchmark:cooperative-all`
+- Command: `pnpm benchmark:cooperative-all:js`
 
 ## Semantic Checks
 
@@ -26,21 +30,21 @@ Relative values use median ns/op; noisy rows have max/min > 1.25.
 
 | Case | Samples | Iterations/sample | Ops/sec | Median ns/op | Min ns/op | P75 ns/op | Max ns/op | Relative to group baseline | Noise |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| withUnboundedConcurrency ok fanout 16 | 7 | 512 | 1617 | 618583 | 589344 | 944461 | 952843 | 1.00x | noisy |
-| withCoopConcurrency ok fanout 16 | 7 | 512 | 4491 | 222651 | 198463 | 255605 | 276647 | 0.36x | noisy |
-| withUnboundedConcurrency async fanout 16 | 7 | 128 | 939 | 1065070 | 755930 | 1250553 | 1382945 | 1.00x | noisy |
-| withCoopConcurrency async fanout 16 | 7 | 256 | 1268 | 788459 | 594976 | 1138728 | 1378940 | 0.74x | noisy |
-| withUnboundedConcurrency explicit fork fanout 16 | 7 | 64 | 583 | 1715222 | 1519904 | 2138153 | 3019964 | 1.00x | noisy |
-| withCoopConcurrency explicit fork fanout 16 | 7 | 64 | 467 | 2143388 | 1869129 | 2601603 | 3947670 | 1.25x | noisy |
-| withUnboundedConcurrency yielding 16x16 | 7 | 128 | 1332 | 750997 | 676244 | 777983 | 779274 | 1.00x | ok |
-| withCoopConcurrency yielding 16x16 budget 1 | 7 | 128 | 794 | 1258682 | 1124880 | 1413323 | 2625518 | 1.68x | noisy |
-| withCoopConcurrency yielding 16x16 budget 8 | 7 | 256 | 1405 | 711498 | 639358 | 1050178 | 1164359 | 0.95x | noisy |
-| withCoopConcurrency yielding 16x16 budget 64 | 7 | 256 | 1196 | 835895 | 589977 | 875376 | 922024 | 1.11x | noisy |
-| withUnboundedConcurrency mixed parked async | 7 | 256 | 2019 | 495187 | 392712 | 519083 | 913018 | 1.00x | noisy |
-| withCoopConcurrency mixed parked async budget 1 | 7 | 256 | 1337 | 748013 | 677658 | 995126 | 2966284 | 1.51x | noisy |
-| firstSettled + withUnboundedConcurrency nested race | 7 | 256 | 1348 | 741595 | 674321 | 800532 | 802748 | 1.00x | ok |
-| withCoopConcurrency nested race | 7 | 512 | 3174 | 315097 | 262359 | 416512 | 618288 | 0.42x | noisy |
-| firstSuccess + withUnboundedConcurrency nested firstSuccess | 7 | 256 | 1219 | 820651 | 737237 | 897775 | 1337599 | 1.00x | noisy |
-| withCoopConcurrency nested firstSuccess | 7 | 256 | 1927 | 518932 | 398069 | 590304 | 641366 | 0.63x | noisy |
-| withUnboundedConcurrency cancel cleanup | 7 | 128 | 1528 | 654531 | 557817 | 791813 | 965751 | 1.00x | noisy |
-| withCoopConcurrency cancel cleanup | 7 | 256 | 1543 | 647905 | 482473 | 885705 | 970192 | 0.99x | noisy |
+| withUnboundedConcurrency ok fanout 16 | 7 | 256 | 1429 | 699794 | 389345 | 827833 | 1027380 | 1.00x | noisy |
+| withCoopConcurrency ok fanout 16 | 7 | 1,024 | 5213 | 191839 | 163922 | 235337 | 277906 | 0.27x | noisy |
+| withUnboundedConcurrency async fanout 16 | 7 | 128 | 999 | 1000840 | 767979 | 1246573 | 1384482 | 1.00x | noisy |
+| withCoopConcurrency async fanout 16 | 7 | 128 | 1586 | 630542 | 508196 | 1168176 | 1533040 | 0.63x | noisy |
+| withUnboundedConcurrency explicit fork fanout 16 | 7 | 128 | 642 | 1558152 | 1382815 | 1794227 | 1809416 | 1.00x | noisy |
+| withCoopConcurrency explicit fork fanout 16 | 7 | 128 | 456 | 2194337 | 1606428 | 2461571 | 3813409 | 1.41x | noisy |
+| withUnboundedConcurrency yielding 16x16 | 7 | 256 | 1233 | 810775 | 531315 | 1026831 | 1078655 | 1.00x | noisy |
+| withCoopConcurrency yielding 16x16 budget 1 | 7 | 256 | 1051 | 951915 | 730461 | 1189937 | 1289765 | 1.17x | noisy |
+| withCoopConcurrency yielding 16x16 budget 8 | 7 | 256 | 1478 | 676763 | 577612 | 751533 | 797900 | 0.83x | noisy |
+| withCoopConcurrency yielding 16x16 budget 64 | 7 | 256 | 1385 | 722214 | 519691 | 867792 | 1127790 | 0.89x | noisy |
+| withUnboundedConcurrency mixed parked async | 7 | 512 | 2422 | 412805 | 353401 | 529743 | 969536 | 1.00x | noisy |
+| withCoopConcurrency mixed parked async budget 1 | 7 | 512 | 1997 | 500689 | 430688 | 532626 | 739699 | 1.21x | noisy |
+| firstSettled + withUnboundedConcurrency nested race | 7 | 256 | 1602 | 624407 | 539767 | 648144 | 1019465 | 1.00x | noisy |
+| withCoopConcurrency nested race | 7 | 512 | 3969 | 251983 | 199441 | 339557 | 435078 | 0.40x | noisy |
+| firstSuccess + withUnboundedConcurrency nested firstSuccess | 7 | 256 | 1569 | 637505 | 607538 | 710729 | 1401519 | 1.00x | noisy |
+| withCoopConcurrency nested firstSuccess | 7 | 512 | 2250 | 444404 | 336311 | 471651 | 504660 | 0.70x | noisy |
+| withUnboundedConcurrency cancel cleanup | 7 | 128 | 1576 | 634333 | 476223 | 870445 | 1220737 | 1.00x | noisy |
+| withCoopConcurrency cancel cleanup | 7 | 256 | 1894 | 528081 | 394323 | 673861 | 903845 | 0.83x | noisy |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,15 +1,13 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-26T20:40:36.554Z
-- Git SHA: 192e251
-- Worktree: M package.json
+- Date: 2026-05-26T23:00:08.550Z
+- Git SHA: a7bbca9
+- Worktree: M benchmarks/cooperative-all.ts
+ M examples/advanced/diagnostics.ts
+ M examples/advanced/incident-collector/cli.ts
  M src/Concurrent.test.ts
  M src/Concurrent.ts
  M src/Trace.test.ts
- M src/internal/runFork.ts
-?? benchmarks/cooperative-all.ts
-?? benchmarks/results/2026-05-26-cooperative-all-evaluation.md
-?? src/internal/forkDiagnostics.ts
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
 - Command: `pnpm benchmark:cooperative-all`
@@ -24,6 +22,7 @@
 | --- | ---: | ---: | ---: |
 | defaultAll + unbounded | 256 | 16 | 240 |
 | cooperativeAll budget 1 | 256 | 1 | 15 |
+| cooperativeStructured budget 1 | 256 | 1 | 15 |
 | cooperativeAll budget 8 | 256 | 8 | 120 |
 | cooperativeAll budget 64 | 256 | 16 | 240 |
 
@@ -31,15 +30,24 @@
 
 | Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| defaultAll + unbounded ok fanout 16 | 1,000 | 254.31 | 3932 | 254308 | 1.00x |
-| cooperativeAll ok fanout 16 | 1,000 | 73.57 | 13593 | 73567 | 0.29x |
-| defaultAll + unbounded async fanout 16 | 1,000 | 419.60 | 2383 | 419600 | 1.00x |
-| cooperativeAll async fanout 16 | 1,000 | 292.47 | 3419 | 292469 | 0.70x |
-| defaultAll + unbounded yielding 16x16 | 250 | 86.16 | 2902 | 344642 | 1.00x |
-| cooperativeAll yielding 16x16 budget 1 | 250 | 57.01 | 4385 | 228055 | 0.66x |
-| cooperativeAll yielding 16x16 budget 8 | 250 | 53.80 | 4646 | 215218 | 0.62x |
-| cooperativeAll yielding 16x16 budget 64 | 250 | 53.09 | 4709 | 212349 | 0.62x |
-| defaultAll + unbounded mixed parked async | 250 | 55.85 | 4476 | 223402 | 1.00x |
-| cooperativeAll mixed parked async budget 1 | 250 | 51.16 | 4886 | 204654 | 0.92x |
-| defaultAll + unbounded cancel cleanup | 250 | 76.05 | 3287 | 304208 | 1.00x |
-| cooperativeAll cancel cleanup | 250 | 66.26 | 3773 | 265048 | 0.87x |
+| defaultAll + unbounded ok fanout 16 | 1,000 | 254.00 | 3937 | 253999 | 1.00x |
+| cooperativeAll ok fanout 16 | 1,000 | 71.14 | 14056 | 71142 | 0.28x |
+| cooperativeStructured ok fanout 16 | 1,000 | 75.39 | 13265 | 75386 | 0.30x |
+| defaultAll + unbounded async fanout 16 | 1,000 | 425.67 | 2349 | 425674 | 1.00x |
+| cooperativeAll async fanout 16 | 1,000 | 291.35 | 3432 | 291352 | 0.68x |
+| cooperativeStructured async fanout 16 | 1,000 | 291.79 | 3427 | 291789 | 0.69x |
+| defaultAll + unbounded yielding 16x16 | 250 | 89.26 | 2801 | 357021 | 1.00x |
+| cooperativeAll yielding 16x16 budget 1 | 250 | 59.76 | 4183 | 239041 | 0.67x |
+| cooperativeStructured yielding 16x16 budget 1 | 250 | 66.26 | 3773 | 265041 | 0.74x |
+| cooperativeAll yielding 16x16 budget 8 | 250 | 54.64 | 4576 | 218543 | 0.61x |
+| cooperativeAll yielding 16x16 budget 64 | 250 | 54.82 | 4560 | 219281 | 0.61x |
+| defaultAll + unbounded mixed parked async | 250 | 56.65 | 4413 | 226585 | 1.00x |
+| cooperativeAll mixed parked async budget 1 | 250 | 53.22 | 4697 | 212892 | 0.94x |
+| cooperativeStructured mixed parked async budget 1 | 250 | 54.16 | 4616 | 216623 | 0.96x |
+| defaultAll + firstSettled + unbounded nested race | 250 | 53.31 | 4689 | 213245 | 1.00x |
+| cooperativeStructured nested race | 250 | 40.70 | 6142 | 162807 | 0.76x |
+| defaultAll + firstSuccess + unbounded nested firstSuccess | 250 | 56.33 | 4438 | 225311 | 1.00x |
+| cooperativeStructured nested firstSuccess | 250 | 38.29 | 6528 | 153179 | 0.68x |
+| defaultAll + unbounded cancel cleanup | 250 | 79.42 | 3148 | 317672 | 1.00x |
+| cooperativeAll cancel cleanup | 250 | 69.47 | 3599 | 277865 | 0.87x |
+| cooperativeStructured cancel cleanup | 250 | 75.76 | 3300 | 303038 | 0.95x |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,13 +1,8 @@
 # Cooperative All Evaluation
 
-- Date: 2026-05-27T15:05:52.557Z
-- Git SHA: 549f212
-- Worktree: M benchmarks/cooperative-all.ts
- M examples/advanced/bookmarks/browser/assets/src/Concurrent.js
- M examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
- M examples/advanced/incident-collector/cli.ts
- M src/Concurrent.test.ts
- M src/Concurrent.ts
+- Date: 2026-05-27T15:30:21.116Z
+- Git SHA: 8894dc8
+- Worktree: M examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
  M src/internal/withCoopConcurrency.ts
 - Node: v24.14.0
 - Platform: darwin 25.3.0 arm64
@@ -30,21 +25,21 @@
 
 | Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| withUnboundedConcurrency ok fanout 16 | 1,000 | 254.00 | 3937 | 254003 | 1.00x |
-| withCoopConcurrency ok fanout 16 | 1,000 | 93.39 | 10708 | 93385 | 0.37x |
-| withUnboundedConcurrency async fanout 16 | 1,000 | 415.13 | 2409 | 415129 | 1.00x |
-| withCoopConcurrency async fanout 16 | 1,000 | 334.67 | 2988 | 334671 | 0.81x |
-| withUnboundedConcurrency explicit fork fanout 16 | 1,000 | 711.33 | 1406 | 711333 | 1.00x |
-| withCoopConcurrency explicit fork fanout 16 | 1,000 | 898.21 | 1113 | 898210 | 1.26x |
-| withUnboundedConcurrency yielding 16x16 | 250 | 76.74 | 3258 | 306944 | 1.00x |
-| withCoopConcurrency yielding 16x16 budget 1 | 250 | 133.06 | 1879 | 532248 | 1.73x |
-| withCoopConcurrency yielding 16x16 budget 8 | 250 | 81.62 | 3063 | 326487 | 1.06x |
-| withCoopConcurrency yielding 16x16 budget 64 | 250 | 75.40 | 3316 | 301600 | 0.98x |
-| withUnboundedConcurrency mixed parked async | 250 | 51.89 | 4818 | 207556 | 1.00x |
-| withCoopConcurrency mixed parked async budget 1 | 250 | 88.34 | 2830 | 353376 | 1.70x |
-| firstSettled + withUnboundedConcurrency nested race | 250 | 63.89 | 3913 | 255554 | 1.00x |
-| withCoopConcurrency nested race | 250 | 26.71 | 9361 | 106823 | 0.42x |
-| firstSuccess + withUnboundedConcurrency nested firstSuccess | 250 | 73.29 | 3411 | 293153 | 1.00x |
-| withCoopConcurrency nested firstSuccess | 250 | 51.20 | 4883 | 204806 | 0.70x |
-| withUnboundedConcurrency cancel cleanup | 250 | 79.38 | 3149 | 317516 | 1.00x |
-| withCoopConcurrency cancel cleanup | 250 | 76.94 | 3249 | 307762 | 0.97x |
+| withUnboundedConcurrency ok fanout 16 | 1,000 | 1605.63 | 623 | 1605628 | 1.00x |
+| withCoopConcurrency ok fanout 16 | 1,000 | 395.85 | 2526 | 395851 | 0.25x |
+| withUnboundedConcurrency async fanout 16 | 1,000 | 1866.01 | 536 | 1866007 | 1.00x |
+| withCoopConcurrency async fanout 16 | 1,000 | 1380.77 | 724 | 1380765 | 0.74x |
+| withUnboundedConcurrency explicit fork fanout 16 | 1,000 | 3298.14 | 303 | 3298137 | 1.00x |
+| withCoopConcurrency explicit fork fanout 16 | 1,000 | 2657.80 | 376 | 2657801 | 0.81x |
+| withUnboundedConcurrency yielding 16x16 | 250 | 196.02 | 1275 | 784069 | 1.00x |
+| withCoopConcurrency yielding 16x16 budget 1 | 250 | 400.53 | 624 | 1602120 | 2.04x |
+| withCoopConcurrency yielding 16x16 budget 8 | 250 | 234.34 | 1067 | 937357 | 1.20x |
+| withCoopConcurrency yielding 16x16 budget 64 | 250 | 192.71 | 1297 | 770850 | 0.98x |
+| withUnboundedConcurrency mixed parked async | 250 | 138.19 | 1809 | 552772 | 1.00x |
+| withCoopConcurrency mixed parked async budget 1 | 250 | 211.81 | 1180 | 847224 | 1.53x |
+| firstSettled + withUnboundedConcurrency nested race | 250 | 172.91 | 1446 | 691639 | 1.00x |
+| withCoopConcurrency nested race | 250 | 85.14 | 2936 | 340577 | 0.49x |
+| firstSuccess + withUnboundedConcurrency nested firstSuccess | 250 | 199.99 | 1250 | 799960 | 1.00x |
+| withCoopConcurrency nested firstSuccess | 250 | 117.89 | 2121 | 471577 | 0.59x |
+| withUnboundedConcurrency cancel cleanup | 250 | 172.75 | 1447 | 691011 | 1.00x |
+| withCoopConcurrency cancel cleanup | 250 | 169.59 | 1474 | 678360 | 0.98x |

--- a/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+++ b/benchmarks/results/2026-05-26-cooperative-all-evaluation.md
@@ -1,0 +1,45 @@
+# Cooperative All Evaluation
+
+- Date: 2026-05-26T20:40:36.554Z
+- Git SHA: 192e251
+- Worktree: M package.json
+ M src/Concurrent.test.ts
+ M src/Concurrent.ts
+ M src/Trace.test.ts
+ M src/internal/runFork.ts
+?? benchmarks/cooperative-all.ts
+?? benchmarks/results/2026-05-26-cooperative-all-evaluation.md
+?? src/internal/forkDiagnostics.ts
+- Node: v24.14.0
+- Platform: darwin 25.3.0 arm64
+- Command: `pnpm benchmark:cooperative-all`
+
+## Semantic Checks
+
+- Parity success/failure checks: pass
+
+## Fairness
+
+| Case | Total steps | Max consecutive same-child steps | First-step spread |
+| --- | ---: | ---: | ---: |
+| defaultAll + unbounded | 256 | 16 | 240 |
+| cooperativeAll budget 1 | 256 | 1 | 15 |
+| cooperativeAll budget 8 | 256 | 8 | 120 |
+| cooperativeAll budget 64 | 256 | 16 | 240 |
+
+## Performance
+
+| Case | Iterations | Total ms | Ops/sec | ns/op | Relative to group baseline |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| defaultAll + unbounded ok fanout 16 | 1,000 | 254.31 | 3932 | 254308 | 1.00x |
+| cooperativeAll ok fanout 16 | 1,000 | 73.57 | 13593 | 73567 | 0.29x |
+| defaultAll + unbounded async fanout 16 | 1,000 | 419.60 | 2383 | 419600 | 1.00x |
+| cooperativeAll async fanout 16 | 1,000 | 292.47 | 3419 | 292469 | 0.70x |
+| defaultAll + unbounded yielding 16x16 | 250 | 86.16 | 2902 | 344642 | 1.00x |
+| cooperativeAll yielding 16x16 budget 1 | 250 | 57.01 | 4385 | 228055 | 0.66x |
+| cooperativeAll yielding 16x16 budget 8 | 250 | 53.80 | 4646 | 215218 | 0.62x |
+| cooperativeAll yielding 16x16 budget 64 | 250 | 53.09 | 4709 | 212349 | 0.62x |
+| defaultAll + unbounded mixed parked async | 250 | 55.85 | 4476 | 223402 | 1.00x |
+| cooperativeAll mixed parked async budget 1 | 250 | 51.16 | 4886 | 204654 | 0.92x |
+| defaultAll + unbounded cancel cleanup | 250 | 76.05 | 3287 | 304208 | 1.00x |
+| cooperativeAll cancel cleanup | 250 | 66.26 | 3773 | 265048 | 0.87x |

--- a/benchmarks/runtime-loops.ts
+++ b/benchmarks/runtime-loops.ts
@@ -3,7 +3,7 @@ import { arch, platform, release } from 'node:os'
 import { performance } from 'node:perf_hooks'
 
 import { assertPromise } from '../src/Async.js'
-import { all, bounded, defaultAll, firstSettled, fork, race, unbounded } from '../src/Concurrent.js'
+import { all, withBoundedConcurrency, firstSettled, fork, race, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
 import { andFinally } from '../src/Finalization.js'
 import { fx, ok, run, runPromise, runTask } from '../src/Fx.js'
@@ -207,19 +207,19 @@ const cases: readonly BenchmarkCase[] = [
   benchmark('sequential async x10', 'runFork', RunForkIterations, 100, async () => {
     await runPromise(sequentialAsync10)
   }),
-  benchmark('fork fanout 16 unbounded', 'runFork', RunForkIterations, 100, async () => {
-    await forkFanout16.pipe(unbounded, runPromise)
+  benchmark('fork fanout 16 withUnboundedConcurrency', 'runFork', RunForkIterations, 100, async () => {
+    await forkFanout16.pipe(withUnboundedConcurrency, runPromise)
   }),
   ...forkBounds.map(limit =>
-    benchmark(`fork fanout 16 bounded ${limit}`, 'runFork', RunForkIterations, 100, async () => {
-      await forkFanout16.pipe(bounded(limit), runPromise)
+    benchmark(`fork fanout 16 withBoundedConcurrency ${limit}`, 'runFork', RunForkIterations, 100, async () => {
+      await forkFanout16.pipe(withBoundedConcurrency(limit), runPromise)
     })
   ),
   benchmark('all fanout 16', 'runFork', RunForkIterations, 100, async () => {
-    await allFanout16.pipe(defaultAll, unbounded, runPromise)
+    await allFanout16.pipe(withUnboundedConcurrency, runPromise)
   }),
   benchmark('race fanout 16', 'runFork', RunForkIterations, 100, async () => {
-    await raceFanout16.pipe(firstSettled, unbounded, runPromise)
+    await raceFanout16.pipe(firstSettled, withUnboundedConcurrency, runPromise)
   }),
   benchmark('dispose blocked task', 'interrupt', InterruptIterations, 100, async () => {
     await disposeTask(blocked)
@@ -232,7 +232,7 @@ const cases: readonly BenchmarkCase[] = [
       const task = yield* fork(blocked)
       task[Symbol.dispose]()
       yield* assertPromise(() => task._disposeAndWait())
-    }).pipe(unbounded, runPromise)
+    }).pipe(withUnboundedConcurrency, runPromise)
   })
 ]
 

--- a/benchmarks/trace.ts
+++ b/benchmarks/trace.ts
@@ -3,7 +3,7 @@ import { arch, platform, release } from 'node:os'
 import { execFileSync } from 'node:child_process'
 
 import { assertPromise } from '../src/Async.js'
-import { all, defaultAll, firstSettled, fork, forkEach, race, unbounded } from '../src/Concurrent.js'
+import { all, firstSettled, fork, forkEach, race, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { fail, returnFail } from '../src/Fail.js'
 import { flatMap, fx, ok, run, runPromise } from '../src/Fx.js'
 import { wait } from '../src/Task.js'
@@ -76,39 +76,39 @@ const cases: readonly BenchmarkCase[] = [
   }),
   benchmark('nested fork failure', 'runtime', FailureIterations, 100, async () => {
     try {
-      await nestedForkFailure(4).pipe(unbounded, runPromise)
+      await nestedForkFailure(4).pipe(withUnboundedConcurrency, runPromise)
     } catch { }
   }),
   benchmark('nested fork success', 'runtime', FailureIterations, 100, async () => {
-    await nestedForkSuccess(4).pipe(unbounded, runPromise)
+    await nestedForkSuccess(4).pipe(withUnboundedConcurrency, runPromise)
   }),
   benchmark('nested fork failure labels', 'runtime', FailureIterations, 100, async () => {
     try {
-      await nestedForkFailure(4).pipe(unbounded, runPromise)
+      await nestedForkFailure(4).pipe(withUnboundedConcurrency, runPromise)
     } catch { }
   }, 'labels'),
   benchmark('nested fork failure off', 'runtime', FailureIterations, 100, async () => {
     try {
-      await nestedForkFailure(4).pipe(unbounded, runPromise)
+      await nestedForkFailure(4).pipe(withUnboundedConcurrency, runPromise)
     } catch { }
   }, 'off'),
   benchmark('all structured failure', 'runtime', FailureIterations, 100, async () => {
     try {
-      await all(structuredChildren()).pipe(defaultAll, unbounded, runPromise)
+      await all(structuredChildren()).pipe(withUnboundedConcurrency, runPromise)
     } catch { }
   }),
   benchmark('forkEach structured failure', 'runtime', FailureIterations, 100, async () => {
     try {
       await forkEach(structuredChildren()).pipe(
         flatMap(([, failed]) => wait(failed)),
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
     } catch { }
   }),
   benchmark('race structured failure', 'runtime', FailureIterations, 100, async () => {
     try {
-      await race(structuredChildren()).pipe(firstSettled, unbounded, runPromise)
+      await race(structuredChildren()).pipe(firstSettled, withUnboundedConcurrency, runPromise)
     } catch { }
   }),
   benchmark('plain breadcrumb object', 'capture', TraceIterations, 1_000, () => {

--- a/examples/advanced/bookmarks/browser/assets/examples/advanced/bookmarks/client.js
+++ b/examples/advanced/bookmarks/browser/assets/examples/advanced/bookmarks/client.js
@@ -1,28 +1,35 @@
-import { catchAll, fail, flatMap } from '@briancavalier/fx';
-import { decode } from '@briancavalier/fx/codec';
-import { expectSuccess, json, request } from '@briancavalier/fx/http-client';
-import { BookmarkJson, BookmarksJson, withBookmarkCodecs } from './codec.js';
-export const createBookmark = (baseUrl, input) => requestJson(baseUrl, 'bookmarks', {
+import { catchAll, catchOnly, fail, flatMap } from '@briancavalier/fx';
+import { decodeOrFail, encodeOrFail } from '@briancavalier/fx/codec';
+import { expectSuccess, request, text } from '@briancavalier/fx/http-client';
+import { AddBookmarkInputJson, BookmarkJson, BookmarksJson, InvalidBookmarkJson, withBookmarkCodecs } from './codec.js';
+export const createBookmark = (baseUrl, input) => createBookmarkRaw(baseUrl, input).pipe(withClientCodecs);
+const createBookmarkRaw = (baseUrl, input) => encodeOrFail(AddBookmarkInputJson, input).pipe(flatMap(body => requestText(baseUrl, 'bookmarks', {
     method: 'POST',
-    body: { type: 'json', value: input }
-}).pipe(flatMap(decodeBookmark));
-export const listBookmarks = (baseUrl, query = {}) => requestJson(baseUrl, 'bookmarks', {
+    body: { type: 'text', value: body },
+    headers: jsonHeaders
+})), flatMap(decodeBookmark));
+export const listBookmarks = (baseUrl, query = {}) => listBookmarksRaw(baseUrl, query).pipe(withClientCodecs);
+const listBookmarksRaw = (baseUrl, query = {}) => requestText(baseUrl, 'bookmarks', {
     query: bookmarkQueryParams(query)
 }).pipe(flatMap(decodeBookmarks));
-export const markBookmarkRead = (baseUrl, id) => requestJson(baseUrl, `bookmarks/${encodeURIComponent(id)}/read`, {
+export const markBookmarkRead = (baseUrl, id) => markBookmarkReadRaw(baseUrl, id).pipe(withClientCodecs);
+const markBookmarkReadRaw = (baseUrl, id) => requestText(baseUrl, `bookmarks/${encodeURIComponent(id)}/read`, {
     method: 'PATCH'
 }).pipe(flatMap(decodeBookmark));
-export const archiveBookmark = (baseUrl, id) => requestJson(baseUrl, `bookmarks/${encodeURIComponent(id)}/archive`, {
+export const archiveBookmark = (baseUrl, id) => archiveBookmarkRaw(baseUrl, id).pipe(withClientCodecs);
+const archiveBookmarkRaw = (baseUrl, id) => requestText(baseUrl, `bookmarks/${encodeURIComponent(id)}/archive`, {
     method: 'PATCH'
 }).pipe(flatMap(decodeBookmark));
-export const refreshBookmarkMetadata = (baseUrl, id) => requestJson(baseUrl, `bookmarks/${encodeURIComponent(id)}/metadata/refresh`, {
+export const refreshBookmarkMetadata = (baseUrl, id) => refreshBookmarkMetadataRaw(baseUrl, id).pipe(withClientCodecs);
+const refreshBookmarkMetadataRaw = (baseUrl, id) => requestText(baseUrl, `bookmarks/${encodeURIComponent(id)}/metadata/refresh`, {
     method: 'POST'
 }).pipe(flatMap(decodeBookmark));
-const requestJson = (baseUrl, path, options = {}) => request({
+const requestText = (baseUrl, path, options = {}) => request({
     method: options.method,
     url: apiUrl(baseUrl, path, options.query),
-    body: options.body
-}).pipe(flatMap(expectSuccess), flatMap(json), catchAll(cause => fail({ tag: 'BookmarkRequestFailed', cause })));
+    body: options.body,
+    headers: options.headers
+}).pipe(flatMap(expectSuccess), flatMap(text), catchAll(cause => fail({ tag: 'BookmarkRequestFailed', cause })));
 const apiUrl = (baseUrl, path, query) => {
     const url = new URL(path, baseUrl.href.endsWith('/') ? baseUrl : new URL(`${baseUrl.href}/`));
     if (query !== undefined) {
@@ -41,6 +48,7 @@ const bookmarkQueryParams = (query) => {
         params.set('text', query.text);
     return params;
 };
-const decodeBookmarks = (value) => withBookmarkCodecs(decode(BookmarksJson, value)).pipe(catchAll(() => invalidResponse(value)));
-const decodeBookmark = (value) => withBookmarkCodecs(decode(BookmarkJson, value)).pipe(catchAll(() => invalidResponse(value)));
-const invalidResponse = (value) => fail({ tag: 'InvalidBookmarkResponse', value });
+const decodeBookmarks = (value) => decodeOrFail(BookmarksJson, value);
+const decodeBookmark = (value) => decodeOrFail(BookmarkJson, value);
+const jsonHeaders = [['content-type', 'application/json']];
+const withClientCodecs = (program) => program.pipe(withBookmarkCodecs, catchOnly(InvalidBookmarkJson, error => fail({ tag: 'InvalidBookmarkResponse', value: error })));

--- a/examples/advanced/bookmarks/browser/assets/examples/advanced/bookmarks/codec.js
+++ b/examples/advanced/bookmarks/browser/assets/examples/advanced/bookmarks/codec.js
@@ -1,25 +1,29 @@
-import { fail, ok } from '@briancavalier/fx';
-import { codecKey, withCodec } from '@briancavalier/fx/codec';
+import { ok } from '@briancavalier/fx';
+import { codecFail, codecKey, codecOk, withCodec } from '@briancavalier/fx/codec';
 export class InvalidBookmarkJson extends Error {
 }
-export const BookmarkJson = codecKey()(Symbol('examples/advanced/bookmarks/BookmarkJson'), {
+export const BookmarkJson = codecKey()('examples/advanced/bookmarks/BookmarkJson', {
     description: 'Bookmark JSON with Date fields encoded as ISO strings'
 });
-export const BookmarksJson = codecKey()(Symbol('examples/advanced/bookmarks/BookmarksJson'), {
+export const BookmarksJson = codecKey()('examples/advanced/bookmarks/BookmarksJson', {
     description: 'Bookmark array JSON with Date fields encoded as ISO strings'
 });
-export const AddBookmarkInputJson = codecKey()(Symbol('examples/advanced/bookmarks/AddBookmarkInputJson'), {
+export const AddBookmarkInputJson = codecKey()('examples/advanced/bookmarks/AddBookmarkInputJson', {
     description: 'Add bookmark request JSON'
 });
+// This example uses a small hand-rolled JSON codec so the data boundary is easy
+// to inspect without adding dependencies. A real application could keep the same
+// codec keys and delegate these handlers to Zod, Valibot, Arktype, Effect
+// Schema, a Standard Schema adapter, or a project-local parser/serializer.
 export const withBookmarkCodecs = (program) => program.pipe(withCodec(BookmarkJson, {
-    encode: bookmark => ok(bookmarkToWire(bookmark)),
-    decode: decodeBookmarkWire
+    encode: bookmark => ok(encodeJson(bookmarkToWire(bookmark))),
+    decode: text => ok(flatMapCodecResult(parseJson(text), decodeBookmarkWire))
 }), withCodec(BookmarksJson, {
-    encode: bookmarks => ok(bookmarks.map(bookmarkToWire)),
-    decode: decodeBookmarkWireArray
+    encode: bookmarks => ok(encodeJson(bookmarks.map(bookmarkToWire))),
+    decode: text => ok(flatMapCodecResult(parseJson(text), decodeBookmarkWireArray))
 }), withCodec(AddBookmarkInputJson, {
-    encode: input => ok(input),
-    decode: decodeAddBookmarkInputWire
+    encode: input => ok(encodeJson(input)),
+    decode: text => ok(flatMapCodecResult(parseJson(text), decodeAddBookmarkInputWire))
 }));
 const decodeBookmarkWireArray = (values) => {
     if (!Array.isArray(values))
@@ -31,7 +35,7 @@ const decodeBookmarkWireArray = (values) => {
             return invalidBookmarkJson('invalid bookmark JSON');
         bookmarks.push(bookmark);
     }
-    return ok(bookmarks);
+    return codecOk(bookmarks);
 };
 const bookmarkToWire = (bookmark) => ({
     id: bookmark.id,
@@ -46,7 +50,7 @@ const bookmarkToWire = (bookmark) => ({
 });
 const decodeBookmarkWire = (value) => {
     const bookmark = parseBookmarkWire(value);
-    return bookmark === undefined ? invalidBookmarkJson('invalid bookmark JSON') : ok(bookmark);
+    return bookmark === undefined ? invalidBookmarkJson('invalid bookmark JSON') : codecOk(bookmark);
 };
 const parseBookmarkWire = (value) => {
     if (!isRecord(value))
@@ -79,9 +83,9 @@ const decodeAddBookmarkInputWire = (value) => {
     if (!isRecord(value) || typeof value.url !== 'string')
         return invalidBookmarkJson('invalid add bookmark input JSON');
     if (value.tags === undefined)
-        return ok({ url: value.url });
+        return codecOk({ url: value.url });
     return isStringArray(value.tags)
-        ? ok({ url: value.url, tags: value.tags })
+        ? codecOk({ url: value.url, tags: value.tags })
         : invalidBookmarkJson('invalid add bookmark input JSON');
 };
 const parseDate = (value) => {
@@ -90,7 +94,24 @@ const parseDate = (value) => {
     const date = new Date(value);
     return Number.isNaN(date.getTime()) ? undefined : date;
 };
-const invalidBookmarkJson = (message) => fail(new InvalidBookmarkJson(message));
+const invalidBookmarkJson = (message) => codecFail(new InvalidBookmarkJson(message));
+const encodeJson = (value) => {
+    try {
+        return codecOk(JSON.stringify(value));
+    }
+    catch {
+        return invalidBookmarkJson('invalid bookmark JSON');
+    }
+};
+const parseJson = (text) => {
+    try {
+        return codecOk(JSON.parse(text));
+    }
+    catch {
+        return invalidBookmarkJson('invalid bookmark JSON');
+    }
+};
+const flatMapCodecResult = (result, f) => result.tag === 'ok' ? f(result.value) : result;
 const isMetadataStatus = (value) => isRecord(value) &&
     (value.tag === 'not-requested' ||
         value.tag === 'available' ||

--- a/examples/advanced/bookmarks/browser/assets/src/Abort.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Abort.js
@@ -1,7 +1,9 @@
 import { at } from './Breadcrumb.js';
 import { ScopedEffect, withOrigin } from './Effect.js';
-import { ok } from './Fx.js';
+import { fx, ok } from './Fx.js';
 import { control } from './Handler.js';
+import { withScope } from './Scope.js';
+import { sameScope } from './internal/scopeIdentity.js';
 /**
  * Abort the named scope without returning a result.
  */
@@ -11,4 +13,26 @@ export const abort = (scope) => withOrigin(new Abort(scope, undefined), at('fx/A
 /**
  * Return a default value from an abort of the named scope.
  */
-export const orReturn = (scope, value) => (f) => f.pipe(control(Abort, (_, abort) => (abort.scope === scope ? ok(value) : abort)));
+export const orReturn = (scope, value) => (f) => f.pipe(control(Abort, (_, abort) => (sameScope(abort.scope, scope) ? ok(value) : abort)));
+const Restart = Symbol('fx/Abort/restartOnAbort');
+/**
+ * Restart a scoped computation when it aborts the named scope.
+ */
+export const restartOnAbort = (scope, options) => (f) => fx(function* () {
+    let restarts = 0;
+    let aborted;
+    const attempt = f.pipe(withScope(scope), control(Abort, (_, abort) => {
+        if (!sameScope(abort.scope, scope))
+            return abort;
+        aborted = abort;
+        return ok(Restart);
+    }));
+    while (true) {
+        const result = yield* attempt;
+        if (result !== Restart)
+            return result;
+        if (restarts >= options.restarts)
+            return yield* aborted;
+        restarts += 1;
+    }
+});

--- a/examples/advanced/bookmarks/browser/assets/src/Codec.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Codec.js
@@ -1,5 +1,7 @@
 import { at } from './Breadcrumb.js';
 import { Effect, withOrigin } from './Effect.js';
+import { fail } from './Fail.js';
+import { flatMap, ok } from './Fx.js';
 import { handle } from './Handler.js';
 export const CodecKeyTypeId = Symbol('fx/Codec/key');
 /**
@@ -14,6 +16,8 @@ export const codecKey = () => (id, metadata = {}) => Object.defineProperty({
     writable: false,
     configurable: false
 });
+export const codecOk = (value) => ({ tag: 'ok', value });
+export const codecFail = (error) => ({ tag: 'fail', error });
 /**
  * Request encoding a value with a branded codec key.
  */
@@ -29,9 +33,17 @@ export class Decode extends Effect('fx/Codec/Decode') {
  */
 export const encode = (codec, value) => withOrigin(new Encode({ codec, value }), at('fx/Codec/encode', encode));
 /**
+ * Encode a value and translate codec failure results into Fail.
+ */
+export const encodeOrFail = (codec, value) => encode(codec, value).pipe(flatMap(codecResultOrFail));
+/**
  * Decode an encoded value using the handler associated with the codec key.
  */
 export const decode = (codec, encoded) => withOrigin(new Decode({ codec, encoded }), at('fx/Codec/decode', decode));
+/**
+ * Decode an encoded value and translate codec failure results into Fail.
+ */
+export const decodeOrFail = (codec, encoded) => decode(codec, encoded).pipe(flatMap(codecResultOrFail));
 /**
  * Handle encode requests for the matching codec key.
  */
@@ -48,3 +60,6 @@ export const withDecoder = (codec, decode) => (fx) => fx.pipe(handle(Decode, eff
  * Handle encode and decode requests for the matching codec key.
  */
 export const withCodec = (codec, { encode, decode }) => (fx) => fx.pipe(withEncoder(codec, encode), withDecoder(codec, decode));
+const codecResultOrFail = (result) => result.tag === 'ok'
+    ? ok(result.value)
+    : fail(result.error);

--- a/examples/advanced/bookmarks/browser/assets/src/Concurrent.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Concurrent.js
@@ -101,7 +101,7 @@ export const concurrently = (policy, fxs, options) => {
 export const withCoopConcurrency = (options = {}) => {
     const normalized = normalizeCoopOptions(options, 'withCoopConcurrency');
     const runtime = new CooperativeRuntime(normalized);
-    return (f) => f.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently), handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork));
+    return (f) => withCapturedHandlers('fx/Concurrent/Concurrently', f).pipe(flatMap(fx => withCapturedHandlers('fx/Concurrent/Fork', fx.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently)))), flatMap(fx => ok(fx.pipe(handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)))), flatten);
 };
 /**
  * Retag a structured concurrency request for first-settled race semantics.
@@ -191,13 +191,15 @@ const taskAll = (tasks) => {
 const normalizeCoopOptions = (options, handlerName) => {
     const concurrency = options.concurrency ?? Infinity;
     const yieldBudget = options.yieldBudget ?? 64;
-    if (concurrency <= 0)
-        throw new RangeError(`${handlerName} concurrency must be > 0, got ${concurrency}`);
-    if (yieldBudget <= 0)
-        throw new RangeError(`${handlerName} yieldBudget must be > 0, got ${yieldBudget}`);
+    if (concurrency <= 0 || (concurrency !== Infinity && !Number.isInteger(concurrency))) {
+        throw new RangeError(`${handlerName} concurrency must be a positive integer or Infinity, got ${concurrency}`);
+    }
+    if (yieldBudget <= 0 || !Number.isInteger(yieldBudget)) {
+        throw new RangeError(`${handlerName} yieldBudget must be a positive integer, got ${yieldBudget}`);
+    }
     return {
-        concurrency: Math.floor(concurrency),
-        yieldBudget: Math.floor(yieldBudget)
+        concurrency,
+        yieldBudget
     };
 };
 const taskRace = (tasks) => {

--- a/examples/advanced/bookmarks/browser/assets/src/Concurrent.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Concurrent.js
@@ -6,7 +6,7 @@ import { handleCaptured, mapCapturedHandlers, withCapturedHandlers } from './Han
 import { Task, wait as waitTask } from './Task.js';
 import { captureTrace } from './Trace.js';
 import { Semaphore } from './internal/Semaphore.js';
-import { runCooperativeConcurrently } from './internal/withCoopConcurrency.js';
+import { CooperativeRuntime } from './internal/withCoopConcurrency.js';
 import { acquireAndRunFork } from './internal/runFork.js';
 import { currentRuntimeContext } from './internal/runtimeContext.js';
 /**
@@ -100,7 +100,8 @@ export const concurrently = (policy, fxs, options) => {
  */
 export const withCoopConcurrency = (options = {}) => {
     const normalized = normalizeCoopOptions(options, 'withCoopConcurrency');
-    return (f) => f.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runCooperativeConcurrently(normalized)));
+    const runtime = new CooperativeRuntime(normalized);
+    return (f) => f.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently), handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork));
 };
 /**
  * Retag a structured concurrency request for first-settled race semantics.

--- a/examples/advanced/bookmarks/browser/assets/src/Concurrent.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Concurrent.js
@@ -1,37 +1,30 @@
 import { at, indexed } from './Breadcrumb.js';
 import { Effect } from './Effect.js';
 import { flatMap, flatten, fx, ok } from './Fx.js';
+import { handle } from './Handler.js';
 import { handleCaptured, mapCapturedHandlers, withCapturedHandlers } from './HandlerCapture.js';
 import { Task, wait as waitTask } from './Task.js';
 import { captureTrace } from './Trace.js';
 import { Semaphore } from './internal/Semaphore.js';
+import { runCooperativeConcurrently } from './internal/withCoopConcurrency.js';
 import { acquireAndRunFork } from './internal/runFork.js';
 import { currentRuntimeContext } from './internal/runtimeContext.js';
 /**
  * Request that a computation be started concurrently.
  *
  * A `Fork` request returns a {@link Task} handle. The scheduling policy is
- * supplied by handlers such as {@link bounded} or {@link unbounded}.
+ * supplied by handlers such as {@link withBoundedConcurrency} or {@link withUnboundedConcurrency}.
  */
 export class Fork extends Effect('fx/Concurrent/Fork') {
 }
+export const allPolicy = { tag: 'all' };
+export const firstSettledPolicy = { tag: 'firstSettled' };
+export const firstSuccessPolicy = { tag: 'firstSuccess' };
 /**
- * Request that a group of computations be run concurrently in a structured
- * scope, returning all results directly.
- *
- * The request describes structured concurrency. A handler decides how the
- * children are scheduled and how failures cancel siblings.
+ * Request that a group of computations run concurrently with a structured
+ * settlement policy.
  */
-export class All extends Effect('fx/Concurrent/All') {
-}
-/**
- * Request that a group of computations be raced in a structured scope,
- * returning the first settled result directly.
- *
- * The request describes structured concurrency. A handler decides how the
- * children are scheduled and how losing children are cancelled.
- */
-export class Race extends Effect('fx/Concurrent/Race') {
+export class Concurrently extends Effect('fx/Concurrent/Concurrently') {
 }
 /**
  * Start an Fx concurrently and return a {@link Task} handle.
@@ -68,72 +61,55 @@ export const forkEach = (fxs, options) => fx(function* () {
  * Request that a tuple of Fx computations run concurrently in a structured
  * scope, returning the tuple of child results directly.
  *
- * Pair `all` with {@link defaultAll} and a fork scheduler such as
- * {@link bounded} or {@link unbounded}.
- *
  * @example
  * const [user, posts] = yield* all([fetchUser, fetchPosts])
  */
-export const all = (fxs, options) => {
-    const trace = traceOrigin(options, 'fx/Concurrent/all', all, 'all');
-    return mapCapturedHandlers('fx/Concurrent/All', fxs).pipe(flatMap(fxs => new All({
-        fxs: fxs,
-        ...trace
-    })));
+export const all = (fxs, options) => concurrently(allPolicy, fxs, traceOrigin(options, 'fx/Concurrent/all', all, 'all'));
+/**
+ * Map an iterable to child computations and run them concurrently in input
+ * order.
+ *
+ * @example
+ * const users = yield* mapAll(userIds, id => fetchUser(id))
+ */
+export const mapAll = (items, f, options) => {
+    const trace = traceOrigin(options, 'fx/Concurrent/mapAll', mapAll, 'all');
+    return all(Array.from(items, f), trace);
 };
 /**
  * Request that a tuple of Fx computations race in a structured scope.
  *
- * Pair `race` with {@link firstSettled} for first-settled semantics or
- * {@link firstSuccess} when failed children should be ignored until all fail.
- *
  * @example
  * const value = yield* race([primary, fallback])
  */
-export const race = (fxs, options) => {
-    const trace = traceOrigin(options, 'fx/Concurrent/race', race, 'race');
-    return mapCapturedHandlers('fx/Concurrent/Race', fxs).pipe(flatMap(fxs => new Race({
+export const race = (fxs, options) => concurrently(firstSettledPolicy, fxs, traceOrigin(options, 'fx/Concurrent/race', race, 'race'));
+/**
+ * Request that a group of computations run concurrently with the supplied
+ * built-in policy.
+ */
+export const concurrently = (policy, fxs, options) => {
+    const trace = traceOrigin(options, 'fx/Concurrent/concurrently', concurrently, policyFrameKind(policy));
+    return mapCapturedHandlers('fx/Concurrent/Concurrently', fxs).pipe(flatMap(fxs => new Concurrently({
+        policy,
         fxs: fxs,
         ...trace
     })));
 };
 /**
- * Handle All by running all child computations concurrently in a structured
- * scope. The first child failure fails the parent and cancels siblings.
- *
- * @example
- * await all([fetchUser, fetchPosts]).pipe(
- *   defaultAll,
- *   unbounded,
- *   runPromise
- * )
+ * Provide cooperative concurrency for built-in structured concurrency policies.
  */
-export const defaultAll = (f) => f.pipe(handleCaptured('fx/Concurrent/All', All, runAll));
+export const withCoopConcurrency = (options = {}) => {
+    const normalized = normalizeCoopOptions(options, 'withCoopConcurrency');
+    return (f) => f.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runCooperativeConcurrently(normalized)));
+};
 /**
- * Handle Race by running child computations concurrently in a structured scope.
- * The first child to settle wins and all losers are cancelled.
- *
- * @example
- * await race([primary, fallback]).pipe(
- *   firstSettled,
- *   unbounded,
- *   runPromise
- * )
+ * Retag a structured concurrency request for first-settled race semantics.
  */
-export const firstSettled = (f) => f.pipe(handleCaptured('fx/Concurrent/Race', Race, runRace));
+export const firstSettled = (f) => f.pipe(handle(Concurrently, retagConcurrently(firstSettledPolicy)));
 /**
- * Handle Race by running child computations concurrently and returning the
- * first successful result. Child failures are ignored until every child has
- * failed, at which point the parent fails with {@link RaceAllFailed}.
- *
- * @example
- * await race([primary, replica, cache]).pipe(
- *   firstSuccess,
- *   unbounded,
- *   runPromise
- * )
+ * Retag a structured concurrency request for first-success race semantics.
  */
-export const firstSuccess = (f) => f.pipe(handleCaptured('fx/Concurrent/Race', Race, runFirstSuccessRace));
+export const firstSuccess = (f) => f.pipe(handle(Concurrently, retagConcurrently(firstSuccessPolicy)));
 /**
  * Failure returned by {@link firstSuccess} when every raced child fails.
  */
@@ -159,22 +135,20 @@ export class RaceAllFailed extends Error {
 /**
  * Handle Fork by running at most `maxConcurrency` forked computations at once.
  *
- * Structured handlers such as {@link defaultAll} and {@link firstSettled}
- * elaborate into Fork requests, so `bounded` also limits their child
- * concurrency.
- *
- * @example
- * ```ts
- * program.pipe(defaultAll, bounded(4), runPromise)
- * ```
+ * Structured concurrency policies are interpreted by forking child tasks, so
+ * `withBoundedConcurrency` also limits structured child concurrency.
  */
-export const bounded = (maxConcurrency) => (f) => withCapturedHandlers('fx/Concurrent/Fork', f).pipe(flatMap(fx => ok(fx.pipe(handleCaptured('fx/Concurrent/Fork', Fork, runForkWith(new Semaphore(maxConcurrency)))))), flatten);
+export const withBoundedConcurrency = (maxConcurrency) => (f) => {
+    const semaphore = new Semaphore(maxConcurrency);
+    return withCapturedHandlers('fx/Concurrent/Fork', f).pipe(flatMap(fx => ok(fx.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runConcurrently), handleCaptured('fx/Concurrent/Fork', Fork, runForkWith(semaphore))))), flatten);
+};
 /**
  * Handle Fork by running forked computations without a concurrency limit.
  */
-export const unbounded = bounded(Infinity);
+export const withUnboundedConcurrency = withBoundedConcurrency(Infinity);
 const runForkWith = (s) => (fork) => ok(acquireAndRunFork(fork.arg, s));
 const childFrameKind = (trace) => trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork';
+const policyFrameKind = (policy) => policy.tag === 'all' ? 'all' : 'race';
 const traceOrigin = (options, message, caller, kind) => {
     const origin = options?.origin ?? at(message, caller);
     const trace = options?.trace ?? captureTrace(origin, undefined, { kind });
@@ -184,9 +158,19 @@ const childTraceOrigin = (parent, index, kind) => {
     const origin = indexed(parent.origin, index);
     return { origin, trace: captureTrace(origin, parent.trace, { kind, index }) };
 };
-const runAll = (all) => forkEach(all.arg.fxs, all.arg).pipe(flatMap(tasks => waitTask(taskAll(tasks))));
-const runRace = (race) => forkEach(race.arg.fxs, race.arg).pipe(flatMap(tasks => waitTask(taskRace(tasks))));
-const runFirstSuccessRace = (race) => forkEach(race.arg.fxs, race.arg).pipe(flatMap(tasks => waitTask(taskFirstSuccess(tasks))));
+const runConcurrently = (group) => forkEach(group.arg.fxs, group.arg).pipe(flatMap(tasks => waitTask(taskForPolicy(group.arg.policy, tasks))));
+const retagConcurrently = (policy) => (group) => mapCapturedHandlers('fx/Concurrent/Concurrently', group.arg.fxs).pipe(flatMap(fxs => new Concurrently({
+    ...group.arg,
+    policy,
+    fxs: fxs
+})));
+const taskForPolicy = (policy, tasks) => {
+    switch (policy.tag) {
+        case 'all': return taskAll(tasks);
+        case 'firstSettled': return taskRace(tasks);
+        case 'firstSuccess': return taskFirstSuccess(tasks);
+    }
+};
 const taskAll = (tasks) => {
     tasks.forEach(t => t._markHandled());
     const d = new InterruptAll(tasks);
@@ -202,6 +186,18 @@ const taskAll = (tasks) => {
         throw failure;
     });
     return new Task(p, reason => { void d.interrupt(reason); }, currentRuntimeContext(), d.interrupted);
+};
+const normalizeCoopOptions = (options, handlerName) => {
+    const concurrency = options.concurrency ?? Infinity;
+    const yieldBudget = options.yieldBudget ?? 64;
+    if (concurrency <= 0)
+        throw new RangeError(`${handlerName} concurrency must be > 0, got ${concurrency}`);
+    if (yieldBudget <= 0)
+        throw new RangeError(`${handlerName} yieldBudget must be > 0, got ${yieldBudget}`);
+    return {
+        concurrency: Math.floor(concurrency),
+        yieldBudget: Math.floor(yieldBudget)
+    };
 };
 const taskRace = (tasks) => {
     tasks.forEach(t => t._markHandled());

--- a/examples/advanced/bookmarks/browser/assets/src/Effect.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Effect.js
@@ -46,10 +46,10 @@ export const Effect = (id) => class {
  *
  * @example
  * ```ts
- * class Stop<const Scope extends string>
+ * class Stop<const S extends Scope>
  *   extends ScopedEffect('app/Stop')<Scope, void, never> { }
  *
- * const stop = <const Scope extends string>(scope: Scope) =>
+ * const stop = <const S extends Scope>(scope: S) =>
  *   new Stop(scope, undefined)
  * ```
  */

--- a/examples/advanced/bookmarks/browser/assets/src/Finalization.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Finalization.js
@@ -3,19 +3,31 @@ import { fx } from './Fx.js';
 import { uninterruptible } from './Interrupt.js';
 /**
  * Request that a cleanup operation be run when the named scope exits.
+ *
+ * A `withScope(...)` handler interprets `Finally` requests for its matching scope
+ * and runs registered finalizers when that scope succeeds, fails, returns,
+ * aborts, or is interrupted.
  */
 export class Finally extends ScopedEffect('fx/Finally') {
 }
 /**
  * Register a cleanup operation to run when the named scope exits.
+ *
+ * Use this when the finalizer does not need to inspect the scope exit.
  */
 export const andFinally = (scope, f) => new Finally(scope, () => f);
 /**
  * Register a cleanup operation that receives the named scope's exit.
+ *
+ * Use this when cleanup behavior depends on whether the scope succeeded,
+ * failed, returned, aborted, or was interrupted.
  */
-export const andFinallyExit = (scope, f) => new Finally(scope, exit => f(exit));
+export const andFinallyExit = (scope, f) => new Finally(scope, f);
 /**
  * Run an initial operation, register cleanup for its result, and return it.
+ *
+ * Acquisition and finalizer registration happen in an uninterruptible region so
+ * an acquired resource is not left without cleanup.
  */
 export const using = (scope, initially, finally_) => uninterruptible(fx(function* () {
     const r = yield* initially;
@@ -30,7 +42,11 @@ export const managed = (value, finalizer) => ({
     finalizer
 });
 /**
- * Run an initial operation that returns a managed value, register its cleanup, and return its value.
+ * Run an initial operation that returns a managed value, register its cleanup,
+ * and return its value.
+ *
+ * Use this when acquisition naturally returns the value and its finalizer
+ * together.
  */
 export const usingManaged = (scope, initially) => uninterruptible(fx(function* () {
     const m = yield* initially;

--- a/examples/advanced/bookmarks/browser/assets/src/Handler.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Handler.js
@@ -1,4 +1,5 @@
 import { Control, Handler } from './internal/Handler.js';
+import { sameScope } from './internal/scopeIdentity.js';
 /**
  * Handle effects of the given type.
  *
@@ -28,21 +29,21 @@ export const handle = (e, f) => (fx) => new Handler(fx, e._fxEffectId, f);
  *
  * @example
  * ```ts
- * class Ask<const Scope extends string>
+ * class Ask<const S extends Scope>
  *   extends ScopedEffect('app/Ask')<Scope, void, string> { }
  *
  * const program = fx(function* () {
- *   return yield* new Ask('user', undefined)
+ *   return yield* new Ask(UserScope, undefined)
  * })
  *
  * const result = program.pipe(
- *   handleScoped(Ask, 'user', () => ok('Ada')),
+ *   handleScoped(Ask, UserScope, () => ok('Ada')),
  *   run
  * )
  * ```
  */
 export const handleScoped = (e, scope, f) => (fx) => new Handler(fx, e._fxEffectId, effect => {
-    if (effect.scope === scope) {
+    if (sameScope(effect.scope, scope)) {
         return f(effect);
     }
     return effect;

--- a/examples/advanced/bookmarks/browser/assets/src/InterruptFrom.js
+++ b/examples/advanced/bookmarks/browser/assets/src/InterruptFrom.js
@@ -1,0 +1,22 @@
+import { at } from './Breadcrumb.js';
+import { ScopedEffect, withOrigin } from './Effect.js';
+import { control } from './Handler.js';
+import { sameScope } from './internal/scopeIdentity.js';
+/**
+ * Interrupt the named scope.
+ */
+export class InterruptFrom extends ScopedEffect('fx/InterruptFrom') {
+}
+export function interruptFrom(scope, reason) {
+    return withOrigin(new InterruptFrom(scope, reason), at('fx/InterruptFrom/interruptFrom', interruptFrom));
+}
+/**
+ * Recover from interruption of the named scope.
+ *
+ * The handler runs when an {@link InterruptFrom} for the matching scope reaches
+ * this boundary. It does not resume the interrupted computation. Interruptions
+ * from other scopes are left visible for another handler.
+ */
+export const recoverInterrupt = (scope, handler) => (f) => f.pipe(control(InterruptFrom, (_, interrupt) => (sameScope(interrupt.scope, scope)
+    ? handler(interrupt.arg)
+    : interrupt)));

--- a/examples/advanced/bookmarks/browser/assets/src/Scope.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Scope.js
@@ -4,67 +4,101 @@ import { Fail, fail, returnFail } from './Fail.js';
 import { Finally } from './Finalization.js';
 import { fx } from './Fx.js';
 import { HandlerCapture } from './HandlerCapture.js';
+import { InterruptFrom } from './InterruptFrom.js';
 import { ReturnFrom } from './ReturnFrom.js';
 import { drainIteratorReturn, isInterpretingReturn } from './internal/iteratorClose.js';
 import { pipeThis } from './internal/pipe.js';
-import { withActiveScope } from './internal/runtimeContext.js';
-export const brand = () => (name) => name;
-export function scope(name) {
-    return (f) => new ScopeBoundary(f, name);
+import { interruptionReason, withActiveScope } from './internal/runtimeContext.js';
+import { ScopeTypeId, sameScope } from './internal/scopeIdentity.js';
+export { ScopeTypeId, sameScope };
+export function scope(name, metadata = {}) {
+    if (name === undefined)
+        return scope;
+    const token = {
+        ...metadata,
+        name
+    };
+    Object.defineProperty(token, ScopeTypeId, {
+        value: name,
+        enumerable: false,
+        writable: false,
+        configurable: false
+    });
+    return token;
+}
+export const scopeLabel = (scope) => scope.label ?? scope.name;
+const scopeDiagnostic = (scope) => {
+    return {
+        id: scope[ScopeTypeId],
+        label: scopeLabel(scope),
+        description: scope.description
+    };
+};
+export function withScope(scope) {
+    return (f) => new ScopeBoundary(f, scope);
 }
 class ScopeBoundary {
     fx;
-    scopeName;
+    scope;
     pipe = pipeThis;
-    constructor(fx, scopeName) {
+    constructor(fx, scope) {
         this.fx = fx;
-        this.scopeName = scopeName;
+        this.scope = scope;
     }
     wrap(fx) {
-        return new ScopeBoundary(fx, this.scopeName);
+        return new ScopeBoundary(fx, this.scope);
     }
     *[Symbol.iterator]() {
         const finalizers = [];
-        const { scopeName } = this;
-        const i = withActiveScope(scopeName, this.fx)[Symbol.iterator]();
+        const { scope } = this;
+        const activeScope = scopeDiagnostic(scope);
+        const i = withActiveScope(activeScope, this.fx)[Symbol.iterator]();
         const captured = {
-            wrap: fx => new ScopeBoundary(fx, scopeName)
+            wrap: fx => new ScopeBoundary(fx, scope)
         };
         let released = false;
         const release = function* (exit) {
             if (released)
                 return [];
             released = true;
-            return yield* withActiveScope(scopeName, releaseSafely(finalizers, exit));
+            return yield* withActiveScope(activeScope, releaseSafely(finalizers, exit));
         };
         const step = function* (ir) {
             while (!ir.done) {
                 if (isEffect(ir.value)) {
                     const effect = ir.value;
-                    const sameScope = effect.scope === scopeName;
-                    if (sameScope && Finally.is(effect)) {
+                    const effectScope = effect.scope;
+                    const matchesScope = effectScope !== undefined && sameScope(effectScope, scope);
+                    if (matchesScope && Finally.is(effect)) {
                         finalizers.push(effect.arg);
                         ir = i.next(undefined);
                     }
-                    else if (sameScope && ReturnFrom.is(effect)) {
-                        const exit = { type: 'returnFrom', scope: scopeName, value: effect.arg };
+                    else if (matchesScope && ReturnFrom.is(effect)) {
+                        const exit = { type: 'returnFrom', scope, value: effect.arg };
                         const failures = yield* release(exit);
                         if (failures.length > 0)
-                            return (yield* withActiveScope(scopeName, failCleanup(failures)));
+                            return (yield* withActiveScope(activeScope, failCleanup(failures)));
                         return effect.arg;
                     }
-                    else if (sameScope && Abort.is(effect)) {
-                        const exit = { type: 'abort', scope: scopeName };
+                    else if (matchesScope && Abort.is(effect)) {
+                        const exit = { type: 'abort', scope };
                         const failures = yield* release(exit);
                         if (failures.length > 0)
-                            return (yield* withActiveScope(scopeName, failCleanup(failures)));
+                            return (yield* withActiveScope(activeScope, failCleanup(failures)));
+                        return (yield effect);
+                    }
+                    else if (matchesScope && InterruptFrom.is(effect)) {
+                        const exit = interruptedExit(scope, effect.arg);
+                        const failures = yield* release(exit);
+                        if (failures.length > 0)
+                            return (yield* withActiveScope(activeScope, failCleanup(failures)));
                         return (yield effect);
                     }
                     else if (Fail.is(effect)) {
                         const exit = { type: 'failure', failure: effect };
                         const failures = yield* release(exit);
                         if (failures.length > 0)
-                            return (yield* withActiveScope(scopeName, failCleanup([effect.arg, ...failures])));
+                            return (yield* withActiveScope(activeScope, failCleanup([effect.arg, ...failures])));
                         return (yield effect);
                     }
                     else if (HandlerCapture.is(effect)) {
@@ -81,7 +115,7 @@ class ScopeBoundary {
             const exit = { type: 'success', value: ir.value };
             const failures = yield* release(exit);
             if (failures.length > 0)
-                return (yield* withActiveScope(scopeName, failCleanup(failures)));
+                return (yield* withActiveScope(activeScope, failCleanup(failures)));
             return ir.value;
         };
         let completed = false;
@@ -91,15 +125,15 @@ class ScopeBoundary {
             return value;
         }
         finally {
-            const cleanupFailures = yield* collectInterruptedCleanupFailures(scopeName, release, completed, isInterpretingReturn(), i, step);
+            const cleanupFailures = yield* collectInterruptedCleanupFailures(scope, release, completed, isInterpretingReturn(), i, step);
             if (cleanupFailures.length > 0)
-                yield* withActiveScope(scopeName, failCleanup(cleanupFailures));
+                yield* withActiveScope(activeScope, failCleanup(cleanupFailures));
         }
     }
 }
-const collectInterruptedCleanupFailures = function* (scopeName, release, completed, shouldDrainReturn, iterator, step) {
+const collectInterruptedCleanupFailures = function* (scope, release, completed, shouldDrainReturn, iterator, step) {
     const failures = [];
-    const exit = { type: 'interrupted', scope: scopeName };
+    const exit = interruptedExit(scope, interruptionReason());
     yield* collectCleanupFailures(failures, function* () {
         failures.push(...yield* release(exit));
     });
@@ -114,6 +148,9 @@ const collectInterruptedCleanupFailures = function* (scopeName, release, complet
     }
     return failures;
 };
+const interruptedExit = (scope, reason) => reason === undefined
+    ? { type: 'interrupted', scope }
+    : { type: 'interrupted', scope, reason };
 const collectCleanupFailures = function* (failures, cleanup) {
     try {
         yield* cleanup();

--- a/examples/advanced/bookmarks/browser/assets/src/Trace.js
+++ b/examples/advanced/bookmarks/browser/assets/src/Trace.js
@@ -291,9 +291,10 @@ const formatActiveScopes = (scopes, context) => {
     if (scopes === undefined || scopes.length === 0)
         return [];
     const label = context?.style.section('Active scopes') ?? 'Active scopes';
-    return [`${label}: ${compactActiveScopes(scopes).join(' > ')}`];
+    return [`${label}: ${compactActiveScopes(scopes).map(formatActiveScopeLabel).join(' > ')}`];
 };
 const compactActiveScopes = (scopes) => scopes.length <= 4 ? scopes : [scopes[0], '...', ...scopes.slice(-3)];
+const formatActiveScopeLabel = (scope) => scope === '...' ? '...' : scope.label;
 const formatContext = (options) => ({
     style: colorEnabled(options?.colors ?? 'auto') ? ansiStyle : plainStyle,
     ...(options?.source === undefined || options.source === false
@@ -336,6 +337,24 @@ const formatDiagnosticActiveScopes = (scopes, lines, indent, context) => {
         return;
     const prefix = ' '.repeat(indent);
     lines.push(`${prefix}${formatted[0]}`);
+    formatDiagnosticActiveScopeDetails(scopes, lines, indent, context);
+};
+const formatDiagnosticActiveScopeDetails = (scopes, lines, indent, context) => {
+    if (scopes === undefined || scopes.length === 0)
+        return;
+    const compacted = compactActiveScopes(scopes);
+    if (!compacted.some(scope => scope !== '...' && scope.description !== undefined))
+        return;
+    const prefix = ' '.repeat(indent);
+    lines.push(`${prefix}${context.style.section('Active scope details:')}`);
+    for (const scope of compacted) {
+        if (scope === '...') {
+            lines.push(`${prefix}  ...`);
+        }
+        else if (scope.description !== undefined) {
+            lines.push(`${prefix}  ${scope.label}: ${scope.description}`);
+        }
+    }
 };
 const formatDiagnosticHeader = (error, context) => {
     const code = error.code === undefined ? '' : ` ${context.style.code(`[${error.code}]`)}`;

--- a/examples/advanced/bookmarks/browser/assets/src/exports/index.js
+++ b/examples/advanced/bookmarks/browser/assets/src/exports/index.js
@@ -1,6 +1,7 @@
 export { Effect, EffectOriginTypeId, EffectTypeId, isEffect, originOf, ScopedEffect, traceOriginOf, withOrigin, withTraceOrigin } from '../Effect.js';
 export { andReturn, andThen, assertSync, bracket, flatMap, flatten, fx, map, ok, run, runPromise, runTask, tap, trySync, unit } from '../Fx.js';
 export { control, handle, handleScoped } from '../Handler.js';
+export { HandlerCapture } from '../HandlerCapture.js';
 export { assert, catchAll, catchIf, catchOnly, fail, failFrom, Fail, returnAll, returnFail, returnIf, returnOnly } from '../Fail.js';
 export { assertPromise, Async, tryPromise } from '../Async.js';
 export { defaultConsole, error as consoleError, Error as ConsoleError, log as consoleLog, Log as ConsoleLog } from '../Console.js';

--- a/examples/advanced/bookmarks/browser/assets/src/internal/forkDiagnostics.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/forkDiagnostics.js
@@ -1,0 +1,50 @@
+import { attachTrace, captureAppendTrace, capturePrependTrace, captureTrace } from '../Trace.js';
+import { getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext } from './runtimeContext.js';
+export class ForkError extends Error {
+    code;
+    constructor(code, message, origin, trace, runtimeContext, options) {
+        super(message, options);
+        this.code = code;
+        if (traceCapturePolicy(runtimeContext) === 'full' && 'stack' in origin)
+            Object.defineProperty(this, 'stack', { get: () => origin.stack });
+        Object.defineProperty(this, 'code', {
+            value: code,
+            enumerable: false,
+            writable: false,
+            configurable: true
+        });
+        if (trace !== undefined)
+            attachTrace(this, trace);
+    }
+}
+export const runtimeContextOfEffect = (effect, fallback) => getRuntimeContext(effect) ?? fallback;
+export const traceWithCause = (trace, cause, runtimeContext, causeTrace) => captureAppendTraceWithContext(runtimeContext, causeTrace ?? trace, causeTrace === undefined ? undefined : trace);
+export const traceUnhandledFail = (fail, causeTrace, parentTrace, runtimeContext) => {
+    if (causeTrace !== undefined)
+        return captureAppendTraceWithContext(runtimeContext, causeTrace, parentTrace);
+    if (fail.trace === undefined)
+        return captureAppendTraceWithContext(runtimeContext, undefined, parentTrace);
+    return parentTrace === undefined
+        ? fail.trace
+        : captureAppendTraceWithContext(runtimeContext, fail.trace, parentTrace) ?? fail.trace;
+};
+export const originOfUnhandledFail = (fail, causeTrace) => causeTrace === undefined ? fail.origin : originFromTrace(causeTrace);
+export const forkFrameMetadata = (trace) => ({
+    kind: trace?.frame.kind ?? 'fork',
+    index: trace?.frame.index
+});
+export const captureTraceWithContext = (context, origin, parent, metadata) => context === undefined
+    ? captureTrace(origin, parent, metadata)
+    : withActiveRuntimeContext(context, () => captureTrace(origin, parent, metadata));
+export const capturePrependTraceWithContext = (context, origin, parent, metadata) => context === undefined
+    ? capturePrependTrace(origin, parent, metadata)
+    : withActiveRuntimeContext(context, () => capturePrependTrace(origin, parent, metadata));
+export const captureAppendTraceWithContext = (context, trace, parent) => context === undefined
+    ? captureAppendTrace(trace, parent)
+    : withActiveRuntimeContext(context, () => captureAppendTrace(trace, parent));
+export const originFromTrace = (trace) => ({
+    message: trace.frame.message,
+    get stack() {
+        return trace.frame.stackSource?.stack;
+    }
+});

--- a/examples/advanced/bookmarks/browser/assets/src/internal/runFork.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/runFork.js
@@ -4,12 +4,13 @@ import { Fail } from '../Fail.js';
 import { Fork } from '../Concurrent.js';
 import { HandlerCapture, withHandlerContext } from '../HandlerCapture.js';
 import { Task } from '../Task.js';
-import { attachTrace, captureAppendTrace, capturePrependTrace, captureTrace, getTrace } from '../Trace.js';
+import { getTrace } from '../Trace.js';
 import { Semaphore } from './Semaphore.js';
 import { DisposableSet } from './disposable.js';
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, forkFrameMetadata, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js';
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js';
 import { withInterpretedReturn } from './iteratorClose.js';
-import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js';
+import { currentRuntimeContext, getRuntimeContext, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js';
 export const runFork = (f, options = {}) => {
     const disposables = new InterruptState();
     const disposed = Promise.withResolvers();
@@ -64,7 +65,7 @@ const runForkLoop = async (f, context, semaphore, disposables, disposed, origin,
             throw e;
         }
         const errorContext = getRuntimeContext(e) ?? runtimeContext;
-        const error = new ForkError('FX_UNHANDLED_EXCEPTION', `Unhandled exception in forked task`, origin, traceWithCause(trace, e, errorContext), errorContext, { cause: e });
+        const error = new ForkError('FX_UNHANDLED_EXCEPTION', `Unhandled exception in forked task`, origin, traceWithCause(trace, e, errorContext, getTrace(e)), errorContext, { cause: e });
         if (disposables.interruptRequested)
             disposed.reject(error);
         throw error;
@@ -104,7 +105,7 @@ const runIterator = async (ir, i, context, semaphore, disposables, origin, trace
                 if (disposables.canInterrupt && interrupt !== undefined)
                     return await disposables.interruptNow(interrupt);
                 const asyncTrace = capturePrependTraceWithContext(effectContext, origin, trace, { kind: 'async' });
-                throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext), effectContext, { cause: e });
+                throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext, getTrace(e)), effectContext, { cause: e });
             }
             // stop if the scope was interrupted while we were waiting
             if (disposables.canInterrupt && interrupt !== undefined)
@@ -123,7 +124,7 @@ const runIterator = async (ir, i, context, semaphore, disposables, origin, trace
                 queueMicrotask(() => {
                     if (t._handled || t._interrupted || disposables.interruptRequested)
                         return;
-                    rejectUnhandled(new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext), effectContext, { cause: e }));
+                    rejectUnhandled(new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext, getTrace(e)), effectContext, { cause: e }));
                 });
             });
             ir = resumeWithRuntimeContext(i, effectContext, t);
@@ -151,7 +152,7 @@ const runIterator = async (ir, i, context, semaphore, disposables, origin, trace
         }
         else {
             const effectContext = runtimeContextOfEffect(ir.value, runtimeContext);
-            throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, origin, traceWithCause(trace, ir.value, effectContext), effectContext, { cause: ir.value });
+            throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, origin, traceWithCause(trace, ir.value, effectContext, getTrace(ir.value)), effectContext, { cause: ir.value });
         }
     }
     return ir.value;
@@ -223,23 +224,6 @@ class InterruptState {
     interruptActiveTasks() {
         for (const task of this.tasks)
             void task.interrupt(this.reason).catch(() => { });
-    }
-}
-class ForkError extends Error {
-    code;
-    constructor(code, message, origin, trace, runtimeContext, options) {
-        super(message, options);
-        this.code = code;
-        if (traceCapturePolicy(runtimeContext) === 'full' && 'stack' in origin)
-            Object.defineProperty(this, 'stack', { get: () => origin.stack });
-        Object.defineProperty(this, 'code', {
-            value: code,
-            enumerable: false,
-            writable: false,
-            configurable: true
-        });
-        if (trace !== undefined)
-            attachTrace(this, trace);
     }
 }
 class UnhandledForkError extends Error {
@@ -317,40 +301,6 @@ const returnWithRuntimeContext = (iterator, runtimeContext) => runtimeContext ==
     ? withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined })
     : withActiveRuntimeContext(runtimeContext, () => withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined }));
 const never = () => new Promise(() => { });
-const traceWithCause = (trace, cause, runtimeContext) => {
-    const causeTrace = getTrace(cause);
-    return captureAppendTraceWithContext(runtimeContext, causeTrace ?? trace, causeTrace === undefined ? undefined : trace);
-};
-const runtimeContextOfEffect = (effect, fallback) => getRuntimeContext(effect) ?? fallback;
-const traceUnhandledFail = (fail, causeTrace, parentTrace, runtimeContext) => {
-    if (causeTrace !== undefined)
-        return captureAppendTraceWithContext(runtimeContext, causeTrace, parentTrace);
-    if (fail.trace === undefined)
-        return captureAppendTraceWithContext(runtimeContext, undefined, parentTrace);
-    return parentTrace === undefined
-        ? fail.trace
-        : captureAppendTraceWithContext(runtimeContext, fail.trace, parentTrace) ?? fail.trace;
-};
-const originOfUnhandledFail = (fail, causeTrace) => causeTrace === undefined ? fail.origin : originFromTrace(causeTrace);
-const forkFrameMetadata = (trace) => ({
-    kind: trace?.frame.kind ?? 'fork',
-    index: trace?.frame.index
-});
-const captureTraceWithContext = (context, origin, parent, metadata) => context === undefined
-    ? captureTrace(origin, parent, metadata)
-    : withActiveRuntimeContext(context, () => captureTrace(origin, parent, metadata));
-const capturePrependTraceWithContext = (context, origin, parent, metadata) => context === undefined
-    ? capturePrependTrace(origin, parent, metadata)
-    : withActiveRuntimeContext(context, () => capturePrependTrace(origin, parent, metadata));
-const captureAppendTraceWithContext = (context, trace, parent) => context === undefined
-    ? captureAppendTrace(trace, parent)
-    : withActiveRuntimeContext(context, () => captureAppendTrace(trace, parent));
-const originFromTrace = (trace) => ({
-    message: trace.frame.message,
-    get stack() {
-        return trace.frame.stackSource?.stack;
-    }
-});
 class DisposableAbortController extends AbortController {
     [Symbol.dispose]() { this.abort(); }
 }

--- a/examples/advanced/bookmarks/browser/assets/src/internal/runtimeContext.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/runtimeContext.js
@@ -45,7 +45,10 @@ export const interruptionReason = (context = activeRuntimeContext) => context?.i
 export const withInterruptionReason = (context, reason) => reason === undefined ? context : { ...context, interruptionReason: reason };
 export const withActiveScope = (scope, fx) => {
     const scopes = activeScopes();
-    const nextScopes = scopes.at(-1) === scope ? scopes : [...scopes, scope];
+    const previousScope = scopes.at(-1);
+    const nextScopes = previousScope?.id === scope.id
+        ? scopes
+        : [...scopes, scope];
     return withRuntimeContext({ activeScopes: nextScopes }, fx);
 };
 const mergeRuntimeContext = (previous, next) => ({

--- a/examples/advanced/bookmarks/browser/assets/src/internal/scopeIdentity.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/scopeIdentity.js
@@ -1,0 +1,2 @@
+export const ScopeTypeId = Symbol('fx/Scope');
+export const sameScope = (a, b) => a[ScopeTypeId] === b[ScopeTypeId];

--- a/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
@@ -1,8 +1,9 @@
 import { Async } from '../Async.js';
 import { at, indexed } from '../Breadcrumb.js';
-import { Concurrently, Fork, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js';
+import { Concurrently, Fork, RaceAllFailed } from '../Concurrent.js';
 import { Fail, fail } from '../Fail.js';
 import { fx, runPromise } from '../Fx.js';
+import { HandlerCapture, handleCaptured } from '../HandlerCapture.js';
 import { Task } from '../Task.js';
 import { captureTrace, getTrace } from '../Trace.js';
 import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, forkFrameMetadata, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js';
@@ -18,6 +19,7 @@ export class CooperativeRuntime {
         this.availableSlots = Math.floor(config.concurrency);
     }
     runConcurrently = (group) => cooperativeGroupFx(this, group, groupPolicy(group.arg.policy));
+    runNestedConcurrently = (group, parent) => cooperativeGroupFx(this, group, groupPolicy(group.arg.policy), parent);
     runFork = (fork) => fx(function* () {
         return this.startFork(fork);
     }.bind(this));
@@ -35,7 +37,8 @@ export class CooperativeRuntime {
             status: 'ready',
             resume: { type: 'next', value: undefined },
             cancelRequested: false,
-            cleanupFailures: []
+            cleanupFailures: [],
+            releaseSlotBeforeResume: false
         };
         const done = Promise.withResolvers();
         const interrupted = Promise.withResolvers();
@@ -85,7 +88,7 @@ export class CooperativeRuntime {
                     continue;
                 }
                 if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-                    await runPromise(fx(function* () { yield* closeFiber(fiber); }));
+                    await runPromise(fx(function* () { yield* closeFiber(this, fiber); }.bind(this)));
                     finishDetachedFiber(this, fiber);
                     if (fiber.cleanupFailures.length > 0)
                         done.reject(resourceReleaseFailed(fiber.cleanupFailures));
@@ -147,7 +150,7 @@ export class CooperativeRuntime {
             waiter();
     }
 }
-const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
+const cooperativeGroupFx = (runtime, group, policy, borrowedSlotFrom) => fx(function* () {
     const fxs = group.arg.fxs;
     const fibers = [];
     const ready = [];
@@ -177,9 +180,14 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
                 status: 'ready',
                 resume: { type: 'next', value: undefined },
                 cancelRequested: false,
-                cleanupFailures: []
+                cleanupFailures: [],
+                releaseSlotBeforeResume: false
             };
-            if (!runtime.tryAcquireSlot(fiber))
+            if (borrowedSlotFrom?.slotAcquired) {
+                borrowedSlotFrom.slotAcquired = false;
+                fiber.slotAcquired = true;
+            }
+            else if (!runtime.tryAcquireSlot(fiber))
                 break;
             next++;
             active++;
@@ -201,7 +209,7 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
         if (decision.type === 'continue')
             return;
         outcome ??= decision;
-        if (decision.cancelRest)
+        if (decision.type !== 'pending' && decision.cancelRest)
             cancelActiveFibers(fibers);
     };
     const succeedFiber = (fiber, value) => {
@@ -235,7 +243,7 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
             if (fiber.status !== 'ready')
                 continue;
             if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-                yield* closeFiber(fiber);
+                yield* closeFiber(runtime, fiber);
                 finish(fiber);
                 continue;
             }
@@ -252,7 +260,7 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
             cancelActiveFibers(fibers);
             for (const fiber of fibers) {
                 if (fiber.status !== 'done') {
-                    yield* closeFiber(fiber);
+                    yield* closeFiber(runtime, fiber);
                     finish(fiber);
                 }
             }
@@ -263,6 +271,8 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
                     : cleanupFailures;
                 return (yield* fail(resourceReleaseFailed(failures)));
             }
+            if (outcome.type === 'pending')
+                return yield* waitForInterruption();
             if (outcome.type === 'fail')
                 return (yield* fail(outcome.error));
             return outcome.value;
@@ -274,7 +284,7 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
             cancelActiveFibers(fibers);
             for (const fiber of fibers) {
                 if (fiber.status !== 'done') {
-                    yield* closeFiber(fiber);
+                    yield* closeFiber(runtime, fiber);
                     finish(fiber);
                 }
             }
@@ -290,13 +300,11 @@ const emptyOutcome = (policy, state, size) => {
 const groupKind = (group) => group.arg.policy.tag === 'all' ? 'all' : 'race';
 const childFrameKind = (trace) => trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork';
 const groupPolicy = (policy) => {
-    if (policy === allPolicy)
-        return allGroupPolicy;
-    if (policy === firstSettledPolicy)
-        return raceGroupPolicy;
-    if (policy === firstSuccessPolicy)
-        return firstSuccessGroupPolicy;
-    throw new TypeError('Unknown concurrency policy');
+    switch (policy.tag) {
+        case 'all': return allGroupPolicy;
+        case 'firstSettled': return raceGroupPolicy;
+        case 'firstSuccess': return firstSuccessGroupPolicy;
+    }
 };
 const allGroupPolicy = {
     init: size => ({ results: sparseArray(size), completed: 0 }),
@@ -312,6 +320,7 @@ const allGroupPolicy = {
 };
 const raceGroupPolicy = {
     init: () => undefined,
+    onEmpty: state => ({ type: 'pending', state }),
     onSuccess: (_state, _index, value) => ({ type: 'succeed', state: undefined, value, cancelRest: true }),
     onFailure: (_state, _index, error) => ({ type: 'fail', state: undefined, error, cancelRest: true })
 };
@@ -373,6 +382,10 @@ function* stepFiber(runtime, fiber, wake, callbacks) {
     while (budget > 0 && fiber.status === 'ready') {
         budget--;
         let ir;
+        const releaseSlotBeforeResume = fiber.releaseSlotBeforeResume && fiber.slotAcquired;
+        fiber.releaseSlotBeforeResume = false;
+        if (releaseSlotBeforeResume)
+            runtime.releaseSlot(fiber);
         try {
             ir = fiber.resume.type === 'throw'
                 ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
@@ -381,6 +394,10 @@ function* stepFiber(runtime, fiber, wake, callbacks) {
         catch (e) {
             callbacks.fail(wrapThrownFiberError(fiber, e));
             break;
+        }
+        finally {
+            if (releaseSlotBeforeResume)
+                yield* reacquireSlot(runtime, fiber);
         }
         fiber.resume = { type: 'next', value: undefined };
         if (ir.done) {
@@ -394,7 +411,12 @@ function* stepFiber(runtime, fiber, wake, callbacks) {
             break;
         }
         if (Concurrently.is(ir.value)) {
-            fiber.resume = { type: 'next', value: yield* runtime.runConcurrently(ir.value) };
+            try {
+                fiber.resume = { type: 'next', value: yield* runtime.runNestedConcurrently(ir.value, fiber) };
+            }
+            finally {
+                yield* reacquireSlot(runtime, fiber);
+            }
             continue;
         }
         if (Fork.is(ir.value)) {
@@ -421,17 +443,28 @@ function* stepFiber(runtime, fiber, wake, callbacks) {
         if (InterruptMaskEnd.is(ir.value)) {
             fiber.masks.unmask(ir.value.arg);
             if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-                yield* closeFiber(fiber);
+                yield* closeFiber(runtime, fiber);
                 callbacks.cancel?.();
                 break;
             }
             fiber.resume = { type: 'next', value: undefined };
             continue;
         }
+        if (HandlerCapture.is(ir.value)) {
+            fiber.resume = { type: 'next', value: yield ir.value };
+            fiber.releaseSlotBeforeResume = true;
+            continue;
+        }
         fiber.resume = { type: 'next', value: yield ir.value };
     }
 }
-function* closeFiber(fiber) {
+function* reacquireSlot(runtime, fiber) {
+    if (fiber.status === 'done')
+        return;
+    while (!runtime.tryAcquireSlot(fiber))
+        yield* runtime.waitForSlot();
+}
+function* closeFiber(runtime, fiber) {
     fiber.abort?.abort();
     fiber.abort = undefined;
     let ir;
@@ -447,6 +480,17 @@ function* closeFiber(fiber) {
             if (Async.is(ir.value)) {
                 ir = fiber.iterator.next(yield ir.value);
             }
+            else if (Concurrently.is(ir.value)) {
+                try {
+                    ir = fiber.iterator.next(yield* runtime.runNestedConcurrently(ir.value, fiber));
+                }
+                finally {
+                    yield* reacquireSlot(runtime, fiber);
+                }
+            }
+            else if (Fork.is(ir.value)) {
+                ir = fiber.iterator.next(runtime.startFork(ir.value));
+            }
             else if (Fail.is(ir.value)) {
                 fiber.cleanupFailures.push(ir.value.arg);
                 return;
@@ -459,8 +503,20 @@ function* closeFiber(fiber) {
                 fiber.masks.unmask(ir.value.arg);
                 ir = fiber.iterator.next();
             }
+            else if (HandlerCapture.is(ir.value)) {
+                const releaseSlotBeforeResume = fiber.slotAcquired;
+                if (releaseSlotBeforeResume)
+                    runtime.releaseSlot(fiber);
+                try {
+                    ir = fiber.iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value));
+                }
+                finally {
+                    if (releaseSlotBeforeResume)
+                        yield* reacquireSlot(runtime, fiber);
+                }
+            }
             else {
-                ir = fiber.iterator.next(yield ir.value);
+                ir = fiber.iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value));
             }
         }
         catch (e) {
@@ -469,6 +525,9 @@ function* closeFiber(fiber) {
         }
     }
 }
+const runCleanupEffect = (runtime, fiber, effect) => fx(function* () {
+    return yield effect;
+}).pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, group => runtime.runNestedConcurrently(group, fiber)), handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork));
 const finishDetachedFiber = (runtime, fiber) => {
     if (fiber.status === 'done')
         return;
@@ -544,5 +603,12 @@ const AsyncWait = (waiters) => new Async({
     }),
     origin: at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait),
     trace: captureTrace(at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait), undefined, { kind: 'async' })
+});
+const waitForInterruption = () => new Async({
+    run: signal => new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }),
+    origin: at('fx/Concurrent/withCoopConcurrency/pending', waitForInterruption),
+    trace: captureTrace(at('fx/Concurrent/withCoopConcurrency/pending', waitForInterruption), undefined, { kind: 'async' })
 });
 const resourceReleaseFailed = (failures) => new AggregateError(failures, 'Resource release failed');

--- a/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
@@ -1,0 +1,349 @@
+import { Async } from '../Async.js';
+import { at, indexed } from '../Breadcrumb.js';
+import { Concurrently, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js';
+import { Fail, fail } from '../Fail.js';
+import { fx } from '../Fx.js';
+import { captureTrace, getTrace } from '../Trace.js';
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js';
+import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js';
+import { withInterpretedReturn } from './iteratorClose.js';
+import { getRuntimeContext, withActiveRuntimeContext } from './runtimeContext.js';
+export const runCooperativeConcurrently = (config) => (group) => cooperativeGroupFx(group, config, groupPolicy(group.arg.policy));
+const cooperativeGroupFx = (group, config, policy) => fx(function* () {
+    const fxs = group.arg.fxs;
+    const fibers = [];
+    const ready = [];
+    const wake = new Wake();
+    const context = getRuntimeContext(group);
+    const parentTraceOrigin = {
+        origin: group.arg.origin,
+        trace: group.arg.trace ?? captureTraceWithContext(context, group.arg.origin, undefined, { kind: groupKind(group) })
+    };
+    const childKind = childFrameKind(parentTraceOrigin.trace);
+    let state = policy.init(fxs.length);
+    let next = 0;
+    let active = 0;
+    let done = 0;
+    let completed = false;
+    let outcome = emptyOutcome(policy, state, fxs.length);
+    const startNext = () => {
+        while (outcome === undefined && active < config.concurrency && next < fxs.length) {
+            const fiber = {
+                index: next,
+                iterator: fxs[next][Symbol.iterator](),
+                traceOrigin: childTraceOriginWithContext(context, parentTraceOrigin, next, childKind),
+                masks: new InterruptMaskState(),
+                status: 'ready',
+                resume: { type: 'next', value: undefined },
+                cancelRequested: false,
+                cleanupFailures: []
+            };
+            next++;
+            active++;
+            fibers.push(fiber);
+            ready.push(fiber);
+        }
+    };
+    const finish = (fiber) => {
+        if (fiber.status === 'done')
+            return;
+        fiber.status = 'done';
+        fiber.abort?.abort();
+        active--;
+        done++;
+    };
+    const settle = (decision) => {
+        state = decision.state;
+        if (decision.type === 'continue')
+            return;
+        outcome ??= decision;
+        if (decision.cancelRest)
+            cancelActiveFibers(fibers);
+    };
+    const succeedFiber = (fiber, value) => {
+        finish(fiber);
+        settle(policy.onSuccess(state, fiber.index, value));
+    };
+    const failFiber = (fiber, failure) => {
+        finish(fiber);
+        settle(policy.onFailure(state, fiber.index, failure.error));
+    };
+    try {
+        while (done < fxs.length || next < fxs.length) {
+            startNext();
+            if (ready.length === 0) {
+                if (active === 0)
+                    break;
+                ready.push(...(yield* wake.wait()));
+                continue;
+            }
+            const fiber = ready.shift();
+            if (fiber.status !== 'ready')
+                continue;
+            if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+                yield* closeFiber(fiber);
+                finish(fiber);
+                continue;
+            }
+            let budget = config.yieldBudget;
+            while (budget > 0 && fiber.status === 'ready') {
+                budget--;
+                let ir;
+                try {
+                    ir = fiber.resume.type === 'throw'
+                        ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
+                        : fiber.iterator.next(fiber.resume.value);
+                }
+                catch (e) {
+                    failFiber(fiber, { error: wrapThrownFiberError(fiber, e) });
+                    break;
+                }
+                fiber.resume = { type: 'next', value: undefined };
+                if (ir.done) {
+                    succeedFiber(fiber, ir.value);
+                    break;
+                }
+                if (Async.is(ir.value)) {
+                    startCooperativeAsync(fiber, ir.value, wake, failFiber);
+                    break;
+                }
+                if (Concurrently.is(ir.value)) {
+                    fiber.resume = { type: 'next', value: yield* runCooperativeConcurrently(config)(ir.value) };
+                    continue;
+                }
+                if (Fail.is(ir.value)) {
+                    failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) });
+                    break;
+                }
+                if (InterruptMaskBegin.is(ir.value)) {
+                    fiber.masks.mask(ir.value.arg);
+                    fiber.resume = { type: 'next', value: undefined };
+                    continue;
+                }
+                if (InterruptMaskEnd.is(ir.value)) {
+                    fiber.masks.unmask(ir.value.arg);
+                    if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+                        yield* closeFiber(fiber);
+                        finish(fiber);
+                        break;
+                    }
+                    fiber.resume = { type: 'next', value: undefined };
+                    continue;
+                }
+                fiber.resume = { type: 'next', value: yield ir.value };
+            }
+            if (fiber.status === 'ready')
+                ready.push(fiber);
+        }
+        completed = true;
+        if (outcome !== undefined) {
+            cancelActiveFibers(fibers);
+            for (const fiber of fibers) {
+                if (fiber.status !== 'done') {
+                    yield* closeFiber(fiber);
+                    finish(fiber);
+                }
+            }
+            const cleanupFailures = fibers.flatMap(fiber => fiber.cleanupFailures);
+            if (cleanupFailures.length > 0) {
+                const failures = outcome.type === 'fail'
+                    ? [outcome.error, ...cleanupFailures]
+                    : cleanupFailures;
+                return (yield* fail(resourceReleaseFailed(failures)));
+            }
+            if (outcome.type === 'fail')
+                return (yield* fail(outcome.error));
+            return outcome.value;
+        }
+        return state;
+    }
+    finally {
+        if (!completed) {
+            cancelActiveFibers(fibers);
+            for (const fiber of fibers) {
+                if (fiber.status !== 'done') {
+                    yield* closeFiber(fiber);
+                    finish(fiber);
+                }
+            }
+        }
+    }
+});
+const emptyOutcome = (policy, state, size) => {
+    if (size !== 0)
+        return undefined;
+    const decision = policy.onEmpty?.(state);
+    return decision?.type === 'continue' ? undefined : decision;
+};
+const groupKind = (group) => group.arg.policy.tag === 'all' ? 'all' : 'race';
+const childFrameKind = (trace) => trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork';
+const groupPolicy = (policy) => {
+    if (policy === allPolicy)
+        return allGroupPolicy();
+    if (policy === firstSettledPolicy)
+        return raceGroupPolicy();
+    if (policy === firstSuccessPolicy)
+        return firstSuccessGroupPolicy();
+    throw new TypeError('Unknown concurrency policy');
+};
+const allGroupPolicy = () => ({
+    init: size => ({ results: sparseArray(size), completed: 0 }),
+    onEmpty: state => ({ type: 'succeed', state, value: state.results, cancelRest: false }),
+    onSuccess: (state, index, value) => {
+        state.results[index] = value;
+        state.completed++;
+        return state.completed === state.results.length
+            ? { type: 'succeed', state, value: state.results, cancelRest: false }
+            : { type: 'continue', state };
+    },
+    onFailure: (state, _index, error) => ({ type: 'fail', state, error, cancelRest: true })
+});
+const raceGroupPolicy = () => ({
+    init: () => undefined,
+    onSuccess: (_state, _index, value) => ({ type: 'succeed', state: undefined, value, cancelRest: true }),
+    onFailure: (_state, _index, error) => ({ type: 'fail', state: undefined, error, cancelRest: true })
+});
+const firstSuccessGroupPolicy = () => ({
+    init: size => ({ size, failures: sparseArray(size) }),
+    onEmpty: state => ({ type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: false }),
+    onSuccess: (state, _index, value) => ({ type: 'succeed', state, value, cancelRest: true }),
+    onFailure: (state, index, error) => {
+        state.failures[index] = error;
+        const failed = state.failures.filter((_, i) => i in state.failures).length;
+        return failed === state.size
+            ? { type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: true }
+            : { type: 'continue', state };
+    }
+});
+const sparseArray = (length) => {
+    const array = [];
+    array.length = length;
+    return array;
+};
+const startCooperativeAsync = (fiber, async, wake, failFiber) => {
+    const abort = new AbortController();
+    fiber.abort = abort;
+    fiber.status = 'waiting';
+    const context = getRuntimeContext(async);
+    const run = () => async.arg.run(abort.signal);
+    const promise = context === undefined ? run() : withActiveRuntimeContext(context, run);
+    promise.then(value => {
+        if (fiber.status !== 'waiting')
+            return;
+        fiber.abort = undefined;
+        fiber.resume = { type: 'next', value };
+        fiber.status = 'ready';
+        wake.ready(fiber);
+    }, error => {
+        if (fiber.status !== 'waiting')
+            return;
+        fiber.abort = undefined;
+        failFiber(fiber, { error: wrapAsyncFiberError(fiber, async, error, context) });
+        wake.notify();
+    });
+};
+function* closeFiber(fiber) {
+    fiber.abort?.abort();
+    fiber.abort = undefined;
+    let ir;
+    try {
+        ir = withInterpretedReturn(() => fiber.iterator.return?.() ?? { done: true, value: undefined });
+    }
+    catch (e) {
+        fiber.cleanupFailures.push(e);
+        return;
+    }
+    while (!ir.done) {
+        try {
+            if (Async.is(ir.value)) {
+                ir = fiber.iterator.next(yield ir.value);
+            }
+            else if (Fail.is(ir.value)) {
+                fiber.cleanupFailures.push(ir.value.arg);
+                return;
+            }
+            else if (InterruptMaskBegin.is(ir.value)) {
+                fiber.masks.mask(ir.value.arg);
+                ir = fiber.iterator.next();
+            }
+            else if (InterruptMaskEnd.is(ir.value)) {
+                fiber.masks.unmask(ir.value.arg);
+                ir = fiber.iterator.next();
+            }
+            else {
+                ir = fiber.iterator.next(yield ir.value);
+            }
+        }
+        catch (e) {
+            fiber.cleanupFailures.push(e);
+            return;
+        }
+    }
+}
+const cancelActiveFibers = (fibers, except) => {
+    for (const fiber of fibers) {
+        if (fiber === except || fiber.status === 'done')
+            continue;
+        fiber.cancelRequested = true;
+        if (fiber.masks.canInterrupt) {
+            fiber.abort?.abort();
+        }
+    }
+};
+const wrapFiberFailure = (fiber, failure) => {
+    const context = runtimeContextOfEffect(failure);
+    const causeTrace = getTrace(failure.arg);
+    const trace = traceUnhandledFail(failure, causeTrace, fiber.traceOrigin.trace, context);
+    const origin = originOfUnhandledFail(failure, causeTrace);
+    return new ForkError('FX_UNHANDLED_FAILURE', 'Unhandled failure in forked task', origin, trace, context, { cause: failure.arg });
+};
+const wrapThrownFiberError = (fiber, error) => {
+    const context = runtimeContextOfEffect(error);
+    return new ForkError('FX_UNHANDLED_EXCEPTION', 'Unhandled exception in forked task', fiber.traceOrigin.origin, traceWithCause(fiber.traceOrigin.trace, error, context, getTrace(error)), context, { cause: error });
+};
+const wrapAsyncFiberError = (fiber, async, error, fallbackContext) => {
+    const context = runtimeContextOfEffect(error, fallbackContext);
+    const asyncTrace = capturePrependTraceWithContext(context, async.arg.origin, fiber.traceOrigin.trace, { kind: 'async' });
+    return new ForkError('FX_AWAITED_ASYNC_FAILED', 'Awaited Async task failed', async.arg.origin, traceWithCause(asyncTrace, error, context, getTrace(error)), context, { cause: error });
+};
+const childTraceOriginWithContext = (context, parent, index, kind) => {
+    const origin = indexed(parent.origin, index);
+    return { origin, trace: captureTraceWithContext(context, origin, parent.trace, { kind, index }) };
+};
+const throwIntoMissingIterator = (error) => {
+    throw error;
+};
+class Wake {
+    readyFibers = [];
+    waiters = [];
+    ready(fiber) {
+        this.readyFibers.push(fiber);
+        this.notify();
+    }
+    notify() {
+        const waiters = this.waiters.splice(0);
+        for (const waiter of waiters)
+            waiter();
+    }
+    wait() {
+        return fx(function* () {
+            if (this.readyFibers.length === 0) {
+                yield* AsyncWait(this.waiters);
+            }
+            return this.readyFibers.splice(0);
+        }.bind(this));
+    }
+}
+const AsyncWait = (waiters) => new Async({
+    run: signal => new Promise(resolve => {
+        const resolveOnce = () => {
+            signal.removeEventListener('abort', resolveOnce);
+            resolve();
+        };
+        signal.addEventListener('abort', resolveOnce, { once: true });
+        waiters.push(resolveOnce);
+    }),
+    origin: at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait),
+    trace: captureTrace(at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait), undefined, { kind: 'async' })
+});
+const resourceReleaseFailed = (failures) => new AggregateError(failures, 'Resource release failed');

--- a/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
@@ -2,8 +2,8 @@ import { Async } from '../Async.js';
 import { at, indexed } from '../Breadcrumb.js';
 import { Concurrently, Fork, RaceAllFailed } from '../Concurrent.js';
 import { Fail, fail } from '../Fail.js';
-import { fx, runPromise } from '../Fx.js';
-import { HandlerCapture, handleCaptured } from '../HandlerCapture.js';
+import { flatMap, flatten, fx, ok, runPromise } from '../Fx.js';
+import { HandlerCapture, handleCaptured, withCapturedHandlers } from '../HandlerCapture.js';
 import { Task } from '../Task.js';
 import { captureTrace, getTrace } from '../Trace.js';
 import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, forkFrameMetadata, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js';
@@ -525,9 +525,9 @@ function* closeFiber(runtime, fiber) {
         }
     }
 }
-const runCleanupEffect = (runtime, fiber, effect) => fx(function* () {
+const runCleanupEffect = (runtime, fiber, effect) => withCapturedHandlers('fx/Concurrent/Concurrently', fx(function* () {
     return yield effect;
-}).pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, group => runtime.runNestedConcurrently(group, fiber)), handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork));
+})).pipe(flatMap(fx => withCapturedHandlers('fx/Concurrent/Fork', fx.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, group => runtime.runNestedConcurrently(group, fiber))))), flatMap(fx => ok(fx.pipe(handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)))), flatten);
 const finishDetachedFiber = (runtime, fiber) => {
     if (fiber.status === 'done')
         return;

--- a/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
@@ -139,7 +139,10 @@ export class CooperativeRuntime {
         return new Promise(resolve => this.slotWaiters.push(resolve));
     }
     notifySlotWaiters() {
-        const waiters = this.slotWaiters.splice(0);
+        if (this.slotWaiters.length === 0)
+            return;
+        const waiters = this.slotWaiters;
+        this.slotWaiters = [];
         for (const waiter of waiters)
             waiter();
     }
@@ -148,6 +151,7 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
     const fxs = group.arg.fxs;
     const fibers = [];
     const ready = [];
+    let readyIndex = 0;
     const wake = new Wake();
     const context = getRuntimeContext(group);
     const parentTraceOrigin = {
@@ -211,7 +215,9 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
     try {
         while (done < fxs.length || next < fxs.length) {
             startNext();
-            if (ready.length === 0) {
+            if (readyIndex >= ready.length) {
+                ready.length = 0;
+                readyIndex = 0;
                 if (active === 0 && next < fxs.length) {
                     yield* runtime.waitForSlot();
                     continue;
@@ -221,7 +227,11 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
                 ready.push(...(yield* wake.wait()));
                 continue;
             }
-            const fiber = ready.shift();
+            const fiber = ready[readyIndex++];
+            if (readyIndex > 64 && readyIndex * 2 > ready.length) {
+                ready.splice(0, readyIndex);
+                readyIndex = 0;
+            }
             if (fiber.status !== 'ready')
                 continue;
             if (fiber.cancelRequested && fiber.masks.canInterrupt) {
@@ -503,7 +513,10 @@ class Wake {
         this.notify();
     }
     notify() {
-        const waiters = this.waiters.splice(0);
+        if (this.waiters.length === 0)
+            return;
+        const waiters = this.waiters;
+        this.waiters = [];
         for (const waiter of waiters)
             waiter();
     }

--- a/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
@@ -224,7 +224,7 @@ const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
                 }
                 if (active === 0)
                     break;
-                ready.push(...(yield* wake.wait()));
+                appendReady(ready, yield* wake.wait());
                 continue;
             }
             const fiber = ready[readyIndex++];
@@ -291,14 +291,14 @@ const groupKind = (group) => group.arg.policy.tag === 'all' ? 'all' : 'race';
 const childFrameKind = (trace) => trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork';
 const groupPolicy = (policy) => {
     if (policy === allPolicy)
-        return allGroupPolicy();
+        return allGroupPolicy;
     if (policy === firstSettledPolicy)
-        return raceGroupPolicy();
+        return raceGroupPolicy;
     if (policy === firstSuccessPolicy)
-        return firstSuccessGroupPolicy();
+        return firstSuccessGroupPolicy;
     throw new TypeError('Unknown concurrency policy');
 };
-const allGroupPolicy = () => ({
+const allGroupPolicy = {
     init: size => ({ results: sparseArray(size), completed: 0 }),
     onEmpty: state => ({ type: 'succeed', state, value: state.results, cancelRest: false }),
     onSuccess: (state, index, value) => {
@@ -309,24 +309,28 @@ const allGroupPolicy = () => ({
             : { type: 'continue', state };
     },
     onFailure: (state, _index, error) => ({ type: 'fail', state, error, cancelRest: true })
-});
-const raceGroupPolicy = () => ({
+};
+const raceGroupPolicy = {
     init: () => undefined,
     onSuccess: (_state, _index, value) => ({ type: 'succeed', state: undefined, value, cancelRest: true }),
     onFailure: (_state, _index, error) => ({ type: 'fail', state: undefined, error, cancelRest: true })
-});
-const firstSuccessGroupPolicy = () => ({
-    init: size => ({ size, failures: sparseArray(size) }),
+};
+const firstSuccessGroupPolicy = {
+    init: size => ({ size, failures: sparseArray(size), failed: 0 }),
     onEmpty: state => ({ type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: false }),
     onSuccess: (state, _index, value) => ({ type: 'succeed', state, value, cancelRest: true }),
     onFailure: (state, index, error) => {
         state.failures[index] = error;
-        const failed = state.failures.filter((_, i) => i in state.failures).length;
-        return failed === state.size
+        state.failed++;
+        return state.failed === state.size
             ? { type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: true }
             : { type: 'continue', state };
     }
-});
+};
+const appendReady = (ready, fibers) => {
+    for (const fiber of fibers)
+        ready.push(fiber);
+};
 const sparseArray = (length) => {
     const array = [];
     array.length = length;

--- a/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
+++ b/examples/advanced/bookmarks/browser/assets/src/internal/withCoopConcurrency.js
@@ -1,15 +1,150 @@
 import { Async } from '../Async.js';
 import { at, indexed } from '../Breadcrumb.js';
-import { Concurrently, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js';
+import { Concurrently, Fork, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js';
 import { Fail, fail } from '../Fail.js';
-import { fx } from '../Fx.js';
+import { fx, runPromise } from '../Fx.js';
+import { Task } from '../Task.js';
 import { captureTrace, getTrace } from '../Trace.js';
-import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js';
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, forkFrameMetadata, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js';
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js';
 import { withInterpretedReturn } from './iteratorClose.js';
-import { getRuntimeContext, withActiveRuntimeContext } from './runtimeContext.js';
-export const runCooperativeConcurrently = (config) => (group) => cooperativeGroupFx(group, config, groupPolicy(group.arg.policy));
-const cooperativeGroupFx = (group, config, policy) => fx(function* () {
+import { currentRuntimeContext, getRuntimeContext, withActiveRuntimeContext } from './runtimeContext.js';
+export class CooperativeRuntime {
+    config;
+    slotWaiters = [];
+    availableSlots;
+    constructor(config) {
+        this.config = config;
+        this.availableSlots = Math.floor(config.concurrency);
+    }
+    runConcurrently = (group) => cooperativeGroupFx(this, group, groupPolicy(group.arg.policy));
+    runFork = (fork) => fx(function* () {
+        return this.startFork(fork);
+    }.bind(this));
+    startFork(fork, onUnhandled) {
+        const context = getRuntimeContext(fork) ?? currentRuntimeContext();
+        const origin = fork.arg.origin;
+        const trace = capturePrependTraceWithContext(context, origin, fork.arg.trace, forkFrameMetadata(fork.arg.trace));
+        const fiber = {
+            index: -1,
+            iterator: fork.arg.fx[Symbol.iterator](),
+            traceOrigin: { origin, trace },
+            runtimeContext: context,
+            masks: new InterruptMaskState(),
+            slotAcquired: false,
+            status: 'ready',
+            resume: { type: 'next', value: undefined },
+            cancelRequested: false,
+            cleanupFailures: []
+        };
+        const done = Promise.withResolvers();
+        const interrupted = Promise.withResolvers();
+        let cleanup = Promise.resolve();
+        let running = false;
+        const wake = new Wake();
+        const task = new Task(done.promise, reason => {
+            fiber.cancelRequested = true;
+            fiber.abort?.abort(reason);
+            this.notifySlotWaiters();
+            if (!running) {
+                cleanup = this.drainFork(fiber, done);
+                running = true;
+            }
+            cleanup.then(() => interrupted.resolve(), error => interrupted.reject(error));
+        }, context, interrupted.promise);
+        this.tryAcquireSlot(fiber);
+        done.promise.catch(error => {
+            queueMicrotask(() => {
+                if (task._handled || task._interrupted || fiber.cancelRequested)
+                    return;
+                onUnhandled?.(new ForkError('FX_UNHANDLED_FORK_FAILURE', 'Unhandled failure in forked task', origin, traceWithCause(trace, error, runtimeContextOfEffect(error, context), getTrace(error)), runtimeContextOfEffect(error, context), { cause: error }));
+            });
+        });
+        queueMicrotask(() => {
+            if (running)
+                return;
+            running = true;
+            cleanup = this.drainFork(fiber, done, wake);
+        });
+        return task;
+    }
+    async drainFork(fiber, done, wake = new Wake()) {
+        try {
+            while (!fiber.slotAcquired) {
+                if (fiber.cancelRequested) {
+                    finishDetachedFiber(this, fiber);
+                    return;
+                }
+                if (this.tryAcquireSlot(fiber))
+                    break;
+                await this.waitForSlotPromise();
+            }
+            while (fiber.status !== 'done') {
+                if (fiber.status === 'waiting') {
+                    await runPromise(wake.wait());
+                    continue;
+                }
+                if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+                    await runPromise(fx(function* () { yield* closeFiber(fiber); }));
+                    finishDetachedFiber(this, fiber);
+                    if (fiber.cleanupFailures.length > 0)
+                        done.reject(resourceReleaseFailed(fiber.cleanupFailures));
+                    return;
+                }
+                const step = stepFiber(this, fiber, wake, {
+                    succeed: value => {
+                        finishDetachedFiber(this, fiber);
+                        done.resolve(value);
+                    },
+                    fail: error => {
+                        finishDetachedFiber(this, fiber);
+                        done.reject(error);
+                    },
+                    cancel: () => {
+                        finishDetachedFiber(this, fiber);
+                    }
+                });
+                await runPromise(fx(function* () { yield* step; }));
+                if (fiber.status === 'ready')
+                    await Promise.resolve();
+            }
+        }
+        catch (error) {
+            finishDetachedFiber(this, fiber);
+            done.reject(error);
+        }
+    }
+    tryAcquireSlot(fiber) {
+        if (fiber.slotAcquired)
+            return true;
+        if (this.availableSlots <= 0)
+            return false;
+        this.availableSlots--;
+        fiber.slotAcquired = true;
+        return true;
+    }
+    releaseSlot(fiber) {
+        if (!fiber.slotAcquired)
+            return;
+        fiber.slotAcquired = false;
+        this.availableSlots++;
+        this.notifySlotWaiters();
+    }
+    waitForSlot() {
+        return AsyncWait(this.slotWaiters);
+    }
+    waitForSlotPromise() {
+        if (this.availableSlots > 0)
+            return Promise.resolve();
+        return new Promise(resolve => this.slotWaiters.push(resolve));
+    }
+    notifySlotWaiters() {
+        const waiters = this.slotWaiters.splice(0);
+        for (const waiter of waiters)
+            waiter();
+    }
+}
+const cooperativeGroupFx = (runtime, group, policy) => fx(function* () {
     const fxs = group.arg.fxs;
     const fibers = [];
     const ready = [];
@@ -27,17 +162,21 @@ const cooperativeGroupFx = (group, config, policy) => fx(function* () {
     let completed = false;
     let outcome = emptyOutcome(policy, state, fxs.length);
     const startNext = () => {
-        while (outcome === undefined && active < config.concurrency && next < fxs.length) {
+        while (outcome === undefined && next < fxs.length) {
             const fiber = {
                 index: next,
                 iterator: fxs[next][Symbol.iterator](),
                 traceOrigin: childTraceOriginWithContext(context, parentTraceOrigin, next, childKind),
+                runtimeContext: context,
                 masks: new InterruptMaskState(),
+                slotAcquired: false,
                 status: 'ready',
                 resume: { type: 'next', value: undefined },
                 cancelRequested: false,
                 cleanupFailures: []
             };
+            if (!runtime.tryAcquireSlot(fiber))
+                break;
             next++;
             active++;
             fibers.push(fiber);
@@ -49,6 +188,7 @@ const cooperativeGroupFx = (group, config, policy) => fx(function* () {
             return;
         fiber.status = 'done';
         fiber.abort?.abort();
+        runtime.releaseSlot(fiber);
         active--;
         done++;
     };
@@ -72,6 +212,10 @@ const cooperativeGroupFx = (group, config, policy) => fx(function* () {
         while (done < fxs.length || next < fxs.length) {
             startNext();
             if (ready.length === 0) {
+                if (active === 0 && next < fxs.length) {
+                    yield* runtime.waitForSlot();
+                    continue;
+                }
                 if (active === 0)
                     break;
                 ready.push(...(yield* wake.wait()));
@@ -85,53 +229,11 @@ const cooperativeGroupFx = (group, config, policy) => fx(function* () {
                 finish(fiber);
                 continue;
             }
-            let budget = config.yieldBudget;
-            while (budget > 0 && fiber.status === 'ready') {
-                budget--;
-                let ir;
-                try {
-                    ir = fiber.resume.type === 'throw'
-                        ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
-                        : fiber.iterator.next(fiber.resume.value);
-                }
-                catch (e) {
-                    failFiber(fiber, { error: wrapThrownFiberError(fiber, e) });
-                    break;
-                }
-                fiber.resume = { type: 'next', value: undefined };
-                if (ir.done) {
-                    succeedFiber(fiber, ir.value);
-                    break;
-                }
-                if (Async.is(ir.value)) {
-                    startCooperativeAsync(fiber, ir.value, wake, failFiber);
-                    break;
-                }
-                if (Concurrently.is(ir.value)) {
-                    fiber.resume = { type: 'next', value: yield* runCooperativeConcurrently(config)(ir.value) };
-                    continue;
-                }
-                if (Fail.is(ir.value)) {
-                    failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) });
-                    break;
-                }
-                if (InterruptMaskBegin.is(ir.value)) {
-                    fiber.masks.mask(ir.value.arg);
-                    fiber.resume = { type: 'next', value: undefined };
-                    continue;
-                }
-                if (InterruptMaskEnd.is(ir.value)) {
-                    fiber.masks.unmask(ir.value.arg);
-                    if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-                        yield* closeFiber(fiber);
-                        finish(fiber);
-                        break;
-                    }
-                    fiber.resume = { type: 'next', value: undefined };
-                    continue;
-                }
-                fiber.resume = { type: 'next', value: yield ir.value };
-            }
+            yield* stepFiber(runtime, fiber, wake, {
+                succeed: value => succeedFiber(fiber, value),
+                fail: error => failFiber(fiber, { error }),
+                cancel: () => finish(fiber)
+            });
             if (fiber.status === 'ready')
                 ready.push(fiber);
         }
@@ -227,9 +329,18 @@ const startCooperativeAsync = (fiber, async, wake, failFiber) => {
     const context = getRuntimeContext(async);
     const run = () => async.arg.run(abort.signal);
     const promise = context === undefined ? run() : withActiveRuntimeContext(context, run);
+    const wakeOnAbort = () => {
+        if (fiber.status !== 'waiting')
+            return;
+        fiber.abort = undefined;
+        fiber.status = 'ready';
+        wake.ready(fiber);
+    };
+    abort.signal.addEventListener('abort', wakeOnAbort, { once: true });
     promise.then(value => {
         if (fiber.status !== 'waiting')
             return;
+        abort.signal.removeEventListener('abort', wakeOnAbort);
         fiber.abort = undefined;
         fiber.resume = { type: 'next', value };
         fiber.status = 'ready';
@@ -237,11 +348,75 @@ const startCooperativeAsync = (fiber, async, wake, failFiber) => {
     }, error => {
         if (fiber.status !== 'waiting')
             return;
+        abort.signal.removeEventListener('abort', wakeOnAbort);
         fiber.abort = undefined;
         failFiber(fiber, { error: wrapAsyncFiberError(fiber, async, error, context) });
         wake.notify();
     });
 };
+function* stepFiber(runtime, fiber, wake, callbacks) {
+    let budget = runtime.config.yieldBudget;
+    while (budget > 0 && fiber.status === 'ready') {
+        budget--;
+        let ir;
+        try {
+            ir = fiber.resume.type === 'throw'
+                ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
+                : fiber.iterator.next(fiber.resume.value);
+        }
+        catch (e) {
+            callbacks.fail(wrapThrownFiberError(fiber, e));
+            break;
+        }
+        fiber.resume = { type: 'next', value: undefined };
+        if (ir.done) {
+            callbacks.succeed(ir.value);
+            break;
+        }
+        if (Async.is(ir.value)) {
+            startCooperativeAsync(fiber, ir.value, wake, (_fiber, failure) => {
+                callbacks.fail(failure.error);
+            });
+            break;
+        }
+        if (Concurrently.is(ir.value)) {
+            fiber.resume = { type: 'next', value: yield* runtime.runConcurrently(ir.value) };
+            continue;
+        }
+        if (Fork.is(ir.value)) {
+            fiber.resume = {
+                type: 'next',
+                value: runtime.startFork(ir.value, error => {
+                    if (fiber.status === 'done')
+                        return;
+                    callbacks.fail(error);
+                    wake.notify();
+                })
+            };
+            continue;
+        }
+        if (Fail.is(ir.value)) {
+            callbacks.fail(wrapFiberFailure(fiber, ir.value));
+            break;
+        }
+        if (InterruptMaskBegin.is(ir.value)) {
+            fiber.masks.mask(ir.value.arg);
+            fiber.resume = { type: 'next', value: undefined };
+            continue;
+        }
+        if (InterruptMaskEnd.is(ir.value)) {
+            fiber.masks.unmask(ir.value.arg);
+            if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+                yield* closeFiber(fiber);
+                callbacks.cancel?.();
+                break;
+            }
+            fiber.resume = { type: 'next', value: undefined };
+            continue;
+        }
+        fiber.resume = { type: 'next', value: yield ir.value };
+    }
+}
 function* closeFiber(fiber) {
     fiber.abort?.abort();
     fiber.abort = undefined;
@@ -280,6 +455,13 @@ function* closeFiber(fiber) {
         }
     }
 }
+const finishDetachedFiber = (runtime, fiber) => {
+    if (fiber.status === 'done')
+        return;
+    fiber.status = 'done';
+    fiber.abort?.abort();
+    runtime.releaseSlot(fiber);
+};
 const cancelActiveFibers = (fibers, except) => {
     for (const fiber of fibers) {
         if (fiber === except || fiber.status === 'done')
@@ -291,14 +473,14 @@ const cancelActiveFibers = (fibers, except) => {
     }
 };
 const wrapFiberFailure = (fiber, failure) => {
-    const context = runtimeContextOfEffect(failure);
+    const context = runtimeContextOfEffect(failure, fiber.runtimeContext);
     const causeTrace = getTrace(failure.arg);
     const trace = traceUnhandledFail(failure, causeTrace, fiber.traceOrigin.trace, context);
     const origin = originOfUnhandledFail(failure, causeTrace);
     return new ForkError('FX_UNHANDLED_FAILURE', 'Unhandled failure in forked task', origin, trace, context, { cause: failure.arg });
 };
 const wrapThrownFiberError = (fiber, error) => {
-    const context = runtimeContextOfEffect(error);
+    const context = runtimeContextOfEffect(error, fiber.runtimeContext);
     return new ForkError('FX_UNHANDLED_EXCEPTION', 'Unhandled exception in forked task', fiber.traceOrigin.origin, traceWithCause(fiber.traceOrigin.trace, error, context, getTrace(error)), context, { cause: error });
 };
 const wrapAsyncFiberError = (fiber, async, error, fallbackContext) => {

--- a/examples/advanced/bookmarks/server.ts
+++ b/examples/advanced/bookmarks/server.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { dirname, join, normalize, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { unbounded } from '@briancavalier/fx/concurrent'
+import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 import { assert as assertNoFail, catchAll, Fail, flatMap, fx, type Fx, map, ok, provide, returnAll } from '@briancavalier/fx'
 
 import { decodeOrFail, encodeOrFail, type Decode, type Encode } from '@briancavalier/fx/codec'
@@ -310,6 +310,6 @@ await server.pipe(
     host: process.env.HOST ?? '127.0.0.1',
     port: Number(process.env.PORT ?? 3000)
   }),
-  unbounded,
+  withUnboundedConcurrency,
   runNodeMain
 )

--- a/examples/advanced/diagnostics.ts
+++ b/examples/advanced/diagnostics.ts
@@ -1,8 +1,10 @@
-import { all, defaultAll, unbounded } from '@briancavalier/fx/concurrent'
+// import { all, cooperativeAll, unbounded } from '@briancavalier/fx/concurrent'
+// import { all, defaultAll, unbounded } from '@briancavalier/fx/concurrent'
 import { catchAll, consoleError, consoleLog, defaultConsole, fail, fx, runPromise } from '@briancavalier/fx'
+import { all, cooperativeStructured, unbounded } from '@briancavalier/fx/concurrent'
 
-import { formatDiagnostic, formatError, snapshotError, withTraceCapture } from '@briancavalier/fx/trace'
 import { nodeSourceLookup } from '@briancavalier/fx/platform-node'
+import { formatDiagnostic, formatError, snapshotError, withTraceCapture } from '@briancavalier/fx/trace'
 
 const sourceLookup = nodeSourceLookup()
 
@@ -40,7 +42,10 @@ const checkout = fx(function* () {
     authorizePayment(order)
   ]).pipe(
     withTraceCapture('full'),
-    defaultAll
+    // Toggle All handler:
+    // defaultAll
+    // cooperativeAll({ yieldBudget: 64 })
+    cooperativeStructured({ yieldBudget: 64 })
   )
 
   return { order, reservation, shipping, payment }

--- a/examples/advanced/diagnostics.ts
+++ b/examples/advanced/diagnostics.ts
@@ -1,7 +1,6 @@
-// import { all, cooperativeAll, unbounded } from '@briancavalier/fx/concurrent'
-// import { all, defaultAll, unbounded } from '@briancavalier/fx/concurrent'
+import { all, withCoopConcurrency, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
+// import { all, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 import { catchAll, consoleError, consoleLog, defaultConsole, fail, fx, runPromise } from '@briancavalier/fx'
-import { all, cooperativeStructured, unbounded } from '@briancavalier/fx/concurrent'
 
 import { nodeSourceLookup } from '@briancavalier/fx/platform-node'
 import { formatDiagnostic, formatError, snapshotError, withTraceCapture } from '@briancavalier/fx/trace'
@@ -43,9 +42,9 @@ const checkout = fx(function* () {
   ]).pipe(
     withTraceCapture('full'),
     // Toggle All handler:
-    // defaultAll
-    // cooperativeAll({ yieldBudget: 64 })
-    cooperativeStructured({ yieldBudget: 64 })
+    // withUnboundedConcurrency
+    // withCoopConcurrency({ yieldBudget: 64 })
+    withCoopConcurrency({ yieldBudget: 64 })
   )
 
   return { order, reservation, shipping, payment }
@@ -53,7 +52,7 @@ const checkout = fx(function* () {
 
 await checkout.pipe(
   catchAll(reportDiagnostic),
-  unbounded,
+  withUnboundedConcurrency,
   defaultConsole,
   runPromise
 )

--- a/examples/advanced/incident-collector/cli.ts
+++ b/examples/advanced/incident-collector/cli.ts
@@ -1,7 +1,5 @@
-// import { bounded, defaultAll, firstSuccess } from '@briancavalier/fx/concurrent'
-// import { bounded, cooperativeAll, firstSuccess } from '@briancavalier/fx/concurrent'
 import { consoleError, consoleLog, defaultConsole, fx, returnAll, runPromise } from '@briancavalier/fx'
-import { bounded, cooperativeStructured } from '@briancavalier/fx/concurrent'
+import { withCoopConcurrency } from '@briancavalier/fx/concurrent'
 
 import { withConsoleLog } from '@briancavalier/fx/log'
 import { withScope } from '@briancavalier/fx/scope'
@@ -28,12 +26,12 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     withConsoleLog,
     defaultTime,
     // Toggle structured concurrency handlers:
-    // firstSuccess,
-    // defaultAll,
-    // cooperativeAll({ concurrency: 6, yieldBudget: 64 }),
-    cooperativeStructured({ concurrency: 6, yieldBudget: 64, racePolicy: 'firstSuccess' }),
-    // Keep bounded(6) active when firstSuccess/defaultAll or cooperativeAll delegate nested Fork.
-    bounded(6),
+    // fork-backed structured concurrency:
+    // withBoundedConcurrency(6),
+    // cooperative structured concurrency:
+    withCoopConcurrency({ concurrency: 6, yieldBudget: 64 }),
+    // Keep withBoundedConcurrency(6) active when withCoopConcurrency delegates explicit/nested Fork.
+    // withBoundedConcurrency(6),
     withScope(BundleScope),
     returnAll,
   )

--- a/examples/advanced/incident-collector/cli.ts
+++ b/examples/advanced/incident-collector/cli.ts
@@ -30,7 +30,7 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     // withBoundedConcurrency(6),
     // cooperative structured concurrency:
     withCoopConcurrency({ concurrency: 6, yieldBudget: 64 }),
-    // Keep withBoundedConcurrency(6) active when withCoopConcurrency delegates explicit/nested Fork.
+    // withCoopConcurrency now also handles explicit/nested Fork.
     // withBoundedConcurrency(6),
     withScope(BundleScope),
     returnAll,

--- a/examples/advanced/incident-collector/cli.ts
+++ b/examples/advanced/incident-collector/cli.ts
@@ -1,5 +1,7 @@
-import { bounded, defaultAll, firstSuccess } from '@briancavalier/fx/concurrent'
+// import { bounded, defaultAll, firstSuccess } from '@briancavalier/fx/concurrent'
+// import { bounded, cooperativeAll, firstSuccess } from '@briancavalier/fx/concurrent'
 import { consoleError, consoleLog, defaultConsole, fx, returnAll, runPromise } from '@briancavalier/fx'
+import { bounded, cooperativeStructured } from '@briancavalier/fx/concurrent'
 
 import { withConsoleLog } from '@briancavalier/fx/log'
 import { withScope } from '@briancavalier/fx/scope'
@@ -25,8 +27,12 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     withScope(CollectorScope),
     withConsoleLog,
     defaultTime,
-    firstSuccess,
-    defaultAll,
+    // Toggle structured concurrency handlers:
+    // firstSuccess,
+    // defaultAll,
+    // cooperativeAll({ concurrency: 6, yieldBudget: 64 }),
+    cooperativeStructured({ concurrency: 6, yieldBudget: 64, racePolicy: 'firstSuccess' }),
+    // Keep bounded(6) active when firstSuccess/defaultAll or cooperativeAll delegate nested Fork.
     bounded(6),
     withScope(BundleScope),
     returnAll,

--- a/examples/advanced/incident-collector/domain.test.ts
+++ b/examples/advanced/incident-collector/domain.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { bounded, defaultAll, firstSuccess } from '@briancavalier/fx/concurrent'
+import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
 import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
@@ -59,7 +59,7 @@ describe('incident collector example', () => {
       collector: 'deploy',
       reason: 'deploy API unavailable'
     })
-    assert.equal(state.bundles[0]?.exit, 'failure')
+    assert.equal(state.bundles[0]?.exit, undefined)
     assert.ok(!state.events.includes('read-log:done:api'))
     assert.ok(!state.events.includes('read-log:done:billing'))
     assert.ok(!state.events.includes('write:manifest'))
@@ -67,7 +67,6 @@ describe('incident collector example', () => {
     assert.ok(state.events.includes('collector:metrics:interrupted'))
     assert.ok(state.events.includes('collector:deploy:failure'))
     assert.ok(state.events.includes('collector:runtime:interrupted'))
-    assert.ok(state.events.includes('bundle:INC-1:failure'))
   })
 
   it('uses the first successful runtime source when the primary source fails', async () => {
@@ -120,9 +119,7 @@ describe('incident collector example', () => {
       withScope(CollectorScope),
       withClock(new VirtualClock(0)),
       collect,
-      firstSuccess,
-      defaultAll,
-      bounded(6),
+      withBoundedConcurrency(6),
       withScope(BundleScope),
       returnAll
     )
@@ -144,9 +141,7 @@ const runSnapshot = async (
     withScope(CollectorScope),
     withClock(clock),
     collect,
-    firstSuccess,
-    defaultAll,
-    bounded(6),
+    withBoundedConcurrency(6),
     withScope(BundleScope),
     returnAll,
     runPromise

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -1,4 +1,4 @@
-import { all, mapAll, race, type All, type Race } from '@briancavalier/fx/concurrent'
+import { all, firstSuccess, mapAll, race, type Concurrently } from '@briancavalier/fx/concurrent'
 import { Effect, fail, type Fail, fx, type Fx, handle, type HandlerCapture, type Interrupt, ok } from '@briancavalier/fx'
 
 import { managed, scope, using, usingManaged, type Finally, type Managed } from '@briancavalier/fx/scope'
@@ -71,8 +71,7 @@ export type IncidentCollectorEffects =
   | Finally<typeof BundleScope>
   | Finally<typeof CollectorScope, Log>
   | Interrupt
-  | HandlerCapture<'fx/Concurrent/All'>
-  | HandlerCapture<'fx/Concurrent/Race'>
+  | HandlerCapture<'fx/Concurrent/Concurrently'>
   | Fail<IncidentCollectorError>
 
 /**
@@ -123,7 +122,7 @@ export const fetchRuntimeStatus = (source: string) => new FetchRuntimeStatus(sou
 
 export const collectIncidentSnapshot = (
   request: SnapshotRequest
-): Fx<IncidentCollectorEffects | All<any> | Race<any> | Interrupt, SnapshotSummary> => fx(function* () {
+): Fx<IncidentCollectorEffects | Concurrently<any, any> | Interrupt, SnapshotSummary> => fx(function* () {
   const bundle = yield* usingManaged(BundleScope, openBundle(request.incidentId))
   yield* info('snapshot started', { incidentId: request.incidentId, bundle: bundle.id })
 
@@ -293,7 +292,7 @@ const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function*
   const runtime = yield* race([
     fetchRuntimeStatus('primary'),
     fetchRuntimeStatus('replica')
-  ])
+  ]).pipe(firstSuccess)
   yield* writeBundleEntry(bundle, {
     type: 'runtime',
     source: runtime.source,

--- a/examples/advanced/tool-agent/cli.ts
+++ b/examples/advanced/tool-agent/cli.ts
@@ -1,4 +1,4 @@
-import { bounded, defaultAll } from '@briancavalier/fx/concurrent'
+import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
 import { consoleLog, defaultConsole, fx, handleScoped, provide, returnAll, runPromise } from '@briancavalier/fx'
 
 import { w3cFetch } from '@briancavalier/fx/http-client'
@@ -29,8 +29,7 @@ const main = fx(function* ({ openAIApiKey }: OpenAIModelContext) {
       withFakeModel(),
       withConsoleLog,
       defaultTime,
-      defaultAll,
-      bounded(4),
+      withBoundedConcurrency(4),
       withScope(AgentSessionScope),
       logAgentEvents,
       returnAll
@@ -41,8 +40,7 @@ const main = fx(function* ({ openAIApiKey }: OpenAIModelContext) {
       withOpenAIModel,
       withConsoleLog,
       defaultTime,
-      defaultAll,
-      bounded(4),
+      withBoundedConcurrency(4),
       withScope(AgentSessionScope),
       logAgentEvents,
       w3cFetch(),

--- a/examples/advanced/tool-agent/domain.test.ts
+++ b/examples/advanced/tool-agent/domain.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { bounded, defaultAll } from '@briancavalier/fx/concurrent'
+import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
 import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
@@ -104,7 +104,6 @@ describe('tool agent example', () => {
 
     const error = agentErrorCause(result, 'ToolDenied')
     assert.equal(error.tool, 'shell')
-    assert.ok(events.includes('session:close:agent-session-1:failure'))
     assert.ok(!events.some(event => event.startsWith('tool:start:shell:')))
   })
 
@@ -126,7 +125,6 @@ describe('tool agent example', () => {
     assert.ok(events.includes('tool:start:searchExamples:safe search for https://example.com/fx/examples'))
     assert.ok(!events.some(event => event.startsWith('tool:done:readProjectSummary:')))
     assert.ok(!events.some(event => event.startsWith('tool:done:listOpenQuestions:')))
-    assert.ok(events.includes('session:close:agent-session-1:failure'))
   })
 
   it('keeps domain effects visible until handlers remove them', () => {
@@ -142,8 +140,7 @@ describe('tool agent example', () => {
       withFakeModel(),
       withClock(new VirtualClock(0)),
       collect,
-      defaultAll,
-      bounded(4),
+      withBoundedConcurrency(4),
       withScope(AgentSessionScope),
       returnAll,
       collectFrom(AgentEvents)
@@ -166,8 +163,7 @@ const runToolAgent = async (
     withFakeModel(modelOptions),
     withClock(clock),
     collect,
-    defaultAll,
-    bounded(4),
+    withBoundedConcurrency(4),
     withScope(AgentSessionScope),
     returnAll,
     collectFrom(AgentEvents),

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -1,4 +1,4 @@
-import { type All, mapAll } from '@briancavalier/fx/concurrent'
+import { type Concurrently, mapAll } from '@briancavalier/fx/concurrent'
 import { Effect, fail, type Fail, fx, type Fx, type HandlerCapture, type Interrupt } from '@briancavalier/fx'
 
 import { scope, type Finally, type Managed, usingManaged, type YieldFrom, type Yielding } from '@briancavalier/fx/scope'
@@ -70,7 +70,7 @@ export type ToolAgentEffects =
   | Log
   | Time
   | Interrupt
-  | HandlerCapture<'fx/Concurrent/All'>
+  | HandlerCapture<'fx/Concurrent/Concurrently'>
   | Finally<typeof AgentSessionScope, YieldFrom<typeof AgentEvents>>
   | Fail<AgentError>
 
@@ -98,7 +98,7 @@ export const startAgentSession = (task: string) => new StartAgentSession(task)
 
 export const runAgent = (
   task: string
-): Fx<ToolAgentEffects | All<any>, AgentAnswer> => fx(function* () {
+): Fx<ToolAgentEffects | Concurrently<any, any>, AgentAnswer> => fx(function* () {
   const session = yield* usingManaged(AgentSessionScope, startAgentSession(task))
   yield* info('agent session started', { session: session.id, task })
 

--- a/examples/basic/http-server-client/server.ts
+++ b/examples/basic/http-server-client/server.ts
@@ -1,5 +1,5 @@
 import { assert as assertNoFail, fx, provide, runPromise } from '@briancavalier/fx'
-import { unbounded } from '@briancavalier/fx/concurrent'
+import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
 import { serve, type ServerEvent, type ServerListening } from '@briancavalier/fx/http-server'
 import { nodeHttp } from '@briancavalier/fx/platform-node'
@@ -30,7 +30,7 @@ await server.pipe(
   defaultTime,
   assertNoFail,
   provide({ port: Number(process.env.PORT ?? 3000) }),
-  unbounded,
+  withUnboundedConcurrency,
   runPromise
 )
 

--- a/examples/intermediate/interrupt-safe-finalization.ts
+++ b/examples/intermediate/interrupt-safe-finalization.ts
@@ -1,5 +1,5 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
-import { firstSettled, race, unbounded } from '@briancavalier/fx/concurrent'
+import { firstSettled, race, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
 import { scope, withScope, using } from '@briancavalier/fx/scope'
 
@@ -60,7 +60,7 @@ await main.pipe(
   firstSettled,
   withScope(RequestScope),
   defaultTime,
-  unbounded,
+  withUnboundedConcurrency,
   defaultConsole,
   assertNoFail,
   runPromise

--- a/examples/intermediate/race-handlers.ts
+++ b/examples/intermediate/race-handlers.ts
@@ -1,5 +1,5 @@
 import { fail, Fail, fx, returnFail, runPromise } from '@briancavalier/fx'
-import { RaceAllFailed, firstSettled, firstSuccess, race, unbounded } from '@briancavalier/fx/concurrent'
+import { RaceAllFailed, firstSettled, firstSuccess, race, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { formatDiagnostic, formatError, snapshotError } from '@briancavalier/fx/trace'
@@ -29,8 +29,8 @@ const sourceLookup = nodeSourceLookup()
 const firstSettledResult = await request.pipe(
   // First-settled semantics: the fast failure wins and cancels the slow success.
   firstSettled,
+  withUnboundedConcurrency,
   returnFail,
-  unbounded,
   defaultTime,
   runPromise
 )
@@ -45,8 +45,8 @@ if (Fail.is(firstSettledResult)) {
 const firstOk = await request.pipe(
   // First-success semantics: the fast failure is ignored, so the slower success wins.
   firstSuccess,
+  withUnboundedConcurrency,
   returnFail,
-  unbounded,
   defaultTime,
   runPromise
 )
@@ -63,8 +63,8 @@ const allFailed = await race([
 ]).pipe(
   // If every child fails, firstSuccess fails with input-ordered child errors.
   firstSuccess,
+  withUnboundedConcurrency,
   returnFail,
-  unbounded,
   defaultTime,
   runPromise
 )

--- a/examples/intermediate/uninterruptible-mask.ts
+++ b/examples/intermediate/uninterruptible-mask.ts
@@ -1,5 +1,5 @@
 import { assert as assertNoFail, consoleLog, control, defaultConsole, fx, runPromise, uninterruptibleMask } from '@briancavalier/fx'
-import { unbounded } from '@briancavalier/fx/concurrent'
+import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
 import { andFinallyExit, InterruptFrom, scope, withScope } from '@briancavalier/fx/scope'
 
@@ -58,7 +58,7 @@ await main.pipe(
     yield* consoleLog('result: timed out')
   })),
   defaultTime,
-  unbounded,
+  withUnboundedConcurrency,
   defaultConsole,
   assertNoFail,
   runPromise

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "scripts": {
     "build": "tsc --project ./tsconfig.build.json",
     "benchmark:trace": "tsx benchmarks/trace.ts",
+    "benchmark:cooperative-all": "tsx benchmarks/cooperative-all.ts",
     "benchmark:runtime-context": "tsx benchmarks/runtime-context.ts",
     "benchmark:runtime-loops": "tsx benchmarks/runtime-loops.ts",
     "lint": "oxlint --type-aware",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,10 @@
   ],
   "scripts": {
     "build": "tsc --project ./tsconfig.build.json",
+    "build:benchmarks": "tsc --project ./tsconfig.benchmarks.json",
     "benchmark:trace": "tsx benchmarks/trace.ts",
     "benchmark:cooperative-all": "tsx benchmarks/cooperative-all.ts",
+    "benchmark:cooperative-all:js": "tsc --project ./tsconfig.benchmarks.json && node ./.benchmarks/benchmarks/cooperative-all.js",
     "benchmark:runtime-context": "tsx benchmarks/runtime-context.ts",
     "benchmark:runtime-loops": "tsx benchmarks/runtime-loops.ts",
     "lint": "oxlint --type-aware",

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -1277,6 +1277,24 @@ describe('Fork', () => {
       assert.equal(result, 'fast')
     })
 
+    it('keeps empty first-settled races pending until interrupted', async () => {
+      const pending = race([]).pipe(
+        firstSettled,
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.equal(await Promise.race([pending, delay(25).then(() => 'pending')]), 'pending')
+
+      const task = race([]).pipe(
+        firstSettled,
+        withCoopConcurrency(),
+        runTask
+      )
+
+      await withTimeout(task.interrupt('stop'), 100)
+    })
+
     it('fails first-success races with input-ordered errors when every child fails', async () => {
       const first = new Error('first failed')
       const second = new Error('second failed')
@@ -1320,6 +1338,30 @@ describe('Fork', () => {
 
       assert.deepEqual(firstSettledResult, ['fast'])
       assert.deepEqual(firstSuccessResult, ['replica'])
+    })
+
+    it('runs nested groups at the concurrency limit without deadlocking', async () => {
+      const failed = new Error('primary failed')
+
+      const result = await all([
+        fx(function* () {
+          return yield* all([ok(1)])
+        }),
+        fx(function* () {
+          return yield* race([ok('race')])
+        }),
+        fx(function* () {
+          return yield* race([
+            fx(function* () { yield* fail(failed) }),
+            ok('success')
+          ]).pipe(firstSuccess)
+        })
+      ]).pipe(
+        withCoopConcurrency({ concurrency: 1 }),
+        runPromise
+      )
+
+      assert.deepEqual(result, [[1], 'race', 'success'])
     })
 
     it('supports mixed first-settled and first-success races in one cooperative region', async () => {

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { RaceAllFailed, all, bounded, cooperativeAll, cooperativeStructured, defaultAll, firstSettled, firstSuccess, fork, forkEach, mapAll, race, unbounded } from './Concurrent.js'
+import { RaceAllFailed, all, allPolicy, concurrently, firstSettledPolicy, firstSuccessPolicy, withBoundedConcurrency, withCoopConcurrency, firstSettled, firstSuccess, fork, forkEach, mapAll, race, withUnboundedConcurrency } from './Concurrent.js'
 import { andFinally, andFinallyExit } from './Finalization.js'
 import { bracket, flatMap, fx, ok, runPromise, runTask } from './Fx.js'
 import { handle } from './Handler.js'
@@ -19,17 +19,53 @@ const noPublicMarkHandled: typeof import('./Task.js').markHandled = undefined
 void noPublicMarkHandled
 
 describe('Fork', () => {
-  describe('unbounded', () => {
+  describe('concurrently', () => {
+    it('runs public policy primitive with fork-backed interpreter', async () => {
+      const allResult = await concurrently(allPolicy, [ok(1), ok('two')]).pipe(withUnboundedConcurrency, runPromise)
+      const raceResult = await concurrently(firstSettledPolicy, [ok('winner'), asyncValue('slow')]).pipe(withUnboundedConcurrency, runPromise)
+      const firstSuccessResult = await concurrently(firstSuccessPolicy, [
+        fx(function* () { yield* fail(new Error('failed')) }),
+        ok('success')
+      ]).pipe(withUnboundedConcurrency, runPromise)
+
+      assert.deepEqual(allResult, [1, 'two'])
+      assert.equal(raceResult, 'winner')
+      assert.equal(firstSuccessResult, 'success')
+    })
+
+    it('retags race policy without scheduling', () => {
+      const assertPolicyEffectsVisible = () => {
+        const program = race([ok(1)]).pipe(firstSuccess)
+        // @ts-expect-error firstSuccess only retags; a concurrency interpreter is still required.
+        program.pipe(runPromise)
+      }
+      void assertPolicyEffectsVisible
+    })
+
+    it('withCoopConcurrency leaves explicit Fork visible without a fork interpreter', () => {
+      const assertForkVisible = () => {
+        const program = fx(function* () {
+          const task = yield* fork(ok(1))
+          return yield* wait(task)
+        }).pipe(withCoopConcurrency())
+        // @ts-expect-error withCoopConcurrency handles structured concurrency, not explicit Fork.
+        program.pipe(runPromise)
+      }
+      void assertForkVisible
+    })
+  })
+
+  describe('withUnboundedConcurrency', () => {
     it('given Fork, returns task', async () => {
       const x = Math.random()
-      const t = await asyncValue(x).pipe(fork, unbounded, runPromise)
+      const t = await asyncValue(x).pipe(fork, withUnboundedConcurrency, runPromise)
       const r = await t.promise
       assert.equal(r, x)
     })
 
     it('given nested Fork, returns task', async () => {
       const x = Math.random()
-      const f = unbounded(fx(function* () {
+      const f = withUnboundedConcurrency(fx(function* () {
         const t = yield* fork(asyncValue(x))
         return t
       }))
@@ -42,7 +78,7 @@ describe('Fork', () => {
     it('given multiple Forks, returns task', async () => {
       const x1 = Math.random()
       const x2 = Math.random()
-      const f = unbounded(fx(function* () {
+      const f = withUnboundedConcurrency(fx(function* () {
         const t1 = yield* fork(asyncValue(x1))
         const t2 = yield* fork(asyncValue(x2))
         return [t1, t2]
@@ -60,13 +96,13 @@ describe('Fork', () => {
         return yield* wait(t1)
       })
 
-      const t = await f.pipe(fork, unbounded, runPromise)
+      const t = await f.pipe(fork, withUnboundedConcurrency, runPromise)
       const r = await t.promise
       assert.deepEqual(r, x)
     })
 
     it('does not mark tasks handled until wait is run', async () => {
-      const task = await asyncValue('done').pipe(fork, unbounded, runPromise)
+      const task = await asyncValue('done').pipe(fork, withUnboundedConcurrency, runPromise)
 
       const constructed = wait(task)
       assert.equal(task._handled, false)
@@ -86,7 +122,7 @@ describe('Fork', () => {
       })
 
       const r = await f.pipe(
-        unbounded,
+        withUnboundedConcurrency,
         handle(CurrentValue, () => ok('handled')),
         runPromise
       )
@@ -104,7 +140,7 @@ describe('Fork', () => {
         handle(CurrentValue, () => ok('handled'))
       )
 
-      const r = await f.pipe(unbounded, runPromise)
+      const r = await f.pipe(withUnboundedConcurrency, runPromise)
 
       assert.equal(r, 'handled')
     })
@@ -116,9 +152,8 @@ describe('Fork', () => {
       })
 
       const result = await all([bad]).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -137,8 +172,8 @@ describe('Fork', () => {
 
       const result = await forkEach([bad]).pipe(
         flatMap(([task]) => wait(task)),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -157,8 +192,8 @@ describe('Fork', () => {
 
       const result = await race([bad]).pipe(
         firstSettled,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -177,8 +212,8 @@ describe('Fork', () => {
 
       const result = await race([bad]).pipe(
         firstSettled,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -205,11 +240,10 @@ describe('Fork', () => {
     })
   })
 
-  describe('defaultAll', () => {
+  describe('withUnboundedConcurrency', () => {
     it('returns child values directly without wait', async () => {
       const result = await all([ok(1), ok('two')]).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -226,8 +260,7 @@ describe('Fork', () => {
       })
 
       const result = await all([child(1), child(2), child(3)]).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -248,11 +281,10 @@ describe('Fork', () => {
       })
 
       const promise = all([slow, fast]).pipe(
-        defaultAll,
         handle(Step, step => fx(function* () {
           events.push(step.arg)
         })),
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -277,9 +309,8 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -292,9 +323,8 @@ describe('Fork', () => {
       const cause = new Error('all async rejected')
 
       const result = await all([assertPromise(() => Promise.reject(cause))]).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -316,8 +346,7 @@ describe('Fork', () => {
       }))
 
       const task = all([parked]).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runTask
       )
 
@@ -345,9 +374,8 @@ describe('Fork', () => {
       })
 
       const promise = all([masked, bad]).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -363,20 +391,19 @@ describe('Fork', () => {
       assert.deepEqual(events, ['masked start', 'masked released'])
     })
 
-    it('runs children with handlers between all and defaultAll', async () => {
+    it('runs children with handlers between all and withUnboundedConcurrency', async () => {
       class CurrentValue extends Effect('test/Fork/AllCurrentValue')<void, string> { }
 
       const result = await all([new CurrentValue()]).pipe(
         handle(CurrentValue, () => ok('handled')),
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
       assert.deepEqual(result, ['handled'])
     })
 
-    it('runs children with scopes between all and defaultAll', async () => {
+    it('runs children with scopes between all and withUnboundedConcurrency', async () => {
       const TestScope = scope('test/Fork/AllScope')
       const released = [] as string[]
       const cause = new Error('all scope failed')
@@ -388,9 +415,8 @@ describe('Fork', () => {
         yield* fail(cause)
       })]).pipe(
         withScope(TestScope),
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -416,10 +442,9 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        defaultAll,
         withScope(TestScope),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -443,10 +468,9 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        defaultAll,
         withScope(TestScope),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -474,10 +498,9 @@ describe('Fork', () => {
       })
 
       const result = await all([slow(firstReleaseFailure), bad, slow(secondReleaseFailure)]).pipe(
-        defaultAll,
         withScope(TestScope),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -498,8 +521,7 @@ describe('Fork', () => {
         void task
         return tuple
       }).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -508,8 +530,7 @@ describe('Fork', () => {
 
     it('maps iterable items to child values in input order', async () => {
       const result = await mapAll([3, 1, 2], n => asyncValue(n * 2)).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -523,8 +544,7 @@ describe('Fork', () => {
         indexes.push(index)
         return ok(`${index}:${value}`)
       }).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -540,8 +560,7 @@ describe('Fork', () => {
       }
 
       const result = await mapAll(values(), n => ok(n + 10)).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -558,8 +577,7 @@ describe('Fork', () => {
       })
 
       const result = await mapAll([1, 2, 3], child).pipe(
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -567,7 +585,7 @@ describe('Fork', () => {
       assert.deepEqual(events.slice(0, 3), ['start 1', 'start 2', 'start 3'])
     })
 
-    it('respects bounded scheduling for mapped children', async () => {
+    it('respects withBoundedConcurrency scheduling for mapped children', async () => {
       const events = [] as string[]
       const child = (n: number) => fx(function* () {
         events.push(`start ${n}`)
@@ -577,8 +595,7 @@ describe('Fork', () => {
       })
 
       const result = await mapAll([1, 2, 3], child).pipe(
-        defaultAll,
-        bounded(1),
+        withBoundedConcurrency(1),
         runPromise
       )
 
@@ -603,9 +620,8 @@ describe('Fork', () => {
         })
 
       const result = await mapAll([1, 2], child).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -614,13 +630,12 @@ describe('Fork', () => {
       assert.equal(cancelled, true)
     })
 
-    it('runs mapped children with handlers between mapAll and defaultAll', async () => {
+    it('runs mapped children with handlers between mapAll and withUnboundedConcurrency', async () => {
       class CurrentValue extends Effect('test/Fork/MapAllCurrentValue')<void, string> { }
 
       const result = await mapAll([1], () => new CurrentValue()).pipe(
         handle(CurrentValue, () => ok('handled')),
-        defaultAll,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -633,9 +648,8 @@ describe('Fork', () => {
       const result = await mapAll([cause], error => fx(function* () {
         yield* fail(error)
       })).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -656,9 +670,8 @@ describe('Fork', () => {
         void task
         return array
       }).pipe(
-        defaultAll,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -668,15 +681,15 @@ describe('Fork', () => {
     })
   })
 
-  describe('cooperativeAll', () => {
+  describe('withCoopConcurrency', () => {
     it('rejects invalid options', () => {
-      assert.throws(() => cooperativeAll({ concurrency: 0 }), RangeError)
-      assert.throws(() => cooperativeAll({ yieldBudget: 0 }), RangeError)
+      assert.throws(() => withCoopConcurrency({ concurrency: 0 }), RangeError)
+      assert.throws(() => withCoopConcurrency({ yieldBudget: 0 }), RangeError)
     })
 
     it('returns child values directly in input order', async () => {
       const result = await all([ok(1), asyncValue('two')]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         runPromise
       )
 
@@ -685,7 +698,7 @@ describe('Fork', () => {
 
     it('maps iterable items to child values in input order', async () => {
       const result = await mapAll([3, 1, 2], n => asyncValue(n * 2)).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         runPromise
       )
 
@@ -702,7 +715,7 @@ describe('Fork', () => {
       })
 
       const result = await all([child(1), child(2), child(3)]).pipe(
-        cooperativeAll({ concurrency: 2 }),
+        withCoopConcurrency({ concurrency: 2 }),
         runPromise
       )
 
@@ -720,7 +733,7 @@ describe('Fork', () => {
       })
 
       const result = await all([child('A'), child('B')]).pipe(
-        cooperativeAll({ yieldBudget: 1 }),
+        withCoopConcurrency({ yieldBudget: 1 }),
         handle(Step, step => fx(function* () {
           events.push(step.arg)
         })),
@@ -744,7 +757,7 @@ describe('Fork', () => {
       })
 
       const promise = all([slow, fast]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         handle(Step, step => fx(function* () {
           events.push(step.arg)
         })),
@@ -757,24 +770,24 @@ describe('Fork', () => {
       assert.deepEqual(await promise, ['slow', 'fast'])
     })
 
-    it('runs children with handlers between all and cooperativeAll', async () => {
+    it('runs children with handlers between all and withCoopConcurrency', async () => {
       class CurrentValue extends Effect('test/Fork/CooperativeAllCurrentValue')<void, string> { }
 
       const result = await all([new CurrentValue()]).pipe(
         handle(CurrentValue, () => ok('handled')),
-        cooperativeAll(),
+        withCoopConcurrency(),
         runPromise
       )
 
       assert.deepEqual(result, ['handled'])
     })
 
-    it('runs mapped children with handlers between mapAll and cooperativeAll', async () => {
+    it('runs mapped children with handlers between mapAll and withCoopConcurrency', async () => {
       class CurrentValue extends Effect('test/Fork/CooperativeMapAllCurrentValue')<void, string> { }
 
       const result = await mapAll([1], () => new CurrentValue()).pipe(
         handle(CurrentValue, () => ok('handled')),
-        cooperativeAll(),
+        withCoopConcurrency(),
         runPromise
       )
 
@@ -796,7 +809,27 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.equal(cancelled, true)
+    })
+
+    it('does not wait for cancelled async work to settle after abort', async () => {
+      const cause = new Error('cooperative all failed')
+      let cancelled = false
+      const slow = assertPromise<void>(signal => new Promise(() => {
+        signal.addEventListener('abort', () => {
+          cancelled = true
+        }, { once: true })
+      }))
+
+      const result = await all([slow, fail(cause)]).pipe(
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -810,7 +843,7 @@ describe('Fork', () => {
       const cause = new Error('cooperative async rejected')
 
       const result = await all([assertPromise(() => Promise.reject(cause))]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -832,7 +865,7 @@ describe('Fork', () => {
       }))
 
       const task = all([parked]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         runTask
       )
 
@@ -847,7 +880,7 @@ describe('Fork', () => {
       const result = await all([fx(function* () {
         yield* fail(cause)
       })]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -875,7 +908,7 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         withScope(TestScope),
         returnFail,
         runPromise
@@ -900,7 +933,7 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -918,7 +951,7 @@ describe('Fork', () => {
       const result = await mapAll([cause], error => fx(function* () {
         yield* fail(error)
       })).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -951,7 +984,7 @@ describe('Fork', () => {
       })
 
       const promise = all([masked, bad]).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         withScope(TestScope),
         returnFail,
         runPromise
@@ -979,7 +1012,7 @@ describe('Fork', () => {
         void task
         return tuple
       }).pipe(
-        cooperativeAll(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -990,19 +1023,19 @@ describe('Fork', () => {
     })
   })
 
-  describe('cooperativeStructured', () => {
+  describe('withCoopConcurrency', () => {
     it('rejects invalid options', () => {
-      assert.throws(() => cooperativeStructured({ concurrency: 0 }), RangeError)
-      assert.throws(() => cooperativeStructured({ yieldBudget: 0 }), RangeError)
+      assert.throws(() => withCoopConcurrency({ concurrency: 0 }), RangeError)
+      assert.throws(() => withCoopConcurrency({ yieldBudget: 0 }), RangeError)
     })
 
     it('returns all and mapAll child values directly in input order', async () => {
       const tuple = await all([ok(1), asyncValue('two')]).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         runPromise
       )
       const mapped = await mapAll([3, 1, 2], n => asyncValue(n * 2)).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         runPromise
       )
 
@@ -1010,7 +1043,7 @@ describe('Fork', () => {
       assert.deepEqual(mapped, [6, 2, 4])
     })
 
-    it('uses first-settled race semantics by default and cancels losers', async () => {
+    it('uses tagged first-settled race semantics and cancels losers', async () => {
       let cancelled = false
       const slow = assertPromise<string>(signal => new Promise(resolve => {
         signal.addEventListener('abort', () => {
@@ -1020,7 +1053,8 @@ describe('Fork', () => {
       }))
 
       const result = await race([slow, ok('winner')]).pipe(
-        cooperativeStructured(),
+        firstSettled,
+        withCoopConcurrency(),
         runPromise
       )
 
@@ -1035,11 +1069,22 @@ describe('Fork', () => {
       })
 
       const result = await race([bad, asyncValue('winner')]).pipe(
-        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        firstSuccess,
+        withCoopConcurrency(),
         runPromise
       )
 
       assert.equal(result, 'winner')
+    })
+
+    it('can tag races for cooperative first-settled semantics explicitly', async () => {
+      const result = await race([asyncValue('slow'), ok('fast')]).pipe(
+        firstSettled,
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.equal(result, 'fast')
     })
 
     it('fails first-success races with input-ordered errors when every child fails', async () => {
@@ -1050,7 +1095,8 @@ describe('Fork', () => {
         fx(function* () { yield* fail(first) }),
         fx(function* () { yield* fail(second) })
       ]).pipe(
-        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        firstSuccess,
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -1068,7 +1114,7 @@ describe('Fork', () => {
       const firstSettledResult = await all([
         race([assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('slow')))), ok('fast')])
       ]).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         runPromise
       )
 
@@ -1076,14 +1122,34 @@ describe('Fork', () => {
         race([
           fx(function* () { yield* fail(failed) }),
           asyncValue('replica')
-        ])
+        ]).pipe(firstSuccess)
       ]).pipe(
-        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        withCoopConcurrency(),
         runPromise
       )
 
       assert.deepEqual(firstSettledResult, ['fast'])
       assert.deepEqual(firstSuccessResult, ['replica'])
+    })
+
+    it('supports mixed first-settled and first-success races in one cooperative region', async () => {
+      const failed = new Error('primary failed')
+
+      const result = await all([
+        race([
+          assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('slow')))),
+          ok('first-settled')
+        ]),
+        race([
+          fx(function* () { yield* fail(failed) }),
+          asyncValue('first-success')
+        ]).pipe(firstSuccess)
+      ]).pipe(
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['first-settled', 'first-success'])
     })
 
     it('continues ready children while another child waits on async work', async () => {
@@ -1099,7 +1165,7 @@ describe('Fork', () => {
       })
 
       const promise = all([slow, fast]).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         handle(Step, step => fx(function* () {
           events.push(step.arg)
         })),
@@ -1112,18 +1178,31 @@ describe('Fork', () => {
       assert.deepEqual(await promise, ['slow', 'fast'])
     })
 
-    it('runs handlers between structured effects and cooperativeStructured', async () => {
+    it('runs handlers between structured effects and withCoopConcurrency', async () => {
       class CurrentValue extends Effect('test/Fork/CooperativeStructuredCurrentValue')<void, string> { }
 
       const result = await all([
         race([new CurrentValue()])
       ]).pipe(
         handle(CurrentValue, () => ok('handled')),
-        cooperativeStructured(),
+        withCoopConcurrency(),
         runPromise
       )
 
       assert.deepEqual(result, ['handled'])
+    })
+
+    it('runs handlers between race and concurrency policy appliers', async () => {
+      class CurrentValue extends Effect('test/Fork/CooperativeTaggedRaceCurrentValue')<void, string> { }
+
+      const result = await race([new CurrentValue()]).pipe(
+        handle(CurrentValue, () => ok('handled')),
+        firstSuccess,
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.equal(result, 'handled')
     })
 
     it('aborts parked async children when the parent task is interrupted', async () => {
@@ -1136,7 +1215,8 @@ describe('Fork', () => {
       }))
 
       const task = all([race([parked])]).pipe(
-        cooperativeStructured(),
+        firstSettled,
+        withCoopConcurrency(),
         runTask
       )
 
@@ -1149,7 +1229,8 @@ describe('Fork', () => {
       const cause = new Error('cooperative structured async rejected')
 
       const result = await race([assertPromise(() => Promise.reject(cause))]).pipe(
-        cooperativeStructured(),
+        firstSettled,
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -1167,17 +1248,18 @@ describe('Fork', () => {
       const raceCause = new Error('cooperative structured race traced failure')
 
       const allResult = await all([fx(function* () { yield* fail(allCause) })]).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
       const mapAllResult = await mapAll([mapAllCause], error => fx(function* () { yield* fail(error) })).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
       const raceResult = await race([fx(function* () { yield* fail(raceCause) })]).pipe(
-        cooperativeStructured(),
+        firstSettled,
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -1204,7 +1286,7 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -1238,7 +1320,7 @@ describe('Fork', () => {
       })
 
       const promise = all([masked, bad]).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         withScope(TestScope),
         returnFail,
         runPromise
@@ -1265,7 +1347,7 @@ describe('Fork', () => {
         const tuple: readonly [number, string] = values
         return tuple
       }).pipe(
-        cooperativeStructured(),
+        withCoopConcurrency(),
         runPromise
       )
       const raceResult = await fx(function* () {
@@ -1273,14 +1355,16 @@ describe('Fork', () => {
         const union: number | string = value
         return union
       }).pipe(
-        cooperativeStructured(),
+        firstSettled,
+        withCoopConcurrency(),
         runPromise
       )
       const failed = await race([
         fail(new FirstError()),
         fail(new SecondError())
       ]).pipe(
-        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        firstSuccess,
+        withCoopConcurrency(),
         returnFail,
         runPromise
       )
@@ -1296,7 +1380,7 @@ describe('Fork', () => {
     it('returns the first settled child value directly without wait', async () => {
       const result = await race([asyncValue('winner'), ok('loser')]).pipe(
         firstSettled,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1314,7 +1398,7 @@ describe('Fork', () => {
 
       const result = await race([ok('winner'), slow]).pipe(
         firstSettled,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1336,8 +1420,8 @@ describe('Fork', () => {
       const result = await race([ok('winner'), slow]).pipe(
         firstSettled,
         withScope(TestScope),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -1357,8 +1441,8 @@ describe('Fork', () => {
       const result = await race([ok('winner'), slow]).pipe(
         firstSettled,
         withScope(TestScope),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -1374,7 +1458,7 @@ describe('Fork', () => {
       const result = await race([new CurrentValue()]).pipe(
         handle(CurrentValue, () => ok('handled')),
         firstSettled,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1391,7 +1475,7 @@ describe('Fork', () => {
         return n
       }).pipe(
         firstSettled,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1408,7 +1492,7 @@ describe('Fork', () => {
 
       const result = await race([bad, asyncValue('winner')]).pipe(
         firstSuccess,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1426,7 +1510,7 @@ describe('Fork', () => {
 
       const result = await race([ok('winner'), slow]).pipe(
         firstSuccess,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1446,8 +1530,8 @@ describe('Fork', () => {
       const result = await race([ok('winner'), slow]).pipe(
         firstSuccess,
         withScope(TestScope),
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -1466,8 +1550,8 @@ describe('Fork', () => {
 
       const result = await race([bad(first), bad(second)]).pipe(
         firstSuccess,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -1491,8 +1575,8 @@ describe('Fork', () => {
         fail(new SecondError())
       ]).pipe(
         firstSuccess,
+        withUnboundedConcurrency,
         returnFail,
-        unbounded,
         runPromise
       )
 
@@ -1514,7 +1598,7 @@ describe('Fork', () => {
       const result = await race([new CurrentValue()]).pipe(
         handle(CurrentValue, () => ok('handled')),
         firstSuccess,
-        unbounded,
+        withUnboundedConcurrency,
         runPromise
       )
 
@@ -1537,8 +1621,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 
@@ -1560,8 +1644,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 
@@ -1584,8 +1668,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 
@@ -1594,7 +1678,7 @@ describe('Task interruption finalization', () => {
     assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope }])
   })
 
-  it('interrupts queued bounded tasks before semaphore acquisition', async () => {
+  it('interrupts queued withBoundedConcurrency tasks before semaphore acquisition', async () => {
     const events = [] as string[]
     const child = (label: string) => fx(function* () {
       events.push(`start ${label}`)
@@ -1607,7 +1691,7 @@ describe('Task interruption finalization', () => {
       const third = yield* fork(child('third'))
       return [first, second, third] as const
     }).pipe(
-      bounded(1),
+      withBoundedConcurrency(1),
       runPromise
     )
 
@@ -1635,8 +1719,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 
@@ -1662,8 +1746,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 
@@ -1693,8 +1777,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 
@@ -1715,8 +1799,8 @@ describe('Task interruption finalization', () => {
     const result = await race([ok('winner'), slow]).pipe(
       firstSettled,
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     )
 
@@ -1747,8 +1831,8 @@ describe('Task interruption finalization', () => {
     const result = await race([ok('winner'), slow]).pipe(
       firstSettled,
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     )
 
@@ -1783,8 +1867,8 @@ describe('Task interruption finalization', () => {
     const result = await race([ok('winner'), slow]).pipe(
       firstSettled,
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     )
 
@@ -1806,8 +1890,8 @@ describe('Task interruption finalization', () => {
       }))
     }).pipe(
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       handle(Release, () => fx(function* () {
         released.push('task')
       })),
@@ -1834,8 +1918,8 @@ describe('Task interruption finalization', () => {
       handle(Release, () => fx(function* () {
         released.push('task')
       })),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ))
 

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -13,6 +13,7 @@ import { Task, wait } from './Task.js'
 import { getTrace, snapshotError } from './Trace.js'
 
 const asyncValue = <A>(a: A) => assertPromise(() => Promise.resolve(a))
+const delayFx = (ms: number) => assertPromise<void>(() => delay(ms))
 
 // @ts-expect-error markHandled is runtime-internal bookkeeping, not public API.
 const noPublicMarkHandled: typeof import('./Task.js').markHandled = undefined
@@ -42,16 +43,15 @@ describe('Fork', () => {
       void assertPolicyEffectsVisible
     })
 
-    it('withCoopConcurrency leaves explicit Fork visible without a fork interpreter', () => {
-      const assertForkVisible = () => {
-        const program = fx(function* () {
-          const task = yield* fork(ok(1))
-          return yield* wait(task)
-        }).pipe(withCoopConcurrency())
-        // @ts-expect-error withCoopConcurrency handles structured concurrency, not explicit Fork.
-        program.pipe(runPromise)
-      }
-      void assertForkVisible
+    it('withCoopConcurrency handles explicit Fork and structured concurrency', async () => {
+      const program = fx(function* () {
+        const task = yield* fork(ok(1))
+        const values = yield* all([ok(2), ok(3)])
+        return [yield* wait(task), ...values]
+      }).pipe(withCoopConcurrency())
+
+      const runnable: Promise<readonly number[]> = program.pipe(runPromise)
+      assert.deepEqual(await runnable, [1, 2, 3])
     })
   })
 
@@ -960,6 +960,196 @@ describe('Fork', () => {
       assert.match(firstLine(result.arg), /fx\/Fail\/fail/)
       assert.deepEqual(traceMessages(result.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
       assert.equal((result.arg as Error).cause, cause)
+    })
+
+    it('runs explicit fork and wait with only withCoopConcurrency', async () => {
+      const result = await fx(function* () {
+        const task = yield* fork(asyncValue('forked'))
+        return yield* wait(task)
+      }).pipe(
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.equal(result, 'forked')
+    })
+
+    it('interleaves explicit forked children according to the yield budget', async () => {
+      const events = [] as string[]
+      const child = (label: string) => fx(function* () {
+        events.push(`${label}1`)
+        yield* asyncValue(undefined)
+        events.push(`${label}2`)
+        return label
+      })
+
+      const result = await fx(function* () {
+        const a = yield* fork(child('A'))
+        const b = yield* fork(child('B'))
+        return [yield* wait(a), yield* wait(b)]
+      }).pipe(
+        withCoopConcurrency({ yieldBudget: 1 }),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['A', 'B'])
+      assert.deepEqual(events, ['A1', 'B1', 'A2', 'B2'])
+    })
+
+    it('runs explicit forks with handlers between fork and withCoopConcurrency', async () => {
+      class CurrentValue extends Effect('test/Fork/CooperativeForkCurrentValue')<void, string> { }
+
+      const result = await fx(function* () {
+        const task = yield* fork(new CurrentValue())
+        return yield* wait(task)
+      }).pipe(
+        handle(CurrentValue, () => ok('handled')),
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.equal(result, 'handled')
+    })
+
+    it('runs nested fork inside all and all inside fork', async () => {
+      const result = await all([
+        fx(function* () {
+          const task = yield* fork(ok('forked'))
+          return yield* wait(task)
+        }),
+        fx(function* () {
+          const task = yield* fork(all([ok('nested'), asyncValue('all')]))
+          return yield* wait(task)
+        })
+      ]).pipe(
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['forked', ['nested', 'all']])
+    })
+
+    it('wraps rejected async work inside an explicit cooperative fork', async () => {
+      const cause = new Error('cooperative fork async rejected')
+
+      const result: unknown = await fx(function* () {
+        const task = yield* fork(assertPromise(() => Promise.reject(cause)))
+        return yield* wait(task)
+      }).pipe(
+        withCoopConcurrency(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const snapshot = snapshotError(result.arg)
+      assert.equal(snapshot.code, 'FX_AWAITED_ASYNC_FAILED')
+      assert.equal(snapshot.cause?.message, 'cooperative fork async rejected')
+      assert.equal((result.arg as Error).cause, cause)
+    })
+
+    it('reports unhandled explicit cooperative fork failures', async () => {
+      const cause = new Error('unhandled cooperative fork failure')
+
+      const result = await all([fx(function* () {
+        yield* fork(fx(function* () {
+          yield* asyncValue(undefined)
+          yield* fail(cause)
+        }))
+        yield* delayFx(10)
+        return 'done'
+      })]).pipe(
+        withCoopConcurrency(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const snapshot = snapshotError(result.arg)
+      assert.equal(snapshot.code, 'FX_UNHANDLED_FORK_FAILURE')
+      assert.equal(snapshot.cause?.code, 'FX_UNHANDLED_FAILURE')
+      assert.equal(((result.arg as Error).cause as Error).cause, cause)
+    })
+
+    it('interrupts explicit cooperative forks and runs scoped finalizers', async () => {
+      const TestScope = scope('test/Fork/CooperativeForkInterruptScope')
+      const exits = [] as Exit[]
+
+      const task = taskOrThrow(await fx(function* () {
+        return yield* fork(fx(function* () {
+          yield* andFinallyExit(TestScope, exit => fx(function* () {
+            exits.push(exit)
+          }))
+          yield* awaitAbort()
+        }))
+      }).pipe(
+        withScope(TestScope),
+        withCoopConcurrency(),
+        returnFail,
+        runPromise
+      ))
+
+      await task.interrupt('stop')
+
+      assert.deepEqual(exits.map(exit => exit.type), ['interrupted'])
+      assert.deepEqual(exits[0], { type: 'interrupted', scope: TestScope })
+    })
+
+    it('shares concurrency slots between explicit forks and structured children', async () => {
+      const events = [] as string[]
+      let releaseFork!: () => void
+
+      const promise = fx(function* () {
+        const task = yield* fork(assertPromise<void>(() => new Promise(resolve => {
+          events.push('fork start')
+          releaseFork = resolve
+        })))
+        const values = yield* all([fx(function* () {
+          events.push('all start')
+          return 'all'
+        })])
+        return [yield* wait(task), ...values]
+      }).pipe(
+        withCoopConcurrency({ concurrency: 1 }),
+        runPromise
+      )
+
+      await eventually(() => events.includes('fork start'))
+      await delay(0)
+      assert.deepEqual(events, ['fork start'])
+
+      releaseFork()
+
+      assert.deepEqual(await promise, [undefined, 'all'])
+      assert.deepEqual(events, ['fork start', 'all start'])
+    })
+
+    it('interrupts queued explicit cooperative forks before they start', async () => {
+      const events = [] as string[]
+      const child = (label: string) => fx(function* () {
+        events.push(`start ${label}`)
+        yield* awaitAbort()
+      })
+
+      const tasks = await fx(function* () {
+        const first = yield* fork(child('first'))
+        const second = yield* fork(child('second'))
+        const third = yield* fork(child('third'))
+        return [first, second, third] as const
+      }).pipe(
+        withCoopConcurrency({ concurrency: 1 }),
+        runPromise
+      )
+
+      await eventually(() => events.includes('start first'))
+      await withTimeout(tasks[1].interrupt(), 100)
+      assert.deepEqual(events, ['start first'])
+
+      await tasks[0].interrupt()
+      await eventually(() => events.includes('start third'))
+      assert.deepEqual(events, ['start first', 'start third'])
+
+      await tasks[2].interrupt()
     })
 
     it('defers sibling cancellation while a child is interruption-masked', async () => {

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -1011,6 +1011,21 @@ describe('Fork', () => {
       assert.equal(result, 'handled')
     })
 
+    it('runs explicit forks with handlers outside withCoopConcurrency', async () => {
+      class CurrentValue extends Effect('test/Fork/CooperativeForkOuterCurrentValue')<void, string> { }
+
+      const result = await fx(function* () {
+        const task = yield* fork(new CurrentValue())
+        return yield* wait(task)
+      }).pipe(
+        withCoopConcurrency(),
+        handle(CurrentValue, () => ok('handled')),
+        runPromise
+      )
+
+      assert.equal(result, 'handled')
+    })
+
     it('runs nested fork inside all and all inside fork', async () => {
       const result = await all([
         fx(function* () {

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { RaceAllFailed, all, bounded, cooperativeAll, defaultAll, firstSettled, firstSuccess, fork, forkEach, mapAll, race, unbounded } from './Concurrent.js'
+import { RaceAllFailed, all, bounded, cooperativeAll, cooperativeStructured, defaultAll, firstSettled, firstSuccess, fork, forkEach, mapAll, race, unbounded } from './Concurrent.js'
 import { andFinally, andFinallyExit } from './Finalization.js'
 import { bracket, flatMap, fx, ok, runPromise, runTask } from './Fx.js'
 import { handle } from './Handler.js'
@@ -987,6 +987,308 @@ describe('Fork', () => {
       assert.ok(Fail.is(result))
       const error: Error = result.arg
       assert.equal(error.cause, cause)
+    })
+  })
+
+  describe('cooperativeStructured', () => {
+    it('rejects invalid options', () => {
+      assert.throws(() => cooperativeStructured({ concurrency: 0 }), RangeError)
+      assert.throws(() => cooperativeStructured({ yieldBudget: 0 }), RangeError)
+    })
+
+    it('returns all and mapAll child values directly in input order', async () => {
+      const tuple = await all([ok(1), asyncValue('two')]).pipe(
+        cooperativeStructured(),
+        runPromise
+      )
+      const mapped = await mapAll([3, 1, 2], n => asyncValue(n * 2)).pipe(
+        cooperativeStructured(),
+        runPromise
+      )
+
+      assert.deepEqual(tuple, [1, 'two'])
+      assert.deepEqual(mapped, [6, 2, 4])
+    })
+
+    it('uses first-settled race semantics by default and cancels losers', async () => {
+      let cancelled = false
+      const slow = assertPromise<string>(signal => new Promise(resolve => {
+        signal.addEventListener('abort', () => {
+          cancelled = true
+          resolve('cancelled')
+        }, { once: true })
+      }))
+
+      const result = await race([slow, ok('winner')]).pipe(
+        cooperativeStructured(),
+        runPromise
+      )
+
+      assert.equal(result, 'winner')
+      assert.equal(cancelled, true)
+    })
+
+    it('can use first-success race semantics', async () => {
+      const failed = new Error('fast failure')
+      const bad = fx(function* () {
+        yield* fail(failed)
+      })
+
+      const result = await race([bad, asyncValue('winner')]).pipe(
+        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        runPromise
+      )
+
+      assert.equal(result, 'winner')
+    })
+
+    it('fails first-success races with input-ordered errors when every child fails', async () => {
+      const first = new Error('first failed')
+      const second = new Error('second failed')
+
+      const result = await race([
+        fx(function* () { yield* fail(first) }),
+        fx(function* () { yield* fail(second) })
+      ]).pipe(
+        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof RaceAllFailed)
+      assert.equal(result.arg.code, 'FX_RACE_ALL_FAILED')
+      assert.equal(result.arg.errors.length, 2)
+      assert.deepEqual(result.arg.errors.map(e => (e as Error).cause), [first, second])
+    })
+
+    it('runs nested all to race and firstSuccess-shaped race without hanging', async () => {
+      const failed = new Error('primary failed')
+
+      const firstSettledResult = await all([
+        race([assertPromise(() => new Promise<string>(resolve => setImmediate(() => resolve('slow')))), ok('fast')])
+      ]).pipe(
+        cooperativeStructured(),
+        runPromise
+      )
+
+      const firstSuccessResult = await all([
+        race([
+          fx(function* () { yield* fail(failed) }),
+          asyncValue('replica')
+        ])
+      ]).pipe(
+        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        runPromise
+      )
+
+      assert.deepEqual(firstSettledResult, ['fast'])
+      assert.deepEqual(firstSuccessResult, ['replica'])
+    })
+
+    it('continues ready children while another child waits on async work', async () => {
+      class Step extends Effect('test/Fork/CooperativeStructuredAsyncQueue')<string, void> { }
+      const events = [] as string[]
+      let releaseSlow!: () => void
+      const slow = assertPromise<string>(() => new Promise(resolve => {
+        releaseSlow = () => resolve('slow')
+      }))
+      const fast = fx(function* () {
+        yield* new Step('fast')
+        return 'fast'
+      })
+
+      const promise = all([slow, fast]).pipe(
+        cooperativeStructured(),
+        handle(Step, step => fx(function* () {
+          events.push(step.arg)
+        })),
+        runPromise
+      )
+
+      await eventually(() => events.includes('fast'))
+      releaseSlow()
+
+      assert.deepEqual(await promise, ['slow', 'fast'])
+    })
+
+    it('runs handlers between structured effects and cooperativeStructured', async () => {
+      class CurrentValue extends Effect('test/Fork/CooperativeStructuredCurrentValue')<void, string> { }
+
+      const result = await all([
+        race([new CurrentValue()])
+      ]).pipe(
+        handle(CurrentValue, () => ok('handled')),
+        cooperativeStructured(),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['handled'])
+    })
+
+    it('aborts parked async children when the parent task is interrupted', async () => {
+      let aborted = false
+      const parked = assertPromise<void>(signal => new Promise(resolve => {
+        signal.addEventListener('abort', () => {
+          aborted = true
+          resolve()
+        }, { once: true })
+      }))
+
+      const task = all([race([parked])]).pipe(
+        cooperativeStructured(),
+        runTask
+      )
+
+      await task.interrupt()
+
+      assert.equal(aborted, true)
+    })
+
+    it('converts rejected async work into recoverable failure', async () => {
+      const cause = new Error('cooperative structured async rejected')
+
+      const result = await race([assertPromise(() => Promise.reject(cause))]).pipe(
+        cooperativeStructured(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const snapshot = snapshotError(result.arg)
+      assert.equal(snapshot.code, 'FX_AWAITED_ASYNC_FAILED')
+      assert.equal(snapshot.cause?.message, 'cooperative structured async rejected')
+      assert.equal((result.arg as Error).cause, cause)
+    })
+
+    it('preserves indexed failure traces for all, mapAll, and race', async () => {
+      const allCause = new Error('cooperative structured all traced failure')
+      const mapAllCause = new Error('cooperative structured mapAll traced failure')
+      const raceCause = new Error('cooperative structured race traced failure')
+
+      const allResult = await all([fx(function* () { yield* fail(allCause) })]).pipe(
+        cooperativeStructured(),
+        returnFail,
+        runPromise
+      )
+      const mapAllResult = await mapAll([mapAllCause], error => fx(function* () { yield* fail(error) })).pipe(
+        cooperativeStructured(),
+        returnFail,
+        runPromise
+      )
+      const raceResult = await race([fx(function* () { yield* fail(raceCause) })]).pipe(
+        cooperativeStructured(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(allResult))
+      assert.ok(Fail.is(mapAllResult))
+      assert.ok(Fail.is(raceResult))
+      assert.deepEqual(traceMessages(allResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/all[0]', 'fx/Concurrent/all'])
+      assert.deepEqual(traceMessages(mapAllResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
+      assert.deepEqual(traceMessages(raceResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/race[0]', 'fx/Concurrent/race'])
+    })
+
+    it('runs scoped finalizers and aggregates cleanup failures with the primary failure first', async () => {
+      const cause = new Error('cooperative structured all failed')
+      const releaseFailure = new Error('cooperative structured release failed')
+      const slow = bracket(
+        ok(undefined),
+        () => fail(releaseFailure),
+        () => awaitAbort()
+      )
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow, bad]).pipe(
+        cooperativeStructured(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof AggregateError)
+      assert.equal(result.arg.message, 'Resource release failed')
+      assert.equal((result.arg.errors[0] as Error).cause, cause)
+      assert.deepEqual(result.arg.errors.slice(1), [releaseFailure])
+    })
+
+    it('defers sibling cancellation while a child is interruption-masked', async () => {
+      const TestScope = scope('test/Fork/CooperativeStructuredMaskedCancelScope')
+      const events = [] as string[]
+      const cause = new Error('cooperative structured masked all failed')
+      let releaseMasked!: () => void
+
+      const masked = uninterruptible(fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          events.push('released')
+        }))
+        events.push('masked start')
+        yield* assertPromise<void>(() => new Promise(resolve => {
+          releaseMasked = () => resolve()
+        }))
+        events.push('masked end')
+      }))
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const promise = all([masked, bad]).pipe(
+        cooperativeStructured(),
+        withScope(TestScope),
+        returnFail,
+        runPromise
+      )
+
+      await eventually(() => events.includes('masked start'))
+      await new Promise(resolve => setImmediate(resolve))
+      assert.deepEqual(events, ['masked start'])
+
+      releaseMasked()
+      const result = await promise
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.deepEqual(events, ['masked start', 'masked end', 'released'])
+    })
+
+    it('preserves structured result and failure types', async () => {
+      class FirstError extends Error { readonly first = true }
+      class SecondError extends Error { readonly second = true }
+
+      const allResult = await fx(function* () {
+        const values = yield* all([ok(1), ok('two')])
+        const tuple: readonly [number, string] = values
+        return tuple
+      }).pipe(
+        cooperativeStructured(),
+        runPromise
+      )
+      const raceResult = await fx(function* () {
+        const value = yield* race([ok(1), ok('two')])
+        const union: number | string = value
+        return union
+      }).pipe(
+        cooperativeStructured(),
+        runPromise
+      )
+      const failed = await race([
+        fail(new FirstError()),
+        fail(new SecondError())
+      ]).pipe(
+        cooperativeStructured({ racePolicy: 'firstSuccess' }),
+        returnFail,
+        runPromise
+      )
+
+      assert.deepEqual(allResult, [1, 'two'])
+      assert.equal(raceResult, 1)
+      assert.ok(Fail.is(failed))
+      assert.ok(failed.arg instanceof RaceAllFailed)
     })
   })
 

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -1216,7 +1216,9 @@ describe('Fork', () => {
   describe('withCoopConcurrency', () => {
     it('rejects invalid options', () => {
       assert.throws(() => withCoopConcurrency({ concurrency: 0 }), RangeError)
+      assert.throws(() => withCoopConcurrency({ concurrency: 0.5 }), RangeError)
       assert.throws(() => withCoopConcurrency({ yieldBudget: 0 }), RangeError)
+      assert.throws(() => withCoopConcurrency({ yieldBudget: 0.5 }), RangeError)
     })
 
     it('returns all and mapAll child values directly in input order', async () => {
@@ -1231,6 +1233,17 @@ describe('Fork', () => {
 
       assert.deepEqual(tuple, [1, 'two'])
       assert.deepEqual(mapped, [6, 2, 4])
+    })
+
+    it('dispatches structurally equivalent policies by tag', async () => {
+      const policy = { tag: 'all' } as const satisfies typeof allPolicy
+
+      const result = await concurrently(policy, [ok(1), ok(2)]).pipe(
+        withCoopConcurrency(),
+        runPromise
+      )
+
+      assert.deepEqual(result, [1, 2])
     })
 
     it('uses tagged first-settled race semantics and cancels losers', async () => {

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -3,10 +3,11 @@ import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { RaceAllFailed, all, bounded, defaultAll, firstSettled, firstSuccess, fork, forkEach, mapAll, race, unbounded } from './Concurrent.js'
+import { RaceAllFailed, all, bounded, cooperativeAll, defaultAll, firstSettled, firstSuccess, fork, forkEach, mapAll, race, unbounded } from './Concurrent.js'
 import { andFinally, andFinallyExit } from './Finalization.js'
-import { bracket, flatMap, fx, ok, runPromise } from './Fx.js'
+import { bracket, flatMap, fx, ok, runPromise, runTask } from './Fx.js'
 import { handle } from './Handler.js'
+import { uninterruptible } from './Interrupt.js'
 import { scope, withScope, type Exit } from './Scope.js'
 import { Task, wait } from './Task.js'
 import { getTrace, snapshotError } from './Trace.js'
@@ -234,6 +235,33 @@ describe('Fork', () => {
       assert.deepEqual(events.slice(0, 3), ['start 1', 'start 2', 'start 3'])
     })
 
+    it('continues ready children while another child waits on async work', async () => {
+      class Step extends Effect('test/Fork/AllAsyncQueue')<string, void> { }
+      const events = [] as string[]
+      let releaseSlow!: () => void
+      const slow = assertPromise<string>(() => new Promise(resolve => {
+        releaseSlow = () => resolve('slow')
+      }))
+      const fast = fx(function* () {
+        yield* new Step('fast')
+        return 'fast'
+      })
+
+      const promise = all([slow, fast]).pipe(
+        defaultAll,
+        handle(Step, step => fx(function* () {
+          events.push(step.arg)
+        })),
+        unbounded,
+        runPromise
+      )
+
+      await eventually(() => events.includes('fast'))
+      releaseSlow()
+
+      assert.deepEqual(await promise, ['slow', 'fast'])
+    })
+
     it('cancels sibling tasks when a child fails', async () => {
       const cause = new Error('all failed')
       let cancelled = false
@@ -258,6 +286,81 @@ describe('Fork', () => {
       assert.ok(Fail.is(result))
       assert.equal((result.arg as Error).cause, cause)
       assert.equal(cancelled, true)
+    })
+
+    it('converts rejected async work into recoverable failure', async () => {
+      const cause = new Error('all async rejected')
+
+      const result = await all([assertPromise(() => Promise.reject(cause))]).pipe(
+        defaultAll,
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const snapshot = snapshotError(result.arg)
+      assert.equal(snapshot.code, 'FX_AWAITED_ASYNC_FAILED')
+      assert.equal(snapshot.cause?.message, 'all async rejected')
+    })
+
+    it('aborts parked async children when the parent task is interrupted', async () => {
+      let started = false
+      let aborted = false
+      const parked = assertPromise<void>(signal => new Promise(resolve => {
+        started = true
+        signal.addEventListener('abort', () => {
+          aborted = true
+          resolve()
+        }, { once: true })
+      }))
+
+      const task = all([parked]).pipe(
+        defaultAll,
+        unbounded,
+        runTask
+      )
+
+      await eventually(() => started)
+      await task.interrupt()
+
+      assert.equal(aborted, true)
+    })
+
+    it('defers sibling cancellation while a child is interruption-masked', async () => {
+      const events = [] as string[]
+      const cause = new Error('masked all failed')
+      let releaseMasked!: () => void
+
+      const masked = uninterruptible(fx(function* () {
+        events.push('masked start')
+        yield* assertPromise<void>(() => new Promise(resolve => {
+          releaseMasked = () => resolve()
+        }))
+        events.push('masked released')
+      }))
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const promise = all([masked, bad]).pipe(
+        defaultAll,
+        returnFail,
+        unbounded,
+        runPromise
+      )
+
+      await eventually(() => events.includes('masked start'))
+      await new Promise(resolve => setImmediate(resolve))
+      assert.deepEqual(events, ['masked start'])
+
+      releaseMasked()
+      const result = await promise
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.deepEqual(events, ['masked start', 'masked released'])
     })
 
     it('runs children with handlers between all and defaultAll', async () => {
@@ -556,6 +659,328 @@ describe('Fork', () => {
         defaultAll,
         returnFail,
         unbounded,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const error: Error = result.arg
+      assert.equal(error.cause, cause)
+    })
+  })
+
+  describe('cooperativeAll', () => {
+    it('rejects invalid options', () => {
+      assert.throws(() => cooperativeAll({ concurrency: 0 }), RangeError)
+      assert.throws(() => cooperativeAll({ yieldBudget: 0 }), RangeError)
+    })
+
+    it('returns child values directly in input order', async () => {
+      const result = await all([ok(1), asyncValue('two')]).pipe(
+        cooperativeAll(),
+        runPromise
+      )
+
+      assert.deepEqual(result, [1, 'two'])
+    })
+
+    it('maps iterable items to child values in input order', async () => {
+      const result = await mapAll([3, 1, 2], n => asyncValue(n * 2)).pipe(
+        cooperativeAll(),
+        runPromise
+      )
+
+      assert.deepEqual(result, [6, 2, 4])
+    })
+
+    it('starts children up to the configured concurrency', async () => {
+      const events = [] as string[]
+      const child = (n: number) => fx(function* () {
+        events.push(`start ${n}`)
+        yield* asyncValue(undefined)
+        events.push(`end ${n}`)
+        return n
+      })
+
+      const result = await all([child(1), child(2), child(3)]).pipe(
+        cooperativeAll({ concurrency: 2 }),
+        runPromise
+      )
+
+      assert.deepEqual(result, [1, 2, 3])
+      assert.deepEqual(events, ['start 1', 'start 2', 'end 1', 'end 2', 'start 3', 'end 3'])
+    })
+
+    it('interleaves ready children according to the yield budget', async () => {
+      class Step extends Effect('test/Fork/CooperativeAllStep')<string, void> { }
+      const events = [] as string[]
+      const child = (label: string) => fx(function* () {
+        yield* new Step(`${label}1`)
+        yield* new Step(`${label}2`)
+        return label
+      })
+
+      const result = await all([child('A'), child('B')]).pipe(
+        cooperativeAll({ yieldBudget: 1 }),
+        handle(Step, step => fx(function* () {
+          events.push(step.arg)
+        })),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['A', 'B'])
+      assert.deepEqual(events, ['A1', 'B1', 'A2', 'B2'])
+    })
+
+    it('continues ready children while another child waits on async work', async () => {
+      class Step extends Effect('test/Fork/CooperativeAllAsyncQueue')<string, void> { }
+      const events = [] as string[]
+      let releaseSlow!: () => void
+      const slow = assertPromise<string>(() => new Promise(resolve => {
+        releaseSlow = () => resolve('slow')
+      }))
+      const fast = fx(function* () {
+        yield* new Step('fast')
+        return 'fast'
+      })
+
+      const promise = all([slow, fast]).pipe(
+        cooperativeAll(),
+        handle(Step, step => fx(function* () {
+          events.push(step.arg)
+        })),
+        runPromise
+      )
+
+      await eventually(() => events.includes('fast'))
+      releaseSlow()
+
+      assert.deepEqual(await promise, ['slow', 'fast'])
+    })
+
+    it('runs children with handlers between all and cooperativeAll', async () => {
+      class CurrentValue extends Effect('test/Fork/CooperativeAllCurrentValue')<void, string> { }
+
+      const result = await all([new CurrentValue()]).pipe(
+        handle(CurrentValue, () => ok('handled')),
+        cooperativeAll(),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['handled'])
+    })
+
+    it('runs mapped children with handlers between mapAll and cooperativeAll', async () => {
+      class CurrentValue extends Effect('test/Fork/CooperativeMapAllCurrentValue')<void, string> { }
+
+      const result = await mapAll([1], () => new CurrentValue()).pipe(
+        handle(CurrentValue, () => ok('handled')),
+        cooperativeAll(),
+        runPromise
+      )
+
+      assert.deepEqual(result, ['handled'])
+    })
+
+    it('cancels sibling async work when a child fails', async () => {
+      const cause = new Error('cooperative all failed')
+      let cancelled = false
+      const slow = assertPromise<void>(signal => new Promise(resolve => {
+        signal.addEventListener('abort', () => {
+          cancelled = true
+          resolve()
+        }, { once: true })
+      }))
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow, bad]).pipe(
+        cooperativeAll(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.equal(cancelled, true)
+    })
+
+    it('converts rejected async work into recoverable failure', async () => {
+      const cause = new Error('cooperative async rejected')
+
+      const result = await all([assertPromise(() => Promise.reject(cause))]).pipe(
+        cooperativeAll(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      const snapshot = snapshotError(result.arg)
+      assert.equal(snapshot.code, 'FX_AWAITED_ASYNC_FAILED')
+      assert.equal(snapshot.cause?.message, 'cooperative async rejected')
+      assert.equal((result.arg as Error).cause, cause)
+    })
+
+    it('aborts parked async children when the parent task is interrupted', async () => {
+      let aborted = false
+      const parked = assertPromise<void>(signal => new Promise(resolve => {
+        signal.addEventListener('abort', () => {
+          aborted = true
+          resolve()
+        }, { once: true })
+      }))
+
+      const task = all([parked]).pipe(
+        cooperativeAll(),
+        runTask
+      )
+
+      await task.interrupt()
+
+      assert.equal(aborted, true)
+    })
+
+    it('preserves basic diagnostic shape for child failures', async () => {
+      const cause = new Error('cooperative traced failure')
+
+      const result = await all([fx(function* () {
+        yield* fail(cause)
+      })]).pipe(
+        cooperativeAll(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.match(firstLine(result.arg), /fx\/Fail\/fail/)
+      assert.deepEqual(traceMessages(result.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/all[0]', 'fx/Concurrent/all'])
+      assert.equal((result.arg as Error).cause, cause)
+    })
+
+    it('runs scoped finalizers when cancelling a sibling', async () => {
+      const TestScope = scope('test/Fork/CooperativeAllCancelScope')
+      const released = [] as string[]
+      const cause = new Error('cooperative all failed')
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          released.push('slow')
+        }))
+        yield* awaitAbort()
+      })
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow, bad]).pipe(
+        cooperativeAll(),
+        withScope(TestScope),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.deepEqual(released, ['slow'])
+    })
+
+    it('aggregates cleanup failures with the primary failure first', async () => {
+      const cause = new Error('cooperative all failed')
+      const releaseFailure = new Error('cooperative release failed')
+      const slow = bracket(
+        ok(undefined),
+        () => fail(releaseFailure),
+        () => awaitAbort()
+      )
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const result = await all([slow, bad]).pipe(
+        cooperativeAll(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.ok(result.arg instanceof AggregateError)
+      assert.equal(result.arg.message, 'Resource release failed')
+      assert.equal((result.arg.errors[0] as Error).cause, cause)
+      assert.deepEqual(result.arg.errors.slice(1), [releaseFailure])
+    })
+
+    it('preserves mapAll indexed child failure traces', async () => {
+      const cause = new Error('cooperative mapAll traced failure')
+
+      const result = await mapAll([cause], error => fx(function* () {
+        yield* fail(error)
+      })).pipe(
+        cooperativeAll(),
+        returnFail,
+        runPromise
+      )
+
+      assert.ok(Fail.is(result))
+      assert.match(firstLine(result.arg), /fx\/Fail\/fail/)
+      assert.deepEqual(traceMessages(result.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
+      assert.equal((result.arg as Error).cause, cause)
+    })
+
+    it('defers sibling cancellation while a child is interruption-masked', async () => {
+      const TestScope = scope('test/Fork/CooperativeAllMaskedCancelScope')
+      const events = [] as string[]
+      const cause = new Error('cooperative masked all failed')
+      let releaseMasked!: () => void
+
+      const masked = uninterruptible(fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          events.push('released')
+        }))
+        events.push('masked start')
+        yield* assertPromise<void>(() => new Promise(resolve => {
+          releaseMasked = () => resolve()
+        }))
+        events.push('masked end')
+      }))
+      const bad = fx(function* () {
+        yield* asyncValue(undefined)
+        yield* fail(cause)
+      })
+
+      const promise = all([masked, bad]).pipe(
+        cooperativeAll(),
+        withScope(TestScope),
+        returnFail,
+        runPromise
+      )
+
+      await eventually(() => events.includes('masked start'))
+      await new Promise(resolve => setImmediate(resolve))
+      assert.deepEqual(events, ['masked start'])
+
+      releaseMasked()
+      const result = await promise
+
+      assert.ok(Fail.is(result))
+      assert.equal((result.arg as Error).cause, cause)
+      assert.deepEqual(events, ['masked start', 'masked end', 'released'])
+    })
+
+    it('types all as a value tuple and preserves child Fail errors', async () => {
+      const cause = new Error('cooperative typed failure')
+      const result = await fx(function* () {
+        const values = yield* all([ok(1), fail(cause)])
+        const tuple: readonly [number, never] = values
+        // @ts-expect-error cooperative all returns values directly, not a Task.
+        const task: Task<readonly [number, never], Fail<Error>> = values
+        void task
+        return tuple
+      }).pipe(
+        cooperativeAll(),
+        returnFail,
         runPromise
       )
 

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -990,6 +990,41 @@ describe('Fork', () => {
       assert.deepEqual(events, ['cleanup before', 'cleanup fork child', 'cleanup after'])
     })
 
+    it('runs cleanup fork children with handlers outside withCoopConcurrency', async () => {
+      const TestScope = scope('test/Fork/CooperativeCleanupForkOuterHandlerScope')
+      class CurrentValue extends Effect('test/Fork/CooperativeCleanupForkCurrentValue')<void, string> { }
+      const events = [] as string[]
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          events.push('cleanup before')
+          const task = yield* fork(new CurrentValue())
+          events.push(yield* wait(task))
+          events.push('cleanup after')
+        }))
+        yield* awaitAbort()
+      })
+
+      const program = race([
+        slow,
+        assertPromise<string>(() => new Promise(resolve => setImmediate(() => resolve('winner'))))
+      ]).pipe(
+        withCoopConcurrency(),
+        handle(CurrentValue, () => ok('handled')),
+        withScope(TestScope),
+        returnFail
+      )
+      // The runtime handles cleanup-yielded concurrency through captured handlers;
+      // the current effect type cannot express that cleanup-only narrowing.
+      const result = await (program as Fx<Async | HandlerCapture<string>, string | void | Fail<AggregateError>>).pipe(
+        runPromise
+      )
+
+      assert.ok(!Fail.is(result))
+      assert.equal(result, 'winner')
+      assert.deepEqual(events, ['cleanup before', 'handled', 'cleanup after'])
+    })
+
     it('aggregates cleanup failures with the primary failure first', async () => {
       const cause = new Error('cooperative all failed')
       const releaseFailure = new Error('cooperative release failed')

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -1,12 +1,13 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { assertPromise } from './Async.js'
+import { assertPromise, type Async } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { RaceAllFailed, all, allPolicy, concurrently, firstSettledPolicy, firstSuccessPolicy, withBoundedConcurrency, withCoopConcurrency, firstSettled, firstSuccess, fork, forkEach, mapAll, race, withUnboundedConcurrency } from './Concurrent.js'
 import { andFinally, andFinallyExit } from './Finalization.js'
-import { bracket, flatMap, fx, ok, runPromise, runTask } from './Fx.js'
+import { bracket, flatMap, fx, ok, runPromise, runTask, type Fx } from './Fx.js'
 import { handle } from './Handler.js'
+import { closeHandlerCapture, type HandlerCapture } from './HandlerCapture.js'
 import { uninterruptible } from './Interrupt.js'
 import { scope, withScope, type Exit } from './Scope.js'
 import { Task, wait } from './Task.js'
@@ -733,6 +734,7 @@ describe('Fork', () => {
       })
 
       const result = await all([child('A'), child('B')]).pipe(
+        closeHandlerCapture('fx/Concurrent/Concurrently'),
         withCoopConcurrency({ yieldBudget: 1 }),
         handle(Step, step => fx(function* () {
           events.push(step.arg)
@@ -917,6 +919,75 @@ describe('Fork', () => {
       assert.ok(Fail.is(result))
       assert.equal((result.arg as Error).cause, cause)
       assert.deepEqual(released, ['slow'])
+    })
+
+    it('runs structured concurrency yielded by outer cleanup handlers', async () => {
+      const TestScope = scope('test/Fork/CooperativeCleanupStructuredScope')
+      const events = [] as string[]
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          events.push('cleanup before')
+          yield* all([fx(function* () {
+            events.push('cleanup all child')
+          })])
+          events.push('cleanup after')
+        }))
+        yield* awaitAbort()
+      })
+
+      const program = race([
+        slow,
+        assertPromise<string>(() => new Promise(resolve => setImmediate(() => resolve('winner'))))
+      ]).pipe(
+        withCoopConcurrency(),
+        withScope(TestScope),
+        returnFail
+      )
+      // The runtime handles cleanup-yielded concurrency through captured handlers;
+      // the current effect type cannot express that cleanup-only narrowing.
+      const result = await (program as Fx<Async | HandlerCapture<string>, string | void | Fail<AggregateError>>).pipe(
+        runPromise
+      )
+
+      assert.ok(!Fail.is(result))
+      assert.equal(result, 'winner')
+      assert.deepEqual(events, ['cleanup before', 'cleanup all child', 'cleanup after'])
+    })
+
+    it('runs explicit forks yielded by outer cleanup handlers', async () => {
+      const TestScope = scope('test/Fork/CooperativeCleanupForkScope')
+      const events = [] as string[]
+
+      const slow = fx(function* () {
+        yield* andFinally(TestScope, fx(function* () {
+          events.push('cleanup before')
+          const task = yield* fork(fx(function* () {
+            events.push('cleanup fork child')
+          }))
+          yield* wait(task)
+          events.push('cleanup after')
+        }))
+        yield* awaitAbort()
+      })
+
+      const program = race([
+        slow,
+        assertPromise<string>(() => new Promise(resolve => setImmediate(() => resolve('winner'))))
+      ]).pipe(
+        withCoopConcurrency(),
+        withScope(TestScope),
+        returnFail
+      )
+      // The runtime handles cleanup-yielded concurrency through captured handlers;
+      // the current effect type cannot express that cleanup-only narrowing.
+      const result = await (program as Fx<Async | HandlerCapture<string>, string | void | Fail<AggregateError>>).pipe(
+        runPromise
+      )
+
+      assert.ok(!Fail.is(result))
+      assert.equal(result, 'winner')
+      assert.deepEqual(events, ['cleanup before', 'cleanup fork child', 'cleanup after'])
     })
 
     it('aggregates cleanup failures with the primary failure first', async () => {

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -3,13 +3,13 @@ import { at, indexed } from './Breadcrumb.js'
 import { Effect } from './Effect.js'
 import { Fail } from './Fail.js'
 import { Fx, flatMap, flatten, fx, ok } from './Fx.js'
-import { Handle } from './Handler.js'
+import { Handle, handle } from './Handler.js'
 import { HandlerCapture, handleCaptured, mapCapturedHandlers, withCapturedHandlers } from './HandlerCapture.js'
 import { Task, wait as waitTask } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
 import { Semaphore } from './internal/Semaphore.js'
-import { runCooperativeAll, runCooperativeRace, type CooperativeConfig } from './internal/cooperativeStructured.js'
+import { runCooperativeConcurrently, type CooperativeConfig } from './internal/withCoopConcurrency.js'
 import { acquireAndRunFork } from './internal/runFork.js'
 import { currentRuntimeContext } from './internal/runtimeContext.js'
 
@@ -17,7 +17,7 @@ import { currentRuntimeContext } from './internal/runtimeContext.js'
  * Request that a computation be started concurrently.
  *
  * A `Fork` request returns a {@link Task} handle. The scheduling policy is
- * supplied by handlers such as {@link bounded} or {@link unbounded}.
+ * supplied by handlers such as {@link withBoundedConcurrency} or {@link withUnboundedConcurrency}.
  */
 export class Fork extends Effect('fx/Concurrent/Fork')<ForkContext, Task<unknown, unknown>> { }
 
@@ -25,30 +25,31 @@ export interface ForkContext extends TraceOrigin {
   readonly fx: Fx<unknown, unknown>
 }
 
-/**
- * Request that a group of computations be run concurrently in a structured
- * scope, returning all results directly.
- *
- * The request describes structured concurrency. A handler decides how the
- * children are scheduled and how failures cancel siblings.
- */
-export class All<const Fxs extends readonly Fx<unknown, unknown>[]> extends Effect('fx/Concurrent/All')<ConcurrentContext<Fxs>, {
-  readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-}> { }
+export const allPolicy = { tag: 'all' } as const
+export const firstSettledPolicy = { tag: 'firstSettled' } as const
+export const firstSuccessPolicy = { tag: 'firstSuccess' } as const
+export type ConcurrentPolicy =
+  | typeof allPolicy
+  | typeof firstSettledPolicy
+  | typeof firstSuccessPolicy
 
 /**
- * Request that a group of computations be raced in a structured scope,
- * returning the first settled result directly.
- *
- * The request describes structured concurrency. A handler decides how the
- * children are scheduled and how losing children are cancelled.
+ * Request that a group of computations run concurrently with a structured
+ * settlement policy.
  */
-export class Race<const Fxs extends readonly Fx<unknown, unknown>[]> extends Effect('fx/Concurrent/Race')<ConcurrentContext<Fxs>, ResultOf<Fxs[number]>> { }
+export class Concurrently<
+  const Policy extends ConcurrentPolicy,
+  const Fxs extends readonly Fx<unknown, unknown>[]
+> extends Effect('fx/Concurrent/Concurrently')<ConcurrentContext<Policy, Fxs>, ConcurrentResult<Policy, Fxs>> { }
 
 /**
  * Context shared by structured concurrency requests.
  */
-export interface ConcurrentContext<Fxs extends readonly Fx<unknown, unknown>[]> extends TraceOrigin {
+export interface ConcurrentContext<
+  Policy extends ConcurrentPolicy,
+  Fxs extends readonly Fx<unknown, unknown>[]
+> extends TraceOrigin {
+  readonly policy: Policy
   readonly fxs: Fxs
 }
 
@@ -99,33 +100,17 @@ export const forkEach = <const Fxs extends readonly Fx<unknown, unknown>[]>(
  * Request that a tuple of Fx computations run concurrently in a structured
  * scope, returning the tuple of child results directly.
  *
- * Pair `all` with {@link defaultAll} and a fork scheduler such as
- * {@link bounded} or {@link unbounded}.
- *
  * @example
  * const [user, posts] = yield* all([fetchUser, fetchPosts])
  */
 export const all = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   fxs: Fxs,
   options?: TraceOptions
-) => {
-  const trace = traceOrigin(options, 'fx/Concurrent/all', all, 'all')
-  return mapCapturedHandlers('fx/Concurrent/All', fxs).pipe(
-    flatMap(fxs => new All({
-      fxs: fxs as unknown as Fxs,
-      ...trace
-    }))
-  ) as Fx<Exclude<EffectsOf<Fxs[number]>, Async | Fail<any>> | All<Fxs> | HandlerCapture<'fx/Concurrent/All'>, {
-    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-  }>
-}
+) => concurrently(allPolicy, fxs, traceOrigin(options, 'fx/Concurrent/all', all, 'all'))
 
 /**
  * Map an iterable to child computations and run them concurrently in input
  * order.
- *
- * Pair `mapAll` with {@link defaultAll} and a fork scheduler such as
- * {@link bounded} or {@link unbounded}.
  *
  * @example
  * const users = yield* mapAll(userIds, id => fetchUser(id))
@@ -134,7 +119,7 @@ export const mapAll = <const A, const E, const B>(
   items: Iterable<A>,
   f: (item: A, index: number) => Fx<E, B>,
   options?: TraceOptions
-): Fx<Exclude<E, Async | Fail<any>> | All<readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/All'>, readonly B[]> => {
+): Fx<Exclude<E, Async | Fail<any>> | Concurrently<typeof allPolicy, readonly Fx<E, B>[]> | HandlerCapture<'fx/Concurrent/Concurrently'>, readonly B[]> => {
   const trace = traceOrigin(options, 'fx/Concurrent/mapAll', mapAll, 'all')
   return all(Array.from(items, f), trace)
 }
@@ -142,116 +127,63 @@ export const mapAll = <const A, const E, const B>(
 /**
  * Request that a tuple of Fx computations race in a structured scope.
  *
- * Pair `race` with {@link firstSettled} for first-settled semantics or
- * {@link firstSuccess} when failed children should be ignored until all fail.
- *
  * @example
  * const value = yield* race([primary, fallback])
  */
 export const race = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   fxs: Fxs,
   options?: TraceOptions
+) => concurrently(firstSettledPolicy, fxs, traceOrigin(options, 'fx/Concurrent/race', race, 'race'))
+
+/**
+ * Request that a group of computations run concurrently with the supplied
+ * built-in policy.
+ */
+export const concurrently = <
+  const Policy extends ConcurrentPolicy,
+  const Fxs extends readonly Fx<unknown, unknown>[]
+>(
+  policy: Policy,
+  fxs: Fxs,
+  options?: TraceOptions
 ) => {
-  const trace = traceOrigin(options, 'fx/Concurrent/race', race, 'race')
-  return mapCapturedHandlers('fx/Concurrent/Race', fxs).pipe(
-    flatMap(fxs => new Race({
+  const trace = traceOrigin(options, 'fx/Concurrent/concurrently', concurrently, policyFrameKind(policy))
+  return mapCapturedHandlers('fx/Concurrent/Concurrently', fxs).pipe(
+    flatMap(fxs => new Concurrently({
+      policy,
       fxs: fxs as unknown as Fxs,
       ...trace
     }))
-  ) as Fx<Exclude<EffectsOf<Fxs[number]>, Async | Fail<any>> | Race<Fxs> | HandlerCapture<'fx/Concurrent/Race'>, ResultOf<Fxs[number]>>
+  ) as Fx<Exclude<EffectsOf<Fxs[number]>, Async | Fail<any>> | Concurrently<Policy, Fxs> | HandlerCapture<'fx/Concurrent/Concurrently'>, ConcurrentResult<Policy, Fxs>>
 }
 
-/**
- * Handle All by running all child computations concurrently in a structured
- * scope. The first child failure fails the parent and cancels siblings.
- *
- * @example
- * await all([fetchUser, fetchPosts]).pipe(
- *   defaultAll,
- *   unbounded,
- *   runPromise
- * )
- */
-export const defaultAll = <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyAll, DefaultAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A> =>
-  f.pipe(handleCaptured('fx/Concurrent/All', All, runAll)) as Fx<Handle<Handle<E, AnyAll, DefaultAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A>
-
-export interface CooperativeAllOptions {
+export interface CoopConcurrencyOptions {
   readonly concurrency?: number
   readonly yieldBudget?: number
 }
 
-export interface CooperativeStructuredOptions extends CooperativeAllOptions {
-  readonly racePolicy?: 'firstSettled' | 'firstSuccess'
-}
-
-export interface CooperativeStructuredFirstSettledOptions extends CooperativeAllOptions {
-  readonly racePolicy?: 'firstSettled'
-}
-
-export interface CooperativeStructuredFirstSuccessOptions extends CooperativeAllOptions {
-  readonly racePolicy: 'firstSuccess'
-}
-
 /**
- * Handle All with a cooperative FIFO scheduler.
- *
- * This prototype handles structured All directly instead of elaborating to
- * Fork. Child computations are stepped up to `yieldBudget` yielded operations
- * per turn, and children waiting on Async are parked until their async
- * operation settles.
+ * Provide cooperative concurrency for built-in structured concurrency policies.
  */
-export const cooperativeAll = (options: CooperativeAllOptions = {}) => {
-  const normalized = normalizeCooperativeAllOptions(options)
-  return <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A> =>
-    f.pipe(handleCaptured('fx/Concurrent/All', All, runCooperativeAll(normalized))) as Fx<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A>
-}
-
-/**
- * Handle structured All and Race effects with one cooperative FIFO scheduler.
- *
- * Race effects use first-settled semantics by default. Set `racePolicy` to
- * `firstSuccess` to evaluate Race with first-success semantics.
- */
-export function cooperativeStructured(options?: CooperativeStructuredFirstSettledOptions): <const E, const A>(f: Fx<E, A>) => Fx<CooperativeStructuredFirstSettledHandledEffects<E>, A>
-export function cooperativeStructured(options: CooperativeStructuredFirstSuccessOptions): <const E, const A>(f: Fx<E, A>) => Fx<CooperativeStructuredFirstSuccessHandledEffects<E>, A>
-export function cooperativeStructured(options: CooperativeStructuredOptions = {}): <const E, const A>(f: Fx<E, A>) => Fx<any, A> {
-  const normalized = normalizeCooperativeAllOptions(options)
-  const racePolicy = options.racePolicy ?? 'firstSettled'
-  return <const E, const A>(f: Fx<E, A>) =>
+export const withCoopConcurrency = (options: CoopConcurrencyOptions = {}) => {
+  const normalized = normalizeCoopOptions(options, 'withCoopConcurrency')
+  return <const E, const A>(f: Fx<E, A>): Fx<CoopConcurrencyHandledEffects<E>, A> =>
     f.pipe(
-      handleCaptured('fx/Concurrent/All', All, runCooperativeAll(normalized)),
-      handleCaptured('fx/Concurrent/Race', Race, runCooperativeRace(normalized, racePolicy))
-    )
+      handleCaptured('fx/Concurrent/Concurrently', Concurrently, runCooperativeConcurrently(normalized))
+    ) as Fx<CoopConcurrencyHandledEffects<E>, A>
 }
 
 /**
- * Handle Race by running child computations concurrently in a structured scope.
- * The first child to settle wins and all losers are cancelled.
- *
- * @example
- * await race([primary, fallback]).pipe(
- *   firstSettled,
- *   unbounded,
- *   runPromise
- * )
+ * Retag a structured concurrency request for first-settled race semantics.
  */
-export const firstSettled = <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyRace, DefaultRaceEffects<E>>, HandlerCapture<'fx/Concurrent/Race'>>, A> =>
-  f.pipe(handleCaptured('fx/Concurrent/Race', Race, runRace)) as Fx<Handle<Handle<E, AnyRace, DefaultRaceEffects<E>>, HandlerCapture<'fx/Concurrent/Race'>>, A>
+export const firstSettled = <const E, const A>(f: Fx<E, A>): Fx<Handle<E, AnyConcurrently, RetagConcurrently<typeof firstSettledPolicy, E> | HandlerCapture<'fx/Concurrent/Concurrently'>>, A> =>
+  f.pipe(handle(Concurrently, retagConcurrently(firstSettledPolicy))) as Fx<Handle<E, AnyConcurrently, RetagConcurrently<typeof firstSettledPolicy, E> | HandlerCapture<'fx/Concurrent/Concurrently'>>, A>
 
 /**
- * Handle Race by running child computations concurrently and returning the
- * first successful result. Child failures are ignored until every child has
- * failed, at which point the parent fails with {@link RaceAllFailed}.
- *
- * @example
- * await race([primary, replica, cache]).pipe(
- *   firstSuccess,
- *   unbounded,
- *   runPromise
- * )
+ * Retag a structured concurrency request for first-success race semantics.
  */
-export const firstSuccess = <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyRace, FirstSuccessRaceEffects<E>>, HandlerCapture<'fx/Concurrent/Race'>>, A> =>
-  f.pipe(handleCaptured('fx/Concurrent/Race', Race, runFirstSuccessRace)) as Fx<Handle<Handle<E, AnyRace, FirstSuccessRaceEffects<E>>, HandlerCapture<'fx/Concurrent/Race'>>, A>
+export const firstSuccess = <const E, const A>(f: Fx<E, A>): Fx<Handle<E, AnyConcurrently, RetagConcurrently<typeof firstSuccessPolicy, E> | HandlerCapture<'fx/Concurrent/Concurrently'>>, A> =>
+  f.pipe(handle(Concurrently, retagConcurrently(firstSuccessPolicy))) as Fx<Handle<E, AnyConcurrently, RetagConcurrently<typeof firstSuccessPolicy, E> | HandlerCapture<'fx/Concurrent/Concurrently'>>, A>
 
 /**
  * Failure returned by {@link firstSuccess} when every raced child fails.
@@ -281,27 +213,28 @@ export class RaceAllFailed<Errors extends readonly unknown[]> extends Error {
 /**
  * Handle Fork by running at most `maxConcurrency` forked computations at once.
  *
- * Structured handlers such as {@link defaultAll} and {@link firstSettled}
- * elaborate into Fork requests, so `bounded` also limits their child
- * concurrency.
- *
- * @example
- * ```ts
- * program.pipe(defaultAll, bounded(4), runPromise)
- * ```
+ * Structured concurrency policies are interpreted by forking child tasks, so
+ * `withBoundedConcurrency` also limits structured child concurrency.
  */
-export const bounded = (maxConcurrency: number) => <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, Fork>, HandlerCapture<'fx/Concurrent/Fork'>> | HandlerCapture<'fx/Concurrent/Fork'>, A> =>
+export const withBoundedConcurrency = (maxConcurrency: number) => <const E, const A>(f: Fx<E, A>): Fx<WithConcurrencyHandledEffects<E>, A> => {
+  const semaphore = new Semaphore(maxConcurrency)
+  return (
   withCapturedHandlers('fx/Concurrent/Fork', f).pipe(
     flatMap(fx =>
-      ok(fx.pipe(handleCaptured('fx/Concurrent/Fork', Fork, runForkWith(new Semaphore(maxConcurrency)))))
+      ok(fx.pipe(
+        handleCaptured('fx/Concurrent/Concurrently', Concurrently, runConcurrently),
+        handleCaptured('fx/Concurrent/Fork', Fork, runForkWith(semaphore))
+      ))
     ),
     flatten
-  ) as Fx<Handle<Handle<E, Fork>, HandlerCapture<'fx/Concurrent/Fork'>> | HandlerCapture<'fx/Concurrent/Fork'>, A>
+  ) as Fx<WithConcurrencyHandledEffects<E>, A>
+  )
+}
 
 /**
  * Handle Fork by running forked computations without a concurrency limit.
  */
-export const unbounded = bounded(Infinity)
+export const withUnboundedConcurrency = withBoundedConcurrency(Infinity)
 
 const runForkWith = (s: Semaphore) =>
   (fork: Fork): Fx<never, Task<unknown, unknown>> =>
@@ -309,6 +242,9 @@ const runForkWith = (s: Semaphore) =>
 
 const childFrameKind = (trace: Trace | undefined) =>
   trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'
+
+const policyFrameKind = (policy: ConcurrentPolicy): TraceFrameKind =>
+  policy.tag === 'all' ? 'all' : 'race'
 
 const traceOrigin = (
   options: TraceOptions | undefined,
@@ -326,50 +262,57 @@ const childTraceOrigin = (parent: TraceOrigin, index: number, kind: TraceFrameKi
   return { origin, trace: captureTrace(origin, parent.trace, { kind, index }) }
 }
 
-const runAll = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  all: All<Fxs>
-): Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-  readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-}> =>
-  forkEach(all.arg.fxs, all.arg).pipe(
-    flatMap(tasks => waitTask(taskAll(tasks)))
-  ) as Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-  readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-}>
+const runConcurrently = <const Policy extends ConcurrentPolicy, const Fxs extends readonly Fx<unknown, unknown>[]>(
+  group: Concurrently<Policy, Fxs>
+): Fx<Fork | Async | ConcurrentPolicyEffects<Policy, Fxs>, ConcurrentResult<Policy, Fxs>> =>
+  forkEach(group.arg.fxs, group.arg).pipe(
+    flatMap(tasks => waitTask(taskForPolicy(group.arg.policy, tasks)))
+  ) as Fx<Fork | Async | ConcurrentPolicyEffects<Policy, Fxs>, ConcurrentResult<Policy, Fxs>>
 
-const runRace = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  race: Race<Fxs>
-): Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, ResultOf<Fxs[number]>> =>
-  forkEach(race.arg.fxs, race.arg).pipe(
-    flatMap(tasks => waitTask(taskRace(tasks)))
-  ) as Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, ResultOf<Fxs[number]>>
+const retagConcurrently = <const Policy extends ConcurrentPolicy>(policy: Policy) =>
+  <const CurrentPolicy extends ConcurrentPolicy, const Fxs extends readonly Fx<unknown, unknown>[]>(
+    group: Concurrently<CurrentPolicy, Fxs>
+  ): Fx<Concurrently<Policy, Fxs> | HandlerCapture<'fx/Concurrent/Concurrently'>, ConcurrentResult<Policy, Fxs>> =>
+    mapCapturedHandlers('fx/Concurrent/Concurrently', group.arg.fxs).pipe(
+      flatMap(fxs => new Concurrently({
+        ...group.arg,
+        policy,
+        fxs: fxs as unknown as Fxs
+      }))
+    ) as Fx<Concurrently<Policy, Fxs> | HandlerCapture<'fx/Concurrent/Concurrently'>, ConcurrentResult<Policy, Fxs>>
 
-const runFirstSuccessRace = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  race: Race<Fxs>
-): Fx<Fork | Async | FirstSuccessRaceFailure<Race<Fxs>>, ResultOf<Fxs[number]>> =>
-  forkEach(race.arg.fxs, race.arg).pipe(
-    flatMap(tasks => waitTask(taskFirstSuccess(tasks)))
-  ) as Fx<Fork | Async | FirstSuccessRaceFailure<Race<Fxs>>, ResultOf<Fxs[number]>>
+const taskForPolicy = <const Policy extends ConcurrentPolicy, Tasks extends readonly Task<unknown, unknown>[]>(
+  policy: Policy,
+  tasks: Tasks
+): Task<ConcurrentTaskResult<Policy, Tasks>, ConcurrentTaskErrors<Policy, Tasks>> => {
+  switch (policy.tag) {
+    case 'all': return taskAll(tasks) as Task<ConcurrentTaskResult<Policy, Tasks>, ConcurrentTaskErrors<Policy, Tasks>>
+    case 'firstSettled': return taskRace(tasks) as Task<ConcurrentTaskResult<Policy, Tasks>, ConcurrentTaskErrors<Policy, Tasks>>
+    case 'firstSuccess': return taskFirstSuccess(tasks) as Task<ConcurrentTaskResult<Policy, Tasks>, ConcurrentTaskErrors<Policy, Tasks>>
+  }
+}
 
 export type EffectsOf<F> = F extends Fx<infer E, unknown> ? E : never
 export type ResultOf<F> = F extends Fx<unknown, infer A> ? A : never
 export type ErrorsOf<E> = Extract<E, Fail<any>>
 
-type AnyAll = All<any>
-type AnyRace = Race<any>
-type EffectsOfAll<E> = E extends All<infer Fxs> ? EffectsOf<Fxs[number]> : never
-type EffectsOfRace<E> = E extends Race<infer Fxs> ? EffectsOf<Fxs[number]> : never
-type DefaultAllEffects<E> = Fork | Async | ErrorsOf<EffectsOfAll<E>>
-type CooperativeAllEffects<E> = Async | ErrorsOf<EffectsOfAll<E>>
-type DefaultRaceEffects<E> = Fork | Async | ErrorsOf<EffectsOfRace<E>>
-type FirstSuccessRaceEffects<E> = Fork | Async | FirstSuccessRaceFailure<E>
-type CooperativeStructuredFirstSettledHandledEffects<E> =
-  Handle<Handle<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, AnyRace, Async | ErrorsOf<EffectsOfRace<E>>>, HandlerCapture<'fx/Concurrent/All'>>, HandlerCapture<'fx/Concurrent/Race'>>
-type CooperativeStructuredFirstSuccessHandledEffects<E> =
-  Handle<Handle<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, AnyRace, Async | FirstSuccessRaceFailure<E>>, HandlerCapture<'fx/Concurrent/All'>>, HandlerCapture<'fx/Concurrent/Race'>>
-type FirstSuccessRaceFailure<E> = E extends Race<infer Fxs>
-  ? EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
-  : never
+type AnyConcurrently = Concurrently<any, any>
+type RetagConcurrently<Policy extends ConcurrentPolicy, E> = E extends Concurrently<any, infer Fxs> ? Concurrently<Policy, Fxs> : never
+type ConcurrentPolicyEffects<Policy extends ConcurrentPolicy, Fxs extends readonly Fx<unknown, unknown>[]> =
+  Policy['tag'] extends 'firstSuccess'
+  ? FirstSuccessFailure<Fxs>
+  : ErrorsOf<EffectsOf<Fxs[number]>>
+export type ConcurrentResult<Policy extends ConcurrentPolicy, Fxs extends readonly Fx<unknown, unknown>[]> =
+  Policy['tag'] extends 'all'
+  ? { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }
+  : ResultOf<Fxs[number]>
+type ConcurrentEffects<E> = E extends Concurrently<infer Policy, infer Fxs> ? Async | ConcurrentPolicyEffects<Policy, Fxs> : never
+type WithConcurrencyHandledEffects<E> =
+  Handle<Handle<Handle<E, AnyConcurrently, Fork | Async | ConcurrentEffects<E>>, Fork>, HandlerCapture<'fx/Concurrent/Fork'> | HandlerCapture<'fx/Concurrent/Concurrently'>>
+type CoopConcurrencyHandledEffects<E> =
+  Handle<Handle<E, AnyConcurrently, ConcurrentEffects<E>>, HandlerCapture<'fx/Concurrent/Concurrently'>>
+type FirstSuccessFailure<Fxs extends readonly Fx<unknown, unknown>[]> =
+  EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
 type EveryFxCanFail<Fxs extends readonly Fx<unknown, unknown>[]> = Fxs extends readonly []
   ? true
   : number extends Fxs['length']
@@ -391,6 +334,14 @@ type TaskErrors<P> = P extends Task<unknown, infer E> ? E : never
 type TaskErrorsOf<Tasks extends readonly Task<unknown, unknown>[]> = {
   readonly [K in keyof Tasks]: TaskErrors<Tasks[K]>
 }
+type ConcurrentTaskResult<Policy extends ConcurrentPolicy, Tasks extends readonly Task<unknown, unknown>[]> =
+  Policy['tag'] extends 'all'
+  ? { readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }
+  : TaskResult<Tasks[number]>
+type ConcurrentTaskErrors<Policy extends ConcurrentPolicy, Tasks extends readonly Task<unknown, unknown>[]> =
+  Policy['tag'] extends 'firstSuccess'
+  ? RaceAllFailed<TaskErrorsOf<Tasks>>
+  : TaskErrors<Tasks[number]>
 
 const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
   tasks.forEach(t => t._markHandled())
@@ -410,11 +361,11 @@ const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) 
   return new Task(p, reason => { void d.interrupt(reason) }, currentRuntimeContext(), d.interrupted) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
 }
 
-const normalizeCooperativeAllOptions = (options: CooperativeAllOptions): CooperativeConfig => {
+const normalizeCoopOptions = (options: CoopConcurrencyOptions, handlerName: string): CooperativeConfig => {
   const concurrency = options.concurrency ?? Infinity
   const yieldBudget = options.yieldBudget ?? 64
-  if (concurrency <= 0) throw new RangeError(`cooperativeAll concurrency must be > 0, got ${concurrency}`)
-  if (yieldBudget <= 0) throw new RangeError(`cooperativeAll yieldBudget must be > 0, got ${yieldBudget}`)
+  if (concurrency <= 0) throw new RangeError(`${handlerName} concurrency must be > 0, got ${concurrency}`)
+  if (yieldBudget <= 0) throw new RangeError(`${handlerName} yieldBudget must be > 0, got ${yieldBudget}`)
   return {
     concurrency: Math.floor(concurrency),
     yieldBudget: Math.floor(yieldBudget)

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -1,19 +1,17 @@
 import { Async } from './Async.js'
 import { at, indexed } from './Breadcrumb.js'
 import { Effect } from './Effect.js'
-import { Fail, fail } from './Fail.js'
+import { Fail } from './Fail.js'
 import { Fx, flatMap, flatten, fx, ok } from './Fx.js'
 import { Handle } from './Handler.js'
 import { HandlerCapture, handleCaptured, mapCapturedHandlers, withCapturedHandlers } from './HandlerCapture.js'
 import { Task, wait as waitTask } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
-import { Trace, captureTrace, getTrace } from './Trace.js'
+import { Trace, captureTrace } from './Trace.js'
 import { Semaphore } from './internal/Semaphore.js'
-import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './internal/forkDiagnostics.js'
-import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './internal/interrupt.js'
-import { withInterpretedReturn } from './internal/iteratorClose.js'
+import { runCooperativeAll, runCooperativeRace, type CooperativeConfig } from './internal/cooperativeStructured.js'
 import { acquireAndRunFork } from './internal/runFork.js'
-import { currentRuntimeContext, getRuntimeContext, withActiveRuntimeContext } from './internal/runtimeContext.js'
+import { currentRuntimeContext } from './internal/runtimeContext.js'
 
 /**
  * Request that a computation be started concurrently.
@@ -182,6 +180,18 @@ export interface CooperativeAllOptions {
   readonly yieldBudget?: number
 }
 
+export interface CooperativeStructuredOptions extends CooperativeAllOptions {
+  readonly racePolicy?: 'firstSettled' | 'firstSuccess'
+}
+
+export interface CooperativeStructuredFirstSettledOptions extends CooperativeAllOptions {
+  readonly racePolicy?: 'firstSettled'
+}
+
+export interface CooperativeStructuredFirstSuccessOptions extends CooperativeAllOptions {
+  readonly racePolicy: 'firstSuccess'
+}
+
 /**
  * Handle All with a cooperative FIFO scheduler.
  *
@@ -194,6 +204,24 @@ export const cooperativeAll = (options: CooperativeAllOptions = {}) => {
   const normalized = normalizeCooperativeAllOptions(options)
   return <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A> =>
     f.pipe(handleCaptured('fx/Concurrent/All', All, runCooperativeAll(normalized))) as Fx<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A>
+}
+
+/**
+ * Handle structured All and Race effects with one cooperative FIFO scheduler.
+ *
+ * Race effects use first-settled semantics by default. Set `racePolicy` to
+ * `firstSuccess` to evaluate Race with first-success semantics.
+ */
+export function cooperativeStructured(options?: CooperativeStructuredFirstSettledOptions): <const E, const A>(f: Fx<E, A>) => Fx<CooperativeStructuredFirstSettledHandledEffects<E>, A>
+export function cooperativeStructured(options: CooperativeStructuredFirstSuccessOptions): <const E, const A>(f: Fx<E, A>) => Fx<CooperativeStructuredFirstSuccessHandledEffects<E>, A>
+export function cooperativeStructured(options: CooperativeStructuredOptions = {}): <const E, const A>(f: Fx<E, A>) => Fx<any, A> {
+  const normalized = normalizeCooperativeAllOptions(options)
+  const racePolicy = options.racePolicy ?? 'firstSettled'
+  return <const E, const A>(f: Fx<E, A>) =>
+    f.pipe(
+      handleCaptured('fx/Concurrent/All', All, runCooperativeAll(normalized)),
+      handleCaptured('fx/Concurrent/Race', Race, runCooperativeRace(normalized, racePolicy))
+    )
 }
 
 /**
@@ -335,6 +363,10 @@ type DefaultAllEffects<E> = Fork | Async | ErrorsOf<EffectsOfAll<E>>
 type CooperativeAllEffects<E> = Async | ErrorsOf<EffectsOfAll<E>>
 type DefaultRaceEffects<E> = Fork | Async | ErrorsOf<EffectsOfRace<E>>
 type FirstSuccessRaceEffects<E> = Fork | Async | FirstSuccessRaceFailure<E>
+type CooperativeStructuredFirstSettledHandledEffects<E> =
+  Handle<Handle<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, AnyRace, Async | ErrorsOf<EffectsOfRace<E>>>, HandlerCapture<'fx/Concurrent/All'>>, HandlerCapture<'fx/Concurrent/Race'>>
+type CooperativeStructuredFirstSuccessHandledEffects<E> =
+  Handle<Handle<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, AnyRace, Async | FirstSuccessRaceFailure<E>>, HandlerCapture<'fx/Concurrent/All'>>, HandlerCapture<'fx/Concurrent/Race'>>
 type FirstSuccessRaceFailure<E> = E extends Race<infer Fxs>
   ? EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
   : never
@@ -378,31 +410,7 @@ const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) 
   return new Task(p, reason => { void d.interrupt(reason) }, currentRuntimeContext(), d.interrupted) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
 }
 
-interface CooperativeAllConfig {
-  readonly concurrency: number
-  readonly yieldBudget: number
-}
-
-type Resume =
-  | { readonly type: 'next', readonly value: unknown }
-  | { readonly type: 'throw', readonly error: unknown }
-
-interface Fiber {
-  readonly index: number
-  readonly iterator: Iterator<unknown, unknown, unknown>
-  readonly traceOrigin: TraceOrigin
-  readonly masks: InterruptMaskState
-  status: 'ready' | 'waiting' | 'done'
-  resume: Resume
-  abort?: AbortController
-  cancelRequested: boolean
-  cleanupFailures: unknown[]
-}
-
-type PrimaryFailure =
-  | { readonly error: unknown }
-
-const normalizeCooperativeAllOptions = (options: CooperativeAllOptions): CooperativeAllConfig => {
+const normalizeCooperativeAllOptions = (options: CooperativeAllOptions): CooperativeConfig => {
   const concurrency = options.concurrency ?? Infinity
   const yieldBudget = options.yieldBudget ?? 64
   if (concurrency <= 0) throw new RangeError(`cooperativeAll concurrency must be > 0, got ${concurrency}`)
@@ -412,314 +420,6 @@ const normalizeCooperativeAllOptions = (options: CooperativeAllOptions): Coopera
     yieldBudget: Math.floor(yieldBudget)
   }
 }
-
-const runCooperativeAll = (config: CooperativeAllConfig) =>
-  <const Fxs extends readonly Fx<unknown, unknown>[]>(
-    all: All<Fxs>
-  ): Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-  }> => cooperativeAllFx(all, config) as Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-  }>
-
-const cooperativeAllFx = <const Fxs extends readonly Fx<unknown, unknown>[]>(
-  all: All<Fxs>,
-  config: CooperativeAllConfig
-) => fx(function* () {
-  const fxs = all.arg.fxs
-  const results = [] as unknown[]
-  const fibers = [] as Fiber[]
-  const ready = [] as Fiber[]
-  const wake = new Wake()
-  const context = getRuntimeContext(all)
-  const parentTraceOrigin = {
-    origin: all.arg.origin,
-    trace: all.arg.trace ?? captureTraceWithContext(context, all.arg.origin, undefined, { kind: 'all' })
-  }
-  const childKind = childFrameKind(parentTraceOrigin.trace)
-  let next = 0
-  let active = 0
-  let completed = false
-  let primaryFailure: PrimaryFailure | undefined
-
-  const startNext = () => {
-    while (primaryFailure === undefined && active < config.concurrency && next < fxs.length) {
-      const fiber: Fiber = {
-        index: next,
-        iterator: fxs[next][Symbol.iterator](),
-        traceOrigin: childTraceOriginWithContext(context, parentTraceOrigin, next, childKind),
-        masks: new InterruptMaskState(),
-        status: 'ready',
-        resume: { type: 'next', value: undefined },
-        cancelRequested: false,
-        cleanupFailures: []
-      }
-      next++
-      active++
-      fibers.push(fiber)
-      ready.push(fiber)
-    }
-  }
-
-  const finish = (fiber: Fiber) => {
-    if (fiber.status === 'done') return
-    fiber.status = 'done'
-    fiber.abort?.abort()
-    active--
-  }
-
-  const failFiber = (fiber: Fiber, failure: PrimaryFailure) => {
-    finish(fiber)
-    primaryFailure ??= failure
-    cancelActiveFibers(fibers, fiber)
-  }
-
-  try {
-    while (fxs.length !== fibers.filter(f => f.status === 'done').length || next < fxs.length) {
-      startNext()
-
-      if (ready.length === 0) {
-        if (active === 0) break
-        ready.push(...(yield* wake.wait()))
-        continue
-      }
-
-      const fiber = ready.shift()!
-      if (fiber.status !== 'ready') continue
-      if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-        yield* closeFiber(fiber)
-        finish(fiber)
-        continue
-      }
-
-      let budget = config.yieldBudget
-      while (budget > 0 && fiber.status === 'ready') {
-        budget--
-        let ir: IteratorResult<unknown, unknown>
-        try {
-          ir = fiber.resume.type === 'throw'
-            ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
-            : fiber.iterator.next(fiber.resume.value)
-        } catch (e) {
-          failFiber(fiber, { error: wrapThrownFiberError(fiber, e) })
-          break
-        }
-        fiber.resume = { type: 'next', value: undefined }
-
-        if (ir.done) {
-          results[fiber.index] = ir.value
-          finish(fiber)
-          break
-        }
-
-        if (Async.is(ir.value)) {
-          startCooperativeAsync(fiber, ir.value, wake, failFiber)
-          break
-        }
-
-        if (Fail.is(ir.value)) {
-          failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) })
-          break
-        }
-
-        if (InterruptMaskBegin.is(ir.value)) {
-          fiber.masks.mask(ir.value.arg)
-          fiber.resume = { type: 'next', value: undefined }
-          continue
-        }
-
-        if (InterruptMaskEnd.is(ir.value)) {
-          fiber.masks.unmask(ir.value.arg)
-          if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-            yield* closeFiber(fiber)
-            finish(fiber)
-            break
-          }
-          fiber.resume = { type: 'next', value: undefined }
-          continue
-        }
-
-        fiber.resume = { type: 'next', value: yield ir.value as any }
-      }
-
-      if (fiber.status === 'ready') ready.push(fiber)
-    }
-
-    completed = true
-
-    if (primaryFailure !== undefined) {
-      cancelActiveFibers(fibers)
-      for (const fiber of fibers) {
-        if (fiber.status !== 'done') {
-          yield* closeFiber(fiber)
-          finish(fiber)
-        }
-      }
-
-      const cleanupFailures = fibers.flatMap(fiber => fiber.cleanupFailures)
-      if (cleanupFailures.length > 0) {
-        return (yield* fail(resourceReleaseFailed([primaryFailure.error, ...cleanupFailures]))) as never
-      }
-      return (yield* fail(primaryFailure.error)) as never
-    }
-
-    return results as { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }
-  } finally {
-    if (!completed) {
-      cancelActiveFibers(fibers)
-      for (const fiber of fibers) {
-        if (fiber.status !== 'done') {
-          yield* closeFiber(fiber)
-          finish(fiber)
-        }
-      }
-    }
-  }
-})
-
-const startCooperativeAsync = (
-  fiber: Fiber,
-  async: Async,
-  wake: Wake,
-  failFiber: (fiber: Fiber, failure: PrimaryFailure) => void
-) => {
-  const abort = new AbortController()
-  fiber.abort = abort
-  fiber.status = 'waiting'
-  const context = getRuntimeContext(async)
-  const run = () => async.arg.run(abort.signal)
-  const promise = context === undefined ? run() : withActiveRuntimeContext(context, run)
-  promise.then(
-    value => {
-      if (fiber.status !== 'waiting') return
-      fiber.abort = undefined
-      fiber.resume = { type: 'next', value }
-      fiber.status = 'ready'
-      wake.ready(fiber)
-    },
-    error => {
-      if (fiber.status !== 'waiting') return
-      fiber.abort = undefined
-      failFiber(fiber, { error: wrapAsyncFiberError(fiber, async, error, context) })
-      wake.notify()
-    }
-  )
-}
-
-function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
-  fiber.abort?.abort()
-  fiber.abort = undefined
-  let ir: IteratorResult<unknown, unknown>
-  try {
-    ir = withInterpretedReturn(() => fiber.iterator.return?.() ?? { done: true, value: undefined })
-  } catch (e) {
-    fiber.cleanupFailures.push(e)
-    return
-  }
-
-  while (!ir.done) {
-    try {
-      if (Async.is(ir.value)) {
-        ir = fiber.iterator.next(yield ir.value as any)
-      } else if (Fail.is(ir.value)) {
-        fiber.cleanupFailures.push(ir.value.arg)
-        return
-      } else if (InterruptMaskBegin.is(ir.value)) {
-        fiber.masks.mask(ir.value.arg)
-        ir = fiber.iterator.next()
-      } else if (InterruptMaskEnd.is(ir.value)) {
-        fiber.masks.unmask(ir.value.arg)
-        ir = fiber.iterator.next()
-      } else {
-        ir = fiber.iterator.next(yield ir.value as any)
-      }
-    } catch (e) {
-      fiber.cleanupFailures.push(e)
-      return
-    }
-  }
-}
-
-const cancelActiveFibers = (fibers: readonly Fiber[], except?: Fiber) => {
-  for (const fiber of fibers) {
-    if (fiber === except || fiber.status === 'done') continue
-    fiber.cancelRequested = true
-    if (fiber.masks.canInterrupt) {
-      fiber.abort?.abort()
-    }
-  }
-}
-
-const wrapFiberFailure = (fiber: Fiber, failure: Fail<unknown>): ForkError => {
-  const context = runtimeContextOfEffect(failure)
-  const causeTrace = getTrace(failure.arg)
-  const trace = traceUnhandledFail(failure, causeTrace, fiber.traceOrigin.trace, context)
-  const origin = originOfUnhandledFail(failure, causeTrace)
-  return new ForkError('FX_UNHANDLED_FAILURE', 'Unhandled failure in forked task', origin, trace, context, { cause: failure.arg })
-}
-
-const wrapThrownFiberError = (fiber: Fiber, error: unknown): ForkError => {
-  const context = runtimeContextOfEffect(error)
-  return new ForkError('FX_UNHANDLED_EXCEPTION', 'Unhandled exception in forked task', fiber.traceOrigin.origin, traceWithCause(fiber.traceOrigin.trace, error, context, getTrace(error)), context, { cause: error })
-}
-
-const wrapAsyncFiberError = (fiber: Fiber, async: Async, error: unknown, fallbackContext?: ReturnType<typeof getRuntimeContext>): ForkError => {
-  const context = runtimeContextOfEffect(error, fallbackContext)
-  const asyncTrace = capturePrependTraceWithContext(context, async.arg.origin, fiber.traceOrigin.trace, { kind: 'async' })
-  return new ForkError('FX_AWAITED_ASYNC_FAILED', 'Awaited Async task failed', async.arg.origin, traceWithCause(asyncTrace, error, context, getTrace(error)), context, { cause: error })
-}
-
-const childTraceOriginWithContext = (
-  context: ReturnType<typeof getRuntimeContext>,
-  parent: TraceOrigin,
-  index: number,
-  kind: TraceFrameKind
-): TraceOrigin => {
-  const origin = indexed(parent.origin, index)
-  return { origin, trace: captureTraceWithContext(context, origin, parent.trace, { kind, index }) }
-}
-
-const throwIntoMissingIterator = (error: unknown): never => {
-  throw error
-}
-
-class Wake {
-  private readonly readyFibers = [] as Fiber[]
-  private readonly waiters = [] as (() => void)[]
-
-  ready(fiber: Fiber) {
-    this.readyFibers.push(fiber)
-    this.notify()
-  }
-
-  notify() {
-    const waiters = this.waiters.splice(0)
-    for (const waiter of waiters) waiter()
-  }
-
-  wait() {
-    return fx(function* (this: Wake) {
-      if (this.readyFibers.length === 0) {
-        yield* AsyncWait(this.waiters)
-      }
-      return this.readyFibers.splice(0)
-    }.bind(this))
-  }
-}
-
-const AsyncWait = (waiters: (() => void)[]) =>
-  new Async({
-    run: signal => new Promise<void>(resolve => {
-      const resolveOnce = () => {
-        signal.removeEventListener('abort', resolveOnce)
-        resolve()
-      }
-      signal.addEventListener('abort', resolveOnce, { once: true })
-      waiters.push(resolveOnce)
-    }),
-    origin: at('fx/Concurrent/cooperativeAll/wait', AsyncWait),
-    trace: captureTrace(at('fx/Concurrent/cooperativeAll/wait', AsyncWait), undefined, { kind: 'async' })
-  }) as Fx<Async, void>
 
 const taskRace = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
   tasks.forEach(t => t._markHandled())

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -169,9 +169,16 @@ export const withCoopConcurrency = (options: CoopConcurrencyOptions = {}) => {
   const normalized = normalizeCoopOptions(options, 'withCoopConcurrency')
   const runtime = new CooperativeRuntime(normalized)
   return <const E, const A>(f: Fx<E, A>): Fx<CoopConcurrencyHandledEffects<E>, A> =>
-    f.pipe(
-      handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently),
-      handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)
+    withCapturedHandlers(
+      'fx/Concurrent/Fork',
+      f.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently))
+    ).pipe(
+      flatMap(fx =>
+        ok(fx.pipe(
+          handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)
+        ))
+      ),
+      flatten
     ) as Fx<CoopConcurrencyHandledEffects<E>, A>
 }
 

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -1,16 +1,19 @@
 import { Async } from './Async.js'
 import { at, indexed } from './Breadcrumb.js'
 import { Effect } from './Effect.js'
-import { Fail } from './Fail.js'
+import { Fail, fail } from './Fail.js'
 import { Fx, flatMap, flatten, fx, ok } from './Fx.js'
 import { Handle } from './Handler.js'
 import { HandlerCapture, handleCaptured, mapCapturedHandlers, withCapturedHandlers } from './HandlerCapture.js'
 import { Task, wait as waitTask } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
-import { Trace, captureTrace } from './Trace.js'
+import { Trace, captureTrace, getTrace } from './Trace.js'
 import { Semaphore } from './internal/Semaphore.js'
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './internal/forkDiagnostics.js'
+import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './internal/interrupt.js'
+import { withInterpretedReturn } from './internal/iteratorClose.js'
 import { acquireAndRunFork } from './internal/runFork.js'
-import { currentRuntimeContext } from './internal/runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, withActiveRuntimeContext } from './internal/runtimeContext.js'
 
 /**
  * Request that a computation be started concurrently.
@@ -174,6 +177,25 @@ export const race = <const Fxs extends readonly Fx<unknown, unknown>[]>(
 export const defaultAll = <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyAll, DefaultAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A> =>
   f.pipe(handleCaptured('fx/Concurrent/All', All, runAll)) as Fx<Handle<Handle<E, AnyAll, DefaultAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A>
 
+export interface CooperativeAllOptions {
+  readonly concurrency?: number
+  readonly yieldBudget?: number
+}
+
+/**
+ * Handle All with a cooperative FIFO scheduler.
+ *
+ * This prototype handles structured All directly instead of elaborating to
+ * Fork. Child computations are stepped up to `yieldBudget` yielded operations
+ * per turn, and children waiting on Async are parked until their async
+ * operation settles.
+ */
+export const cooperativeAll = (options: CooperativeAllOptions = {}) => {
+  const normalized = normalizeCooperativeAllOptions(options)
+  return <const E, const A>(f: Fx<E, A>): Fx<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A> =>
+    f.pipe(handleCaptured('fx/Concurrent/All', All, runCooperativeAll(normalized))) as Fx<Handle<Handle<E, AnyAll, CooperativeAllEffects<E>>, HandlerCapture<'fx/Concurrent/All'>>, A>
+}
+
 /**
  * Handle Race by running child computations concurrently in a structured scope.
  * The first child to settle wins and all losers are cancelled.
@@ -284,8 +306,8 @@ const runAll = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   forkEach(all.arg.fxs, all.arg).pipe(
     flatMap(tasks => waitTask(taskAll(tasks)))
   ) as Fx<Fork | Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-  }>
+  readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
+}>
 
 const runRace = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   race: Race<Fxs>
@@ -310,6 +332,7 @@ type AnyRace = Race<any>
 type EffectsOfAll<E> = E extends All<infer Fxs> ? EffectsOf<Fxs[number]> : never
 type EffectsOfRace<E> = E extends Race<infer Fxs> ? EffectsOf<Fxs[number]> : never
 type DefaultAllEffects<E> = Fork | Async | ErrorsOf<EffectsOfAll<E>>
+type CooperativeAllEffects<E> = Async | ErrorsOf<EffectsOfAll<E>>
 type DefaultRaceEffects<E> = Fork | Async | ErrorsOf<EffectsOfRace<E>>
 type FirstSuccessRaceEffects<E> = Fork | Async | FirstSuccessRaceFailure<E>
 type FirstSuccessRaceFailure<E> = E extends Race<infer Fxs>
@@ -354,6 +377,349 @@ const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) 
   )
   return new Task(p, reason => { void d.interrupt(reason) }, currentRuntimeContext(), d.interrupted) as Task<{ readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }, TaskErrors<Tasks[number]>>
 }
+
+interface CooperativeAllConfig {
+  readonly concurrency: number
+  readonly yieldBudget: number
+}
+
+type Resume =
+  | { readonly type: 'next', readonly value: unknown }
+  | { readonly type: 'throw', readonly error: unknown }
+
+interface Fiber {
+  readonly index: number
+  readonly iterator: Iterator<unknown, unknown, unknown>
+  readonly traceOrigin: TraceOrigin
+  readonly masks: InterruptMaskState
+  status: 'ready' | 'waiting' | 'done'
+  resume: Resume
+  abort?: AbortController
+  cancelRequested: boolean
+  cleanupFailures: unknown[]
+}
+
+type PrimaryFailure =
+  | { readonly error: unknown }
+
+const normalizeCooperativeAllOptions = (options: CooperativeAllOptions): CooperativeAllConfig => {
+  const concurrency = options.concurrency ?? Infinity
+  const yieldBudget = options.yieldBudget ?? 64
+  if (concurrency <= 0) throw new RangeError(`cooperativeAll concurrency must be > 0, got ${concurrency}`)
+  if (yieldBudget <= 0) throw new RangeError(`cooperativeAll yieldBudget must be > 0, got ${yieldBudget}`)
+  return {
+    concurrency: Math.floor(concurrency),
+    yieldBudget: Math.floor(yieldBudget)
+  }
+}
+
+const runCooperativeAll = (config: CooperativeAllConfig) =>
+  <const Fxs extends readonly Fx<unknown, unknown>[]>(
+    all: All<Fxs>
+  ): Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
+    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
+  }> => cooperativeAllFx(all, config) as Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
+    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
+  }>
+
+const cooperativeAllFx = <const Fxs extends readonly Fx<unknown, unknown>[]>(
+  all: All<Fxs>,
+  config: CooperativeAllConfig
+) => fx(function* () {
+  const fxs = all.arg.fxs
+  const results = [] as unknown[]
+  const fibers = [] as Fiber[]
+  const ready = [] as Fiber[]
+  const wake = new Wake()
+  const context = getRuntimeContext(all)
+  const parentTraceOrigin = {
+    origin: all.arg.origin,
+    trace: all.arg.trace ?? captureTraceWithContext(context, all.arg.origin, undefined, { kind: 'all' })
+  }
+  const childKind = childFrameKind(parentTraceOrigin.trace)
+  let next = 0
+  let active = 0
+  let completed = false
+  let primaryFailure: PrimaryFailure | undefined
+
+  const startNext = () => {
+    while (primaryFailure === undefined && active < config.concurrency && next < fxs.length) {
+      const fiber: Fiber = {
+        index: next,
+        iterator: fxs[next][Symbol.iterator](),
+        traceOrigin: childTraceOriginWithContext(context, parentTraceOrigin, next, childKind),
+        masks: new InterruptMaskState(),
+        status: 'ready',
+        resume: { type: 'next', value: undefined },
+        cancelRequested: false,
+        cleanupFailures: []
+      }
+      next++
+      active++
+      fibers.push(fiber)
+      ready.push(fiber)
+    }
+  }
+
+  const finish = (fiber: Fiber) => {
+    if (fiber.status === 'done') return
+    fiber.status = 'done'
+    fiber.abort?.abort()
+    active--
+  }
+
+  const failFiber = (fiber: Fiber, failure: PrimaryFailure) => {
+    finish(fiber)
+    primaryFailure ??= failure
+    cancelActiveFibers(fibers, fiber)
+  }
+
+  try {
+    while (fxs.length !== fibers.filter(f => f.status === 'done').length || next < fxs.length) {
+      startNext()
+
+      if (ready.length === 0) {
+        if (active === 0) break
+        ready.push(...(yield* wake.wait()))
+        continue
+      }
+
+      const fiber = ready.shift()!
+      if (fiber.status !== 'ready') continue
+      if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+        yield* closeFiber(fiber)
+        finish(fiber)
+        continue
+      }
+
+      let budget = config.yieldBudget
+      while (budget > 0 && fiber.status === 'ready') {
+        budget--
+        let ir: IteratorResult<unknown, unknown>
+        try {
+          ir = fiber.resume.type === 'throw'
+            ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
+            : fiber.iterator.next(fiber.resume.value)
+        } catch (e) {
+          failFiber(fiber, { error: wrapThrownFiberError(fiber, e) })
+          break
+        }
+        fiber.resume = { type: 'next', value: undefined }
+
+        if (ir.done) {
+          results[fiber.index] = ir.value
+          finish(fiber)
+          break
+        }
+
+        if (Async.is(ir.value)) {
+          startCooperativeAsync(fiber, ir.value, wake, failFiber)
+          break
+        }
+
+        if (Fail.is(ir.value)) {
+          failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) })
+          break
+        }
+
+        if (InterruptMaskBegin.is(ir.value)) {
+          fiber.masks.mask(ir.value.arg)
+          fiber.resume = { type: 'next', value: undefined }
+          continue
+        }
+
+        if (InterruptMaskEnd.is(ir.value)) {
+          fiber.masks.unmask(ir.value.arg)
+          if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+            yield* closeFiber(fiber)
+            finish(fiber)
+            break
+          }
+          fiber.resume = { type: 'next', value: undefined }
+          continue
+        }
+
+        fiber.resume = { type: 'next', value: yield ir.value as any }
+      }
+
+      if (fiber.status === 'ready') ready.push(fiber)
+    }
+
+    completed = true
+
+    if (primaryFailure !== undefined) {
+      cancelActiveFibers(fibers)
+      for (const fiber of fibers) {
+        if (fiber.status !== 'done') {
+          yield* closeFiber(fiber)
+          finish(fiber)
+        }
+      }
+
+      const cleanupFailures = fibers.flatMap(fiber => fiber.cleanupFailures)
+      if (cleanupFailures.length > 0) {
+        return (yield* fail(resourceReleaseFailed([primaryFailure.error, ...cleanupFailures]))) as never
+      }
+      return (yield* fail(primaryFailure.error)) as never
+    }
+
+    return results as { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }
+  } finally {
+    if (!completed) {
+      cancelActiveFibers(fibers)
+      for (const fiber of fibers) {
+        if (fiber.status !== 'done') {
+          yield* closeFiber(fiber)
+          finish(fiber)
+        }
+      }
+    }
+  }
+})
+
+const startCooperativeAsync = (
+  fiber: Fiber,
+  async: Async,
+  wake: Wake,
+  failFiber: (fiber: Fiber, failure: PrimaryFailure) => void
+) => {
+  const abort = new AbortController()
+  fiber.abort = abort
+  fiber.status = 'waiting'
+  const context = getRuntimeContext(async)
+  const run = () => async.arg.run(abort.signal)
+  const promise = context === undefined ? run() : withActiveRuntimeContext(context, run)
+  promise.then(
+    value => {
+      if (fiber.status !== 'waiting') return
+      fiber.abort = undefined
+      fiber.resume = { type: 'next', value }
+      fiber.status = 'ready'
+      wake.ready(fiber)
+    },
+    error => {
+      if (fiber.status !== 'waiting') return
+      fiber.abort = undefined
+      failFiber(fiber, { error: wrapAsyncFiberError(fiber, async, error, context) })
+      wake.notify()
+    }
+  )
+}
+
+function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
+  fiber.abort?.abort()
+  fiber.abort = undefined
+  let ir: IteratorResult<unknown, unknown>
+  try {
+    ir = withInterpretedReturn(() => fiber.iterator.return?.() ?? { done: true, value: undefined })
+  } catch (e) {
+    fiber.cleanupFailures.push(e)
+    return
+  }
+
+  while (!ir.done) {
+    try {
+      if (Async.is(ir.value)) {
+        ir = fiber.iterator.next(yield ir.value as any)
+      } else if (Fail.is(ir.value)) {
+        fiber.cleanupFailures.push(ir.value.arg)
+        return
+      } else if (InterruptMaskBegin.is(ir.value)) {
+        fiber.masks.mask(ir.value.arg)
+        ir = fiber.iterator.next()
+      } else if (InterruptMaskEnd.is(ir.value)) {
+        fiber.masks.unmask(ir.value.arg)
+        ir = fiber.iterator.next()
+      } else {
+        ir = fiber.iterator.next(yield ir.value as any)
+      }
+    } catch (e) {
+      fiber.cleanupFailures.push(e)
+      return
+    }
+  }
+}
+
+const cancelActiveFibers = (fibers: readonly Fiber[], except?: Fiber) => {
+  for (const fiber of fibers) {
+    if (fiber === except || fiber.status === 'done') continue
+    fiber.cancelRequested = true
+    if (fiber.masks.canInterrupt) {
+      fiber.abort?.abort()
+    }
+  }
+}
+
+const wrapFiberFailure = (fiber: Fiber, failure: Fail<unknown>): ForkError => {
+  const context = runtimeContextOfEffect(failure)
+  const causeTrace = getTrace(failure.arg)
+  const trace = traceUnhandledFail(failure, causeTrace, fiber.traceOrigin.trace, context)
+  const origin = originOfUnhandledFail(failure, causeTrace)
+  return new ForkError('FX_UNHANDLED_FAILURE', 'Unhandled failure in forked task', origin, trace, context, { cause: failure.arg })
+}
+
+const wrapThrownFiberError = (fiber: Fiber, error: unknown): ForkError => {
+  const context = runtimeContextOfEffect(error)
+  return new ForkError('FX_UNHANDLED_EXCEPTION', 'Unhandled exception in forked task', fiber.traceOrigin.origin, traceWithCause(fiber.traceOrigin.trace, error, context, getTrace(error)), context, { cause: error })
+}
+
+const wrapAsyncFiberError = (fiber: Fiber, async: Async, error: unknown, fallbackContext?: ReturnType<typeof getRuntimeContext>): ForkError => {
+  const context = runtimeContextOfEffect(error, fallbackContext)
+  const asyncTrace = capturePrependTraceWithContext(context, async.arg.origin, fiber.traceOrigin.trace, { kind: 'async' })
+  return new ForkError('FX_AWAITED_ASYNC_FAILED', 'Awaited Async task failed', async.arg.origin, traceWithCause(asyncTrace, error, context, getTrace(error)), context, { cause: error })
+}
+
+const childTraceOriginWithContext = (
+  context: ReturnType<typeof getRuntimeContext>,
+  parent: TraceOrigin,
+  index: number,
+  kind: TraceFrameKind
+): TraceOrigin => {
+  const origin = indexed(parent.origin, index)
+  return { origin, trace: captureTraceWithContext(context, origin, parent.trace, { kind, index }) }
+}
+
+const throwIntoMissingIterator = (error: unknown): never => {
+  throw error
+}
+
+class Wake {
+  private readonly readyFibers = [] as Fiber[]
+  private readonly waiters = [] as (() => void)[]
+
+  ready(fiber: Fiber) {
+    this.readyFibers.push(fiber)
+    this.notify()
+  }
+
+  notify() {
+    const waiters = this.waiters.splice(0)
+    for (const waiter of waiters) waiter()
+  }
+
+  wait() {
+    return fx(function* (this: Wake) {
+      if (this.readyFibers.length === 0) {
+        yield* AsyncWait(this.waiters)
+      }
+      return this.readyFibers.splice(0)
+    }.bind(this))
+  }
+}
+
+const AsyncWait = (waiters: (() => void)[]) =>
+  new Async({
+    run: signal => new Promise<void>(resolve => {
+      const resolveOnce = () => {
+        signal.removeEventListener('abort', resolveOnce)
+        resolve()
+      }
+      signal.addEventListener('abort', resolveOnce, { once: true })
+      waiters.push(resolveOnce)
+    }),
+    origin: at('fx/Concurrent/cooperativeAll/wait', AsyncWait),
+    trace: captureTrace(at('fx/Concurrent/cooperativeAll/wait', AsyncWait), undefined, { kind: 'async' })
+  }) as Fx<Async, void>
 
 const taskRace = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) => {
   tasks.forEach(t => t._markHandled())

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -169,10 +169,13 @@ export const withCoopConcurrency = (options: CoopConcurrencyOptions = {}) => {
   const normalized = normalizeCoopOptions(options, 'withCoopConcurrency')
   const runtime = new CooperativeRuntime(normalized)
   return <const E, const A>(f: Fx<E, A>): Fx<CoopConcurrencyHandledEffects<E>, A> =>
-    withCapturedHandlers(
-      'fx/Concurrent/Fork',
-      f.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently))
-    ).pipe(
+    withCapturedHandlers('fx/Concurrent/Concurrently', f).pipe(
+      flatMap(fx =>
+        withCapturedHandlers(
+          'fx/Concurrent/Fork',
+          fx.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently))
+        )
+      ),
       flatMap(fx =>
         ok(fx.pipe(
           handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -9,7 +9,7 @@ import { Task, wait as waitTask } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
 import { Semaphore } from './internal/Semaphore.js'
-import { runCooperativeConcurrently, type CooperativeConfig } from './internal/withCoopConcurrency.js'
+import { CooperativeRuntime, type CooperativeConfig } from './internal/withCoopConcurrency.js'
 import { acquireAndRunFork } from './internal/runFork.js'
 import { currentRuntimeContext } from './internal/runtimeContext.js'
 
@@ -167,9 +167,11 @@ export interface CoopConcurrencyOptions {
  */
 export const withCoopConcurrency = (options: CoopConcurrencyOptions = {}) => {
   const normalized = normalizeCoopOptions(options, 'withCoopConcurrency')
+  const runtime = new CooperativeRuntime(normalized)
   return <const E, const A>(f: Fx<E, A>): Fx<CoopConcurrencyHandledEffects<E>, A> =>
     f.pipe(
-      handleCaptured('fx/Concurrent/Concurrently', Concurrently, runCooperativeConcurrently(normalized))
+      handleCaptured('fx/Concurrent/Concurrently', Concurrently, runtime.runConcurrently),
+      handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)
     ) as Fx<CoopConcurrencyHandledEffects<E>, A>
 }
 
@@ -310,7 +312,7 @@ type ConcurrentEffects<E> = E extends Concurrently<infer Policy, infer Fxs> ? As
 type WithConcurrencyHandledEffects<E> =
   Handle<Handle<Handle<E, AnyConcurrently, Fork | Async | ConcurrentEffects<E>>, Fork>, HandlerCapture<'fx/Concurrent/Fork'> | HandlerCapture<'fx/Concurrent/Concurrently'>>
 type CoopConcurrencyHandledEffects<E> =
-  Handle<Handle<E, AnyConcurrently, ConcurrentEffects<E>>, HandlerCapture<'fx/Concurrent/Concurrently'>>
+  Handle<Handle<Handle<E, AnyConcurrently, ConcurrentEffects<E>>, Fork>, HandlerCapture<'fx/Concurrent/Fork'> | HandlerCapture<'fx/Concurrent/Concurrently'>>
 type FirstSuccessFailure<Fxs extends readonly Fx<unknown, unknown>[]> =
   EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
 type EveryFxCanFail<Fxs extends readonly Fx<unknown, unknown>[]> = Fxs extends readonly []

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -366,11 +366,15 @@ const taskAll = <Tasks extends readonly Task<unknown, unknown>[]>(tasks: Tasks) 
 const normalizeCoopOptions = (options: CoopConcurrencyOptions, handlerName: string): CooperativeConfig => {
   const concurrency = options.concurrency ?? Infinity
   const yieldBudget = options.yieldBudget ?? 64
-  if (concurrency <= 0) throw new RangeError(`${handlerName} concurrency must be > 0, got ${concurrency}`)
-  if (yieldBudget <= 0) throw new RangeError(`${handlerName} yieldBudget must be > 0, got ${yieldBudget}`)
+  if (concurrency <= 0 || (concurrency !== Infinity && !Number.isInteger(concurrency))) {
+    throw new RangeError(`${handlerName} concurrency must be a positive integer or Infinity, got ${concurrency}`)
+  }
+  if (yieldBudget <= 0 || !Number.isInteger(yieldBudget)) {
+    throw new RangeError(`${handlerName} yieldBudget must be a positive integer, got ${yieldBudget}`)
+  }
   return {
-    concurrency: Math.floor(concurrency),
-    yieldBudget: Math.floor(yieldBudget)
+    concurrency,
+    yieldBudget
   }
 }
 

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { fail, Fail, returnFail } from './Fail.js'
-import { firstSettled, race, unbounded } from './Concurrent.js'
+import { firstSettled, race, withUnboundedConcurrency } from './Concurrent.js'
 import { andFinally, andFinallyExit, managed, using, usingManaged } from './Finalization.js'
 import { bracket, fx, ok, run, runPromise, runTask, type Fx } from './Fx.js'
 import { control, handle } from './Handler.js'
@@ -464,8 +464,8 @@ describe('Interrupt masking', () => {
     const result = race([ok('winner'), loser]).pipe(
       firstSettled,
       withScope(TestScope),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       runPromise
     ).then(value => {
       settled = true

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Fail, fail, returnFail } from './Fail.js'
-import { unbounded } from './Concurrent.js'
+import { withUnboundedConcurrency } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
 import { andFinallyExit } from './Finalization.js'
 import { control } from './Handler.js'
@@ -29,8 +29,8 @@ describe('Timeout', () => {
       }),
       withScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       withClock(c),
       runPromise
     )
@@ -59,8 +59,8 @@ describe('Timeout', () => {
       timeout(TestScope, { ms: 50, reason: () => reason }),
       withScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       withClock(c),
       runPromise
     )
@@ -86,8 +86,8 @@ describe('Timeout', () => {
       timeout(TestScope, { ms: 50 }),
       withScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       withClock(c),
       runPromise
     )
@@ -116,8 +116,8 @@ describe('Timeout', () => {
       timeout(TestScope, { ms: 100 }),
       withScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       withClock(c),
       runPromise
     )
@@ -145,8 +145,8 @@ describe('Timeout', () => {
       timeout(TestScope, { ms: 50 }),
       withScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
+      withUnboundedConcurrency,
       returnFail,
-      unbounded,
       withClock(c),
       runPromise
     ).then(r => {

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise, tryPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
-import { all, cooperativeAll, cooperativeStructured, defaultAll, firstSettled, fork, mapAll, race, unbounded } from './Concurrent.js'
+import { RaceAllFailed, all, withCoopConcurrency, firstSettled, firstSuccess, fork, mapAll, race, withUnboundedConcurrency } from './Concurrent.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { andFinally } from './Finalization.js'
 import { fx, runPromise } from './Fx.js'
@@ -379,7 +379,7 @@ describe('Trace', () => {
         return [offResult, labelsResult] as const
       })
 
-      const [offResult, labelsResult] = await f.pipe(unbounded, runPromise)
+      const [offResult, labelsResult] = await f.pipe(withUnboundedConcurrency, runPromise)
 
       assert.ok(Fail.is(offResult))
       assert.ok(Fail.is(labelsResult))
@@ -396,14 +396,14 @@ describe('Trace', () => {
       const allError = new Error('all failed')
       const raceError = new Error('race failed')
       const allProgram = fx(function* () {
-        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), defaultAll)
+        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'))
       })
       const raceProgram = fx(function* () {
         return yield* race([fx(function* () { yield* fail(raceError) })]).pipe(withTraceCapture('labels'), firstSettled)
       })
 
-      const allResult = await allProgram.pipe(returnFail, unbounded, runPromise)
-      const raceResult = await raceProgram.pipe(returnFail, unbounded, runPromise)
+      const allResult = await allProgram.pipe(withUnboundedConcurrency, returnFail, runPromise)
+      const raceResult = await raceProgram.pipe(withUnboundedConcurrency, returnFail, runPromise)
 
       assert.ok(Fail.is(allResult))
       assert.ok(Fail.is(raceResult))
@@ -418,16 +418,16 @@ describe('Trace', () => {
     }
   })
 
-  it('propagates regional trace policy and frame metadata through cooperativeAll', async () => {
+  it('propagates regional trace policy and frame metadata through withCoopConcurrency', async () => {
     const previous = setTraceCapturePolicy('off')
     try {
       const allError = new Error('cooperative all failed')
       const mapAllError = new Error('cooperative mapAll failed')
       const allProgram = fx(function* () {
-        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), cooperativeAll())
+        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), withCoopConcurrency())
       })
       const mapAllProgram = fx(function* () {
-        return yield* mapAll([mapAllError], error => fx(function* () { yield* fail(error) })).pipe(withTraceCapture('labels'), cooperativeAll())
+        return yield* mapAll([mapAllError], error => fx(function* () { yield* fail(error) })).pipe(withTraceCapture('labels'), withCoopConcurrency())
       })
 
       const allResult = await allProgram.pipe(returnFail, runPromise)
@@ -446,20 +446,20 @@ describe('Trace', () => {
     }
   })
 
-  it('propagates regional trace policy and frame metadata through cooperativeStructured', async () => {
+  it('propagates regional trace policy and frame metadata through withCoopConcurrency', async () => {
     const previous = setTraceCapturePolicy('off')
     try {
       const allError = new Error('cooperative structured all failed')
       const mapAllError = new Error('cooperative structured mapAll failed')
       const raceError = new Error('cooperative structured race failed')
       const allProgram = fx(function* () {
-        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), cooperativeStructured())
+        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), withCoopConcurrency())
       })
       const mapAllProgram = fx(function* () {
-        return yield* mapAll([mapAllError], error => fx(function* () { yield* fail(error) })).pipe(withTraceCapture('labels'), cooperativeStructured())
+        return yield* mapAll([mapAllError], error => fx(function* () { yield* fail(error) })).pipe(withTraceCapture('labels'), withCoopConcurrency())
       })
       const raceProgram = fx(function* () {
-        return yield* race([fx(function* () { yield* fail(raceError) })]).pipe(withTraceCapture('labels'), cooperativeStructured())
+        return yield* race([fx(function* () { yield* fail(raceError) })]).pipe(withTraceCapture('labels'), firstSettled, withCoopConcurrency())
       })
 
       const allResult = await allProgram.pipe(returnFail, runPromise)
@@ -483,6 +483,30 @@ describe('Trace', () => {
     }
   })
 
+  it('propagates regional trace policy through first-success race policy', async () => {
+    const previous = setTraceCapturePolicy('off')
+    try {
+      const raceError = new Error('cooperative tagged race failed')
+      const raceProgram = fx(function* () {
+        return yield* race([fx(function* () { yield* fail(raceError) })]).pipe(
+          withTraceCapture('labels'),
+          firstSuccess,
+          withCoopConcurrency()
+        )
+      })
+
+      const raceResult = await raceProgram.pipe(returnFail, runPromise)
+
+      assert.ok(Fail.is(raceResult))
+      assert.ok(raceResult.arg instanceof RaceAllFailed)
+      assert.deepEqual(traceMessages(raceResult.arg.errors[0]).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/race[0]', 'fx/Concurrent/race'])
+      assert.equal(snapshotError(raceResult.arg.errors[0]).trace?.frames[1]?.kind, 'race')
+      assert.equal(snapshotError(raceResult.arg.errors[0]).trace?.frames[1]?.index, 0)
+    } finally {
+      setTraceCapturePolicy(previous)
+    }
+  })
+
   it('propagates active scopes to forked children', async () => {
     const HttpRequest = scope('http/request')
     const f = fx(function* () {
@@ -493,7 +517,7 @@ describe('Trace', () => {
     }).pipe(withScope(HttpRequest))
 
     await assert.rejects(
-      runPromise(f.pipe(unbounded) as never),
+      runPromise(f.pipe(withUnboundedConcurrency) as never),
       e => {
         assert.deepEqual(snapshotError(e).trace?.activeScopes, [{
           id: 'http/request',
@@ -508,14 +532,14 @@ describe('Trace', () => {
   it('propagates active scopes through structured concurrency handlers', async () => {
     const HttpRequest = scope('http/request')
     const allProgram = fx(function* () {
-      yield* all([fx(function* () { yield* fail(new Error('all scoped')) })]).pipe(defaultAll)
+      yield* all([fx(function* () { yield* fail(new Error('all scoped')) })])
     }).pipe(withScope(HttpRequest))
     const raceProgram = fx(function* () {
       yield* race([fx(function* () { yield* fail(new Error('race scoped')) })]).pipe(firstSettled)
     }).pipe(withScope(HttpRequest))
 
     await assert.rejects(
-      runPromise(allProgram.pipe(unbounded) as never),
+      runPromise(allProgram.pipe(withUnboundedConcurrency) as never),
       e => {
         assert.deepEqual(snapshotError(e).trace?.activeScopes, [{
           id: 'http/request',
@@ -526,7 +550,7 @@ describe('Trace', () => {
       }
     )
     await assert.rejects(
-      runPromise(raceProgram.pipe(unbounded) as never),
+      runPromise(raceProgram.pipe(withUnboundedConcurrency) as never),
       e => {
         assert.deepEqual(snapshotError(e).trace?.activeScopes, [{
           id: 'http/request',
@@ -586,7 +610,7 @@ describe('Trace', () => {
         return yield* fork(fx(function* () {
           yield* fail(new Error('task context'))
         }).pipe(withTraceCapture('full')))
-      }).pipe(unbounded, runPromise)
+      }).pipe(withUnboundedConcurrency, runPromise)
 
       const result = await wait(failingTask).pipe(
         withTraceCapture('off'),
@@ -652,17 +676,15 @@ describe('Trace', () => {
       return yield* sleep(100).pipe(timeout(TimeoutScope, { ms: 50 }))
     })
 
-    const timeoutPromise = timeoutProgram.pipe(
+    const timeoutPromise = runPromise(timeoutProgram.pipe(
       withScope(TimeoutScope),
       control(InterruptFrom, (_, interrupt) => fx(function* () {
         return interrupt.arg
       })),
       withTraceCapture('labels'),
-      returnFail,
-      unbounded,
-      withClock(clock),
-      runPromise
-    )
+      withUnboundedConcurrency,
+      withClock(clock)
+    ) as never)
     await clock.step(50)
     const timeoutResult = await timeoutPromise
 

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise, tryPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
-import { all, defaultAll, firstSettled, fork, race, unbounded } from './Concurrent.js'
+import { all, cooperativeAll, defaultAll, firstSettled, fork, mapAll, race, unbounded } from './Concurrent.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { andFinally } from './Finalization.js'
 import { fx, runPromise } from './Fx.js'
@@ -413,6 +413,34 @@ describe('Trace', () => {
       assert.deepEqual(traceMessages(raceResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/race[0]', 'fx/Concurrent/race'])
       assert.equal(snapshotError(raceResult.arg).trace?.frames[1]?.kind, 'fork')
       assert.equal(snapshotError(raceResult.arg).trace?.frames[1]?.index, 0)
+    } finally {
+      setTraceCapturePolicy(previous)
+    }
+  })
+
+  it('propagates regional trace policy and frame metadata through cooperativeAll', async () => {
+    const previous = setTraceCapturePolicy('off')
+    try {
+      const allError = new Error('cooperative all failed')
+      const mapAllError = new Error('cooperative mapAll failed')
+      const allProgram = fx(function* () {
+        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), cooperativeAll())
+      })
+      const mapAllProgram = fx(function* () {
+        return yield* mapAll([mapAllError], error => fx(function* () { yield* fail(error) })).pipe(withTraceCapture('labels'), cooperativeAll())
+      })
+
+      const allResult = await allProgram.pipe(returnFail, runPromise)
+      const mapAllResult = await mapAllProgram.pipe(returnFail, runPromise)
+
+      assert.ok(Fail.is(allResult))
+      assert.ok(Fail.is(mapAllResult))
+      assert.deepEqual(traceMessages(allResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/all[0]', 'fx/Concurrent/all'])
+      assert.equal(snapshotError(allResult.arg).trace?.frames[1]?.kind, 'all')
+      assert.equal(snapshotError(allResult.arg).trace?.frames[1]?.index, 0)
+      assert.deepEqual(traceMessages(mapAllResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
+      assert.equal(snapshotError(mapAllResult.arg).trace?.frames[1]?.kind, 'all')
+      assert.equal(snapshotError(mapAllResult.arg).trace?.frames[1]?.index, 0)
     } finally {
       setTraceCapturePolicy(previous)
     }

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise, tryPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
-import { all, cooperativeAll, defaultAll, firstSettled, fork, mapAll, race, unbounded } from './Concurrent.js'
+import { all, cooperativeAll, cooperativeStructured, defaultAll, firstSettled, fork, mapAll, race, unbounded } from './Concurrent.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { andFinally } from './Finalization.js'
 import { fx, runPromise } from './Fx.js'
@@ -441,6 +441,43 @@ describe('Trace', () => {
       assert.deepEqual(traceMessages(mapAllResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
       assert.equal(snapshotError(mapAllResult.arg).trace?.frames[1]?.kind, 'all')
       assert.equal(snapshotError(mapAllResult.arg).trace?.frames[1]?.index, 0)
+    } finally {
+      setTraceCapturePolicy(previous)
+    }
+  })
+
+  it('propagates regional trace policy and frame metadata through cooperativeStructured', async () => {
+    const previous = setTraceCapturePolicy('off')
+    try {
+      const allError = new Error('cooperative structured all failed')
+      const mapAllError = new Error('cooperative structured mapAll failed')
+      const raceError = new Error('cooperative structured race failed')
+      const allProgram = fx(function* () {
+        return yield* all([fx(function* () { yield* fail(allError) })]).pipe(withTraceCapture('labels'), cooperativeStructured())
+      })
+      const mapAllProgram = fx(function* () {
+        return yield* mapAll([mapAllError], error => fx(function* () { yield* fail(error) })).pipe(withTraceCapture('labels'), cooperativeStructured())
+      })
+      const raceProgram = fx(function* () {
+        return yield* race([fx(function* () { yield* fail(raceError) })]).pipe(withTraceCapture('labels'), cooperativeStructured())
+      })
+
+      const allResult = await allProgram.pipe(returnFail, runPromise)
+      const mapAllResult = await mapAllProgram.pipe(returnFail, runPromise)
+      const raceResult = await raceProgram.pipe(returnFail, runPromise)
+
+      assert.ok(Fail.is(allResult))
+      assert.ok(Fail.is(mapAllResult))
+      assert.ok(Fail.is(raceResult))
+      assert.deepEqual(traceMessages(allResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/all[0]', 'fx/Concurrent/all'])
+      assert.equal(snapshotError(allResult.arg).trace?.frames[1]?.kind, 'all')
+      assert.equal(snapshotError(allResult.arg).trace?.frames[1]?.index, 0)
+      assert.deepEqual(traceMessages(mapAllResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/mapAll[0]', 'fx/Concurrent/mapAll'])
+      assert.equal(snapshotError(mapAllResult.arg).trace?.frames[1]?.kind, 'all')
+      assert.equal(snapshotError(mapAllResult.arg).trace?.frames[1]?.index, 0)
+      assert.deepEqual(traceMessages(raceResult.arg).slice(0, 3), ['fx/Fail/fail', 'fx/Concurrent/race[0]', 'fx/Concurrent/race'])
+      assert.equal(snapshotError(raceResult.arg).trace?.frames[1]?.kind, 'race')
+      assert.equal(snapshotError(raceResult.arg).trace?.frames[1]?.index, 0)
     } finally {
       setTraceCapturePolicy(previous)
     }

--- a/src/YieldFrom.test.ts
+++ b/src/YieldFrom.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { abort, orReturn } from './Abort.js'
-import { unbounded } from './Concurrent.js'
+import { withUnboundedConcurrency } from './Concurrent.js'
 import { Effect } from './Effect.js'
 import { fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { handle, handleScoped } from './Handler.js'
@@ -261,7 +261,7 @@ describe('YieldFrom', () => {
 
     const [result, values] = await fromAsyncIterable(NumberScope, makeAsyncIterable).pipe(
       collectFrom(NumberScope),
-      unbounded,
+      withUnboundedConcurrency,
       runPromise
     )
 

--- a/src/internal/cooperativeStructured.ts
+++ b/src/internal/cooperativeStructured.ts
@@ -1,0 +1,462 @@
+import { Async } from '../Async.js'
+import { at, indexed } from '../Breadcrumb.js'
+import { All, Race, RaceAllFailed } from '../Concurrent.js'
+import type { EffectsOf, ErrorsOf, ResultOf } from '../Concurrent.js'
+import { Fail, fail } from '../Fail.js'
+import { Fx, fx } from '../Fx.js'
+import type { TraceFrameKind, TraceOrigin } from '../Trace.js'
+import { captureTrace, getTrace } from '../Trace.js'
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js'
+import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
+import { withInterpretedReturn } from './iteratorClose.js'
+import { getRuntimeContext, withActiveRuntimeContext } from './runtimeContext.js'
+
+export interface CooperativeConfig {
+  readonly concurrency: number
+  readonly yieldBudget: number
+}
+
+export type CooperativeRacePolicy = 'firstSettled' | 'firstSuccess'
+
+type CooperativeRaceEffects<E> = Async | ErrorsOf<EffectsOfRace<E>> | FirstSuccessRaceFailure<E>
+type EffectsOfRace<E> = E extends Race<infer Fxs> ? EffectsOf<Fxs[number]> : never
+type FirstSuccessRaceFailure<E> = E extends Race<infer Fxs>
+  ? EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
+  : never
+type EveryFxCanFail<Fxs extends readonly Fx<unknown, unknown>[]> = Fxs extends readonly []
+  ? true
+  : number extends Fxs['length']
+  ? true
+  : Fxs extends readonly [infer F, ...infer Rest]
+  ? F extends Fx<unknown, unknown>
+  ? [FailuresOfFx<F>] extends [never]
+  ? false
+  : Rest extends readonly Fx<unknown, unknown>[] ? EveryFxCanFail<Rest> : true
+  : false
+  : true
+type FailuresOfFxs<Fxs extends readonly Fx<unknown, unknown>[]> = {
+  readonly [K in keyof Fxs]: FailuresOfFx<Fxs[K]>
+}
+type FailuresOfFx<F> = FailureOf<ErrorsOf<EffectsOf<F>>>
+type FailureOf<E> = E extends Fail<infer F> ? F : never
+
+type Resume =
+  | { readonly type: 'next', readonly value: unknown }
+  | { readonly type: 'throw', readonly error: unknown }
+
+interface Fiber {
+  readonly index: number
+  readonly iterator: Iterator<unknown, unknown, unknown>
+  readonly traceOrigin: TraceOrigin
+  readonly masks: InterruptMaskState
+  status: 'ready' | 'waiting' | 'done'
+  resume: Resume
+  abort?: AbortController
+  cancelRequested: boolean
+  cleanupFailures: unknown[]
+}
+
+type PrimaryFailure =
+  | { readonly error: unknown }
+
+type GroupDecision<S> =
+  | { readonly type: 'continue', readonly state: S }
+  | { readonly type: 'succeed', readonly state: S, readonly value: unknown, readonly cancelRest: boolean }
+  | { readonly type: 'fail', readonly state: S, readonly error: unknown, readonly cancelRest: boolean }
+
+interface GroupPolicy<S> {
+  readonly init: (size: number) => S
+  readonly onEmpty?: (state: S) => GroupDecision<S>
+  readonly onSuccess: (state: S, index: number, value: unknown) => GroupDecision<S>
+  readonly onFailure: (state: S, index: number, error: unknown) => GroupDecision<S>
+}
+
+export const runCooperativeAll = (config: CooperativeConfig) =>
+  <const Fxs extends readonly Fx<unknown, unknown>[]>(
+    all: All<Fxs>
+  ): Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
+    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
+  }> => cooperativeGroupFx(all, config, allPolicy()) as Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
+  readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
+}>
+
+export const runCooperativeRace = (config: CooperativeConfig, racePolicy: CooperativeRacePolicy) =>
+  <const Fxs extends readonly Fx<unknown, unknown>[]>(
+    race: Race<Fxs>
+  ): Fx<CooperativeRaceEffects<Race<Fxs>>, ResultOf<Fxs[number]>> => {
+    const policy: GroupPolicy<any> = racePolicy === 'firstSuccess' ? firstSuccessGroupPolicy() : raceGroupPolicy()
+    return cooperativeGroupFx(race, config, policy) as Fx<CooperativeRaceEffects<Race<Fxs>>, ResultOf<Fxs[number]>>
+  }
+
+const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S>(
+  group: All<Fxs> | Race<Fxs>,
+  config: CooperativeConfig,
+  policy: GroupPolicy<S>
+) => fx(function* () {
+  const fxs = group.arg.fxs
+  const fibers = [] as Fiber[]
+  const ready = [] as Fiber[]
+  const wake = new Wake()
+  const context = getRuntimeContext(group)
+  const parentTraceOrigin = {
+    origin: group.arg.origin,
+    trace: group.arg.trace ?? captureTraceWithContext(context, group.arg.origin, undefined, { kind: groupKind(group) })
+  }
+  const childKind = childFrameKind(parentTraceOrigin.trace)
+  let state = policy.init(fxs.length)
+  let next = 0
+  let active = 0
+  let done = 0
+  let completed = false
+  let outcome: Exclude<GroupDecision<S>, { readonly type: 'continue' }> | undefined = emptyOutcome(policy, state, fxs.length)
+
+  const startNext = () => {
+    while (outcome === undefined && active < config.concurrency && next < fxs.length) {
+      const fiber: Fiber = {
+        index: next,
+        iterator: fxs[next][Symbol.iterator](),
+        traceOrigin: childTraceOriginWithContext(context, parentTraceOrigin, next, childKind),
+        masks: new InterruptMaskState(),
+        status: 'ready',
+        resume: { type: 'next', value: undefined },
+        cancelRequested: false,
+        cleanupFailures: []
+      }
+      next++
+      active++
+      fibers.push(fiber)
+      ready.push(fiber)
+    }
+  }
+
+  const finish = (fiber: Fiber) => {
+    if (fiber.status === 'done') return
+    fiber.status = 'done'
+    fiber.abort?.abort()
+    active--
+    done++
+  }
+
+  const settle = (decision: GroupDecision<S>) => {
+    state = decision.state
+    if (decision.type === 'continue') return
+    outcome ??= decision
+    if (decision.cancelRest) cancelActiveFibers(fibers)
+  }
+
+  const succeedFiber = (fiber: Fiber, value: unknown) => {
+    finish(fiber)
+    settle(policy.onSuccess(state, fiber.index, value))
+  }
+
+  const failFiber = (fiber: Fiber, failure: PrimaryFailure) => {
+    finish(fiber)
+    settle(policy.onFailure(state, fiber.index, failure.error))
+  }
+
+  try {
+    while (done < fxs.length || next < fxs.length) {
+      startNext()
+
+      if (ready.length === 0) {
+        if (active === 0) break
+        ready.push(...(yield* wake.wait()))
+        continue
+      }
+
+      const fiber = ready.shift()!
+      if (fiber.status !== 'ready') continue
+      if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+        yield* closeFiber(fiber)
+        finish(fiber)
+        continue
+      }
+
+      let budget = config.yieldBudget
+      while (budget > 0 && fiber.status === 'ready') {
+        budget--
+        let ir: IteratorResult<unknown, unknown>
+        try {
+          ir = fiber.resume.type === 'throw'
+            ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
+            : fiber.iterator.next(fiber.resume.value)
+        } catch (e) {
+          failFiber(fiber, { error: wrapThrownFiberError(fiber, e) })
+          break
+        }
+        fiber.resume = { type: 'next', value: undefined }
+
+        if (ir.done) {
+          succeedFiber(fiber, ir.value)
+          break
+        }
+
+        if (Async.is(ir.value)) {
+          startCooperativeAsync(fiber, ir.value, wake, failFiber)
+          break
+        }
+
+        if (Fail.is(ir.value)) {
+          failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) })
+          break
+        }
+
+        if (InterruptMaskBegin.is(ir.value)) {
+          fiber.masks.mask(ir.value.arg)
+          fiber.resume = { type: 'next', value: undefined }
+          continue
+        }
+
+        if (InterruptMaskEnd.is(ir.value)) {
+          fiber.masks.unmask(ir.value.arg)
+          if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+            yield* closeFiber(fiber)
+            finish(fiber)
+            break
+          }
+          fiber.resume = { type: 'next', value: undefined }
+          continue
+        }
+
+        fiber.resume = { type: 'next', value: yield ir.value as any }
+      }
+
+      if (fiber.status === 'ready') ready.push(fiber)
+    }
+
+    completed = true
+
+    if (outcome !== undefined) {
+      cancelActiveFibers(fibers)
+      for (const fiber of fibers) {
+        if (fiber.status !== 'done') {
+          yield* closeFiber(fiber)
+          finish(fiber)
+        }
+      }
+
+      const cleanupFailures = fibers.flatMap(fiber => fiber.cleanupFailures)
+      if (cleanupFailures.length > 0) {
+        const failures = outcome.type === 'fail'
+          ? [outcome.error, ...cleanupFailures]
+          : cleanupFailures
+        return (yield* fail(resourceReleaseFailed(failures))) as never
+      }
+      if (outcome.type === 'fail') return (yield* fail(outcome.error)) as never
+      return outcome.value
+    }
+
+    return state
+  } finally {
+    if (!completed) {
+      cancelActiveFibers(fibers)
+      for (const fiber of fibers) {
+        if (fiber.status !== 'done') {
+          yield* closeFiber(fiber)
+          finish(fiber)
+        }
+      }
+    }
+  }
+})
+
+const emptyOutcome = <S>(
+  policy: GroupPolicy<S>,
+  state: S,
+  size: number
+): Exclude<GroupDecision<S>, { readonly type: 'continue' }> | undefined => {
+  if (size !== 0) return undefined
+  const decision = policy.onEmpty?.(state)
+  return decision?.type === 'continue' ? undefined : decision
+}
+
+const groupKind = (group: All<any> | Race<any>): TraceFrameKind =>
+  All.is(group) ? 'all' : 'race'
+
+const childFrameKind = (trace: TraceOrigin['trace'] | undefined) =>
+  trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'
+
+const allPolicy = (): GroupPolicy<{ readonly results: unknown[], completed: number }> => ({
+  init: size => ({ results: sparseArray(size), completed: 0 }),
+  onEmpty: state => ({ type: 'succeed', state, value: state.results, cancelRest: false }),
+  onSuccess: (state, index, value) => {
+    state.results[index] = value
+    state.completed++
+    return state.completed === state.results.length
+      ? { type: 'succeed', state, value: state.results, cancelRest: false }
+      : { type: 'continue', state }
+  },
+  onFailure: (state, _index, error) => ({ type: 'fail', state, error, cancelRest: true })
+})
+
+const raceGroupPolicy = (): GroupPolicy<void> => ({
+  init: () => undefined,
+  onSuccess: (_state, _index, value) => ({ type: 'succeed', state: undefined, value, cancelRest: true }),
+  onFailure: (_state, _index, error) => ({ type: 'fail', state: undefined, error, cancelRest: true })
+})
+
+const firstSuccessGroupPolicy = (): GroupPolicy<{ readonly size: number, readonly failures: unknown[] }> => ({
+  init: size => ({ size, failures: sparseArray(size) }),
+  onEmpty: state => ({ type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: false }),
+  onSuccess: (state, _index, value) => ({ type: 'succeed', state, value, cancelRest: true }),
+  onFailure: (state, index, error) => {
+    state.failures[index] = error
+    const failed = state.failures.filter((_, i) => i in state.failures).length
+    return failed === state.size
+      ? { type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: true }
+      : { type: 'continue', state }
+  }
+})
+
+const sparseArray = (length: number): unknown[] => {
+  const array = [] as unknown[]
+  array.length = length
+  return array
+}
+
+const startCooperativeAsync = (
+  fiber: Fiber,
+  async: Async,
+  wake: Wake,
+  failFiber: (fiber: Fiber, failure: PrimaryFailure) => void
+) => {
+  const abort = new AbortController()
+  fiber.abort = abort
+  fiber.status = 'waiting'
+  const context = getRuntimeContext(async)
+  const run = () => async.arg.run(abort.signal)
+  const promise = context === undefined ? run() : withActiveRuntimeContext(context, run)
+  promise.then(
+    value => {
+      if (fiber.status !== 'waiting') return
+      fiber.abort = undefined
+      fiber.resume = { type: 'next', value }
+      fiber.status = 'ready'
+      wake.ready(fiber)
+    },
+    error => {
+      if (fiber.status !== 'waiting') return
+      fiber.abort = undefined
+      failFiber(fiber, { error: wrapAsyncFiberError(fiber, async, error, context) })
+      wake.notify()
+    }
+  )
+}
+
+function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
+  fiber.abort?.abort()
+  fiber.abort = undefined
+  let ir: IteratorResult<unknown, unknown>
+  try {
+    ir = withInterpretedReturn(() => fiber.iterator.return?.() ?? { done: true, value: undefined })
+  } catch (e) {
+    fiber.cleanupFailures.push(e)
+    return
+  }
+
+  while (!ir.done) {
+    try {
+      if (Async.is(ir.value)) {
+        ir = fiber.iterator.next(yield ir.value as any)
+      } else if (Fail.is(ir.value)) {
+        fiber.cleanupFailures.push(ir.value.arg)
+        return
+      } else if (InterruptMaskBegin.is(ir.value)) {
+        fiber.masks.mask(ir.value.arg)
+        ir = fiber.iterator.next()
+      } else if (InterruptMaskEnd.is(ir.value)) {
+        fiber.masks.unmask(ir.value.arg)
+        ir = fiber.iterator.next()
+      } else {
+        ir = fiber.iterator.next(yield ir.value as any)
+      }
+    } catch (e) {
+      fiber.cleanupFailures.push(e)
+      return
+    }
+  }
+}
+
+const cancelActiveFibers = (fibers: readonly Fiber[], except?: Fiber) => {
+  for (const fiber of fibers) {
+    if (fiber === except || fiber.status === 'done') continue
+    fiber.cancelRequested = true
+    if (fiber.masks.canInterrupt) {
+      fiber.abort?.abort()
+    }
+  }
+}
+
+const wrapFiberFailure = (fiber: Fiber, failure: Fail<unknown>): ForkError => {
+  const context = runtimeContextOfEffect(failure)
+  const causeTrace = getTrace(failure.arg)
+  const trace = traceUnhandledFail(failure, causeTrace, fiber.traceOrigin.trace, context)
+  const origin = originOfUnhandledFail(failure, causeTrace)
+  return new ForkError('FX_UNHANDLED_FAILURE', 'Unhandled failure in forked task', origin, trace, context, { cause: failure.arg })
+}
+
+const wrapThrownFiberError = (fiber: Fiber, error: unknown): ForkError => {
+  const context = runtimeContextOfEffect(error)
+  return new ForkError('FX_UNHANDLED_EXCEPTION', 'Unhandled exception in forked task', fiber.traceOrigin.origin, traceWithCause(fiber.traceOrigin.trace, error, context, getTrace(error)), context, { cause: error })
+}
+
+const wrapAsyncFiberError = (fiber: Fiber, async: Async, error: unknown, fallbackContext?: ReturnType<typeof getRuntimeContext>): ForkError => {
+  const context = runtimeContextOfEffect(error, fallbackContext)
+  const asyncTrace = capturePrependTraceWithContext(context, async.arg.origin, fiber.traceOrigin.trace, { kind: 'async' })
+  return new ForkError('FX_AWAITED_ASYNC_FAILED', 'Awaited Async task failed', async.arg.origin, traceWithCause(asyncTrace, error, context, getTrace(error)), context, { cause: error })
+}
+
+const childTraceOriginWithContext = (
+  context: ReturnType<typeof getRuntimeContext>,
+  parent: TraceOrigin,
+  index: number,
+  kind: TraceFrameKind
+): TraceOrigin => {
+  const origin = indexed(parent.origin, index)
+  return { origin, trace: captureTraceWithContext(context, origin, parent.trace, { kind, index }) }
+}
+
+const throwIntoMissingIterator = (error: unknown): never => {
+  throw error
+}
+
+class Wake {
+  private readonly readyFibers = [] as Fiber[]
+  private readonly waiters = [] as (() => void)[]
+
+  ready(fiber: Fiber) {
+    this.readyFibers.push(fiber)
+    this.notify()
+  }
+
+  notify() {
+    const waiters = this.waiters.splice(0)
+    for (const waiter of waiters) waiter()
+  }
+
+  wait() {
+    return fx(function* (this: Wake) {
+      if (this.readyFibers.length === 0) {
+        yield* AsyncWait(this.waiters)
+      }
+      return this.readyFibers.splice(0)
+    }.bind(this))
+  }
+}
+
+const AsyncWait = (waiters: (() => void)[]) =>
+  new Async({
+    run: signal => new Promise<void>(resolve => {
+      const resolveOnce = () => {
+        signal.removeEventListener('abort', resolveOnce)
+        resolve()
+      }
+      signal.addEventListener('abort', resolveOnce, { once: true })
+      waiters.push(resolveOnce)
+    }),
+    origin: at('fx/Concurrent/cooperativeStructured/wait', AsyncWait),
+    trace: captureTrace(at('fx/Concurrent/cooperativeStructured/wait', AsyncWait), undefined, { kind: 'async' })
+  }) as Fx<Async, void>
+
+const resourceReleaseFailed = (failures: readonly unknown[]) =>
+  new AggregateError(failures, 'Resource release failed')

--- a/src/internal/forkDiagnostics.ts
+++ b/src/internal/forkDiagnostics.ts
@@ -1,0 +1,90 @@
+import type { Breadcrumb } from '../Breadcrumb.js'
+import { Fail } from '../Fail.js'
+import { attachTrace, captureAppendTrace, capturePrependTrace, captureTrace } from '../Trace.js'
+import type { Trace, TraceFrameMetadata } from '../Trace.js'
+import type { RuntimeContext } from './runtimeContext.js'
+import { getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext } from './runtimeContext.js'
+
+export class ForkError extends Error {
+  constructor(readonly code: ForkErrorCode, message: string, origin: Breadcrumb, trace: Trace | undefined, runtimeContext?: RuntimeContext, options?: ErrorOptions) {
+    super(message, options)
+    if (traceCapturePolicy(runtimeContext) === 'full' && 'stack' in origin) Object.defineProperty(this, 'stack', { get: () => origin.stack })
+    Object.defineProperty(this, 'code', {
+      value: code,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    })
+    if (trace !== undefined) attachTrace(this, trace)
+  }
+}
+
+export type ForkErrorCode = 'FX_AWAITED_ASYNC_FAILED' | 'FX_UNHANDLED_FORK_FAILURE' | 'FX_UNHANDLED_FAILURE' | 'FX_UNHANDLED_EXCEPTION'
+
+export const runtimeContextOfEffect = (effect: unknown, fallback?: RuntimeContext): RuntimeContext | undefined =>
+  getRuntimeContext(effect) ?? fallback
+
+export const traceWithCause = (
+  trace: Trace | undefined,
+  cause: unknown,
+  runtimeContext: RuntimeContext | undefined,
+  causeTrace: Trace | undefined
+): Trace | undefined =>
+  captureAppendTraceWithContext(runtimeContext, causeTrace ?? trace, causeTrace === undefined ? undefined : trace)
+
+export const traceUnhandledFail = (
+  fail: Fail<unknown>,
+  causeTrace: Trace | undefined,
+  parentTrace: Trace | undefined,
+  runtimeContext?: RuntimeContext
+): Trace | undefined => {
+  if (causeTrace !== undefined) return captureAppendTraceWithContext(runtimeContext, causeTrace, parentTrace)
+  if (fail.trace === undefined) return captureAppendTraceWithContext(runtimeContext, undefined, parentTrace)
+  return parentTrace === undefined
+    ? fail.trace
+    : captureAppendTraceWithContext(runtimeContext, fail.trace, parentTrace) ?? fail.trace
+}
+
+export const originOfUnhandledFail = (fail: Fail<unknown>, causeTrace: Trace | undefined): Breadcrumb =>
+  causeTrace === undefined ? fail.origin : originFromTrace(causeTrace)
+
+export const forkFrameMetadata = (trace: Trace | undefined): TraceFrameMetadata => ({
+  kind: trace?.frame.kind ?? 'fork',
+  index: trace?.frame.index
+})
+
+export const captureTraceWithContext = (
+  context: RuntimeContext | undefined,
+  origin: Breadcrumb,
+  parent?: Trace,
+  metadata?: TraceFrameMetadata
+): Trace | undefined =>
+  context === undefined
+    ? captureTrace(origin, parent, metadata)
+    : withActiveRuntimeContext(context, () => captureTrace(origin, parent, metadata))
+
+export const capturePrependTraceWithContext = (
+  context: RuntimeContext | undefined,
+  origin: Breadcrumb,
+  parent?: Trace,
+  metadata?: TraceFrameMetadata
+): Trace | undefined =>
+  context === undefined
+    ? capturePrependTrace(origin, parent, metadata)
+    : withActiveRuntimeContext(context, () => capturePrependTrace(origin, parent, metadata))
+
+export const captureAppendTraceWithContext = (
+  context: RuntimeContext | undefined,
+  trace: Trace | undefined,
+  parent?: Trace
+): Trace | undefined =>
+  context === undefined
+    ? captureAppendTrace(trace, parent)
+    : withActiveRuntimeContext(context, () => captureAppendTrace(trace, parent))
+
+export const originFromTrace = (trace: Trace): Breadcrumb => ({
+  message: trace.frame.message,
+  get stack() {
+    return trace.frame.stackSource?.stack
+  }
+})

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -6,14 +6,15 @@ import { Fx } from '../Fx.js'
 import { CapturedHandler, HandlerCapture, withHandlerContext } from '../HandlerCapture.js'
 import type { Interrupt } from '../Interrupt.js'
 import { Task } from '../Task.js'
-import { attachTrace, captureAppendTrace, capturePrependTrace, captureTrace, getTrace } from '../Trace.js'
-import type { Trace, TraceFrameMetadata, TraceOptions } from '../Trace.js'
+import { getTrace } from '../Trace.js'
+import type { Trace, TraceOptions } from '../Trace.js'
 import { Semaphore } from './Semaphore.js'
 import { DisposableSet } from './disposable.js'
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, forkFrameMetadata, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
 import { withInterpretedReturn } from './iteratorClose.js'
 import type { RuntimeContext } from './runtimeContext.js'
-import { currentRuntimeContext, getRuntimeContext, traceCapturePolicy, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
 
 export type RunForkOptions = TraceOptions & {
   readonly maxConcurrency?: number
@@ -104,7 +105,7 @@ const runForkLoop = async <const E, const A>(
       throw e
     }
     const errorContext = getRuntimeContext(e) ?? runtimeContext
-    const error = new ForkError('FX_UNHANDLED_EXCEPTION', `Unhandled exception in forked task`, origin, traceWithCause(trace, e, errorContext), errorContext, { cause: e })
+    const error = new ForkError('FX_UNHANDLED_EXCEPTION', `Unhandled exception in forked task`, origin, traceWithCause(trace, e, errorContext, getTrace(e)), errorContext, { cause: e })
     if (disposables.interruptRequested) disposed.reject(error)
     throw error
   }
@@ -164,7 +165,7 @@ const runIterator = async <const E, const A>(
         if (e instanceof UnhandledForkError) throw e.error
         if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt)
         const asyncTrace = capturePrependTraceWithContext(effectContext, origin, trace, { kind: 'async' })
-        throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext), effectContext, { cause: e })
+        throw new ForkError('FX_AWAITED_ASYNC_FAILED', `Awaited Async task failed`, origin, traceWithCause(asyncTrace, e, effectContext, getTrace(e)), effectContext, { cause: e })
       }
       // stop if the scope was interrupted while we were waiting
       if (disposables.canInterrupt && interrupt !== undefined) return await disposables.interruptNow(interrupt)
@@ -181,7 +182,7 @@ const runIterator = async <const E, const A>(
           queueMicrotask(() => {
             if (t._handled || t._interrupted || disposables.interruptRequested) return
             rejectUnhandled(
-              new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext), effectContext, { cause: e })
+              new ForkError('FX_UNHANDLED_FORK_FAILURE', `Unhandled failure in forked task`, forkOrigin, traceWithCause(forkTrace, e, effectContext, getTrace(e)), effectContext, { cause: e })
             )
           })
         })
@@ -204,7 +205,7 @@ const runIterator = async <const E, const A>(
       throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, failOrigin, failTrace, effectContext, { cause: ir.value.arg })
     } else {
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
-      throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, origin, traceWithCause(trace, ir.value, effectContext), effectContext, { cause: ir.value })
+      throw new ForkError('FX_UNHANDLED_FAILURE', `Unhandled failure in forked task`, origin, traceWithCause(trace, ir.value, effectContext, getTrace(ir.value)), effectContext, { cause: ir.value })
     }
   }
   return ir.value as A
@@ -294,22 +295,6 @@ class InterruptState {
     for (const task of this.tasks) void task.interrupt(this.reason).catch(() => { })
   }
 }
-
-class ForkError extends Error {
-  constructor(readonly code: ForkErrorCode, message: string, origin: Breadcrumb, trace: Trace | undefined, runtimeContext?: RuntimeContext, options?: ErrorOptions) {
-    super(message, options)
-    if (traceCapturePolicy(runtimeContext) === 'full' && 'stack' in origin) Object.defineProperty(this, 'stack', { get: () => origin.stack })
-    Object.defineProperty(this, 'code', {
-      value: code,
-      enumerable: false,
-      writable: false,
-      configurable: true
-    })
-    if (trace !== undefined) attachTrace(this, trace)
-  }
-}
-
-type ForkErrorCode = 'FX_AWAITED_ASYNC_FAILED' | 'FX_UNHANDLED_FORK_FAILURE' | 'FX_UNHANDLED_FAILURE' | 'FX_UNHANDLED_EXCEPTION'
 
 class UnhandledForkError extends Error {
   constructor(readonly error: unknown) {
@@ -419,71 +404,6 @@ const returnWithRuntimeContext = <E, A>(
       withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A }))
 
 const never = <A>(): Promise<A> => new Promise(() => { })
-
-const traceWithCause = (trace: Trace | undefined, cause: unknown, runtimeContext?: RuntimeContext): Trace | undefined => {
-  const causeTrace = getTrace(cause)
-  return captureAppendTraceWithContext(runtimeContext, causeTrace ?? trace, causeTrace === undefined ? undefined : trace)
-}
-
-const runtimeContextOfEffect = (effect: unknown, fallback?: RuntimeContext): RuntimeContext | undefined =>
-  getRuntimeContext(effect) ?? fallback
-
-const traceUnhandledFail = (
-  fail: Fail<unknown>,
-  causeTrace: Trace | undefined,
-  parentTrace: Trace | undefined,
-  runtimeContext?: RuntimeContext
-): Trace | undefined => {
-  if (causeTrace !== undefined) return captureAppendTraceWithContext(runtimeContext, causeTrace, parentTrace)
-  if (fail.trace === undefined) return captureAppendTraceWithContext(runtimeContext, undefined, parentTrace)
-  return parentTrace === undefined
-    ? fail.trace
-    : captureAppendTraceWithContext(runtimeContext, fail.trace, parentTrace) ?? fail.trace
-}
-
-const originOfUnhandledFail = (fail: Fail<unknown>, causeTrace: Trace | undefined): Breadcrumb =>
-  causeTrace === undefined ? fail.origin : originFromTrace(causeTrace)
-
-const forkFrameMetadata = (trace: Trace | undefined): TraceFrameMetadata => ({
-  kind: trace?.frame.kind ?? 'fork',
-  index: trace?.frame.index
-})
-
-const captureTraceWithContext = (
-  context: RuntimeContext | undefined,
-  origin: Breadcrumb,
-  parent?: Trace,
-  metadata?: TraceFrameMetadata
-): Trace | undefined =>
-  context === undefined
-    ? captureTrace(origin, parent, metadata)
-    : withActiveRuntimeContext(context, () => captureTrace(origin, parent, metadata))
-
-const capturePrependTraceWithContext = (
-  context: RuntimeContext | undefined,
-  origin: Breadcrumb,
-  parent?: Trace,
-  metadata?: TraceFrameMetadata
-): Trace | undefined =>
-  context === undefined
-    ? capturePrependTrace(origin, parent, metadata)
-    : withActiveRuntimeContext(context, () => capturePrependTrace(origin, parent, metadata))
-
-const captureAppendTraceWithContext = (
-  context: RuntimeContext | undefined,
-  trace: Trace | undefined,
-  parent?: Trace
-): Trace | undefined =>
-  context === undefined
-    ? captureAppendTrace(trace, parent)
-    : withActiveRuntimeContext(context, () => captureAppendTrace(trace, parent))
-
-const originFromTrace = (trace: Trace): Breadcrumb => ({
-  message: trace.frame.message,
-  get stack() {
-    return trace.frame.stackSource?.stack
-  }
-})
 
 class DisposableAbortController extends AbortController {
   [Symbol.dispose]() { this.abort() }

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -1,15 +1,16 @@
 import { Async } from '../Async.js'
 import { at, indexed } from '../Breadcrumb.js'
-import { Concurrently, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js'
+import { Concurrently, Fork, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js'
 import type { ConcurrentPolicy, ConcurrentResult, EffectsOf, ErrorsOf } from '../Concurrent.js'
 import { Fail, fail } from '../Fail.js'
-import { Fx, fx } from '../Fx.js'
+import { Fx, fx, runPromise } from '../Fx.js'
+import { Task } from '../Task.js'
 import type { TraceFrameKind, TraceOrigin } from '../Trace.js'
 import { captureTrace, getTrace } from '../Trace.js'
-import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js'
+import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, forkFrameMetadata, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from './forkDiagnostics.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
 import { withInterpretedReturn } from './iteratorClose.js'
-import { getRuntimeContext, withActiveRuntimeContext } from './runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, withActiveRuntimeContext } from './runtimeContext.js'
 
 export interface CooperativeConfig {
   readonly concurrency: number
@@ -47,6 +48,8 @@ interface Fiber {
   readonly iterator: Iterator<unknown, unknown, unknown>
   readonly traceOrigin: TraceOrigin
   readonly masks: InterruptMaskState
+  readonly runtimeContext: ReturnType<typeof getRuntimeContext>
+  slotAcquired: boolean
   status: 'ready' | 'waiting' | 'done'
   resume: Resume
   abort?: AbortController
@@ -69,15 +72,151 @@ interface GroupPolicy<S> {
   readonly onFailure: (state: S, index: number, error: unknown) => GroupDecision<S>
 }
 
-export const runCooperativeConcurrently = (config: CooperativeConfig) =>
-  <const Policy extends ConcurrentPolicy, const Fxs extends readonly Fx<unknown, unknown>[]>(
+export class CooperativeRuntime {
+  private readonly slotWaiters = [] as (() => void)[]
+  private availableSlots: number
+
+  constructor(readonly config: CooperativeConfig) {
+    this.availableSlots = Math.floor(config.concurrency)
+  }
+
+  readonly runConcurrently = <const Policy extends ConcurrentPolicy, const Fxs extends readonly Fx<unknown, unknown>[]>(
     group: Concurrently<Policy, Fxs>
   ): Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>> =>
-    cooperativeGroupFx(group, config, groupPolicy(group.arg.policy)) as Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>>
+    cooperativeGroupFx(this, group, groupPolicy(group.arg.policy)) as Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>>
+
+  readonly runFork = (fork: Fork): Fx<never, Task<unknown, unknown>> =>
+    fx(function* (this: CooperativeRuntime) {
+      return this.startFork(fork)
+    }.bind(this))
+
+  startFork(fork: Fork, onUnhandled?: (error: unknown) => void): Task<unknown, unknown> {
+    const context = getRuntimeContext(fork) ?? currentRuntimeContext()
+    const origin = fork.arg.origin
+    const trace = capturePrependTraceWithContext(context, origin, fork.arg.trace, forkFrameMetadata(fork.arg.trace))
+    const fiber: Fiber = {
+      index: -1,
+      iterator: fork.arg.fx[Symbol.iterator](),
+      traceOrigin: { origin, trace },
+      runtimeContext: context,
+      masks: new InterruptMaskState(),
+      slotAcquired: false,
+      status: 'ready',
+      resume: { type: 'next', value: undefined },
+      cancelRequested: false,
+      cleanupFailures: []
+    }
+    const done = Promise.withResolvers<unknown>()
+    const interrupted = Promise.withResolvers<void>()
+    let cleanup: Promise<void> = Promise.resolve()
+    let running = false
+    const wake = new Wake()
+    const task = new Task<unknown, unknown>(
+      done.promise,
+      reason => {
+        fiber.cancelRequested = true
+        fiber.abort?.abort(reason)
+        this.notifySlotWaiters()
+        if (!running) {
+          cleanup = this.drainFork(fiber, done)
+          running = true
+        }
+        cleanup.then(() => interrupted.resolve(), error => interrupted.reject(error))
+      },
+      context,
+      interrupted.promise
+    )
+    this.tryAcquireSlot(fiber)
+    done.promise.catch(error => {
+      queueMicrotask(() => {
+        if (task._handled || task._interrupted || fiber.cancelRequested) return
+        onUnhandled?.(new ForkError('FX_UNHANDLED_FORK_FAILURE', 'Unhandled failure in forked task', origin, traceWithCause(trace, error, runtimeContextOfEffect(error, context), getTrace(error)), runtimeContextOfEffect(error, context), { cause: error }))
+      })
+    })
+    queueMicrotask(() => {
+      if (running) return
+      running = true
+      cleanup = this.drainFork(fiber, done, wake)
+    })
+    return task
+  }
+
+  private async drainFork(fiber: Fiber, done: PromiseWithResolvers<unknown>, wake = new Wake()): Promise<void> {
+    try {
+      while (!fiber.slotAcquired) {
+        if (fiber.cancelRequested) {
+          finishDetachedFiber(this, fiber)
+          return
+        }
+        if (this.tryAcquireSlot(fiber)) break
+        await this.waitForSlotPromise()
+      }
+      while (fiber.status !== 'done') {
+        if (fiber.status === 'waiting') {
+          await runPromise(wake.wait())
+          continue
+        }
+        if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+          await runPromise(fx(function* () { yield* closeFiber(fiber) }) as Fx<any, void>)
+          finishDetachedFiber(this, fiber)
+          if (fiber.cleanupFailures.length > 0) done.reject(resourceReleaseFailed(fiber.cleanupFailures))
+          return
+        }
+        const step = stepFiber(this, fiber, wake, {
+          succeed: value => {
+            finishDetachedFiber(this, fiber)
+            done.resolve(value)
+          },
+          fail: error => {
+            finishDetachedFiber(this, fiber)
+            done.reject(error)
+          },
+          cancel: () => {
+            finishDetachedFiber(this, fiber)
+          }
+        })
+        await runPromise(fx(function* () { yield* step }) as Fx<any, void>)
+        if (fiber.status === 'ready') await Promise.resolve()
+      }
+    } catch (error) {
+      finishDetachedFiber(this, fiber)
+      done.reject(error)
+    }
+  }
+
+  tryAcquireSlot(fiber: Fiber): boolean {
+    if (fiber.slotAcquired) return true
+    if (this.availableSlots <= 0) return false
+    this.availableSlots--
+    fiber.slotAcquired = true
+    return true
+  }
+
+  releaseSlot(fiber: Fiber) {
+    if (!fiber.slotAcquired) return
+    fiber.slotAcquired = false
+    this.availableSlots++
+    this.notifySlotWaiters()
+  }
+
+  waitForSlot() {
+    return AsyncWait(this.slotWaiters)
+  }
+
+  private waitForSlotPromise() {
+    if (this.availableSlots > 0) return Promise.resolve()
+    return new Promise<void>(resolve => this.slotWaiters.push(resolve))
+  }
+
+  private notifySlotWaiters() {
+    const waiters = this.slotWaiters.splice(0)
+    for (const waiter of waiters) waiter()
+  }
+}
 
 const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S>(
+  runtime: CooperativeRuntime,
   group: Concurrently<ConcurrentPolicy, Fxs>,
-  config: CooperativeConfig,
   policy: GroupPolicy<S>
 ) => fx(function* () {
   const fxs = group.arg.fxs
@@ -98,17 +237,20 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
   let outcome: Exclude<GroupDecision<S>, { readonly type: 'continue' }> | undefined = emptyOutcome(policy, state, fxs.length)
 
   const startNext = () => {
-    while (outcome === undefined && active < config.concurrency && next < fxs.length) {
+    while (outcome === undefined && next < fxs.length) {
       const fiber: Fiber = {
         index: next,
         iterator: fxs[next][Symbol.iterator](),
         traceOrigin: childTraceOriginWithContext(context, parentTraceOrigin, next, childKind),
+        runtimeContext: context,
         masks: new InterruptMaskState(),
+        slotAcquired: false,
         status: 'ready',
         resume: { type: 'next', value: undefined },
         cancelRequested: false,
         cleanupFailures: []
       }
+      if (!runtime.tryAcquireSlot(fiber)) break
       next++
       active++
       fibers.push(fiber)
@@ -120,6 +262,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
     if (fiber.status === 'done') return
     fiber.status = 'done'
     fiber.abort?.abort()
+    runtime.releaseSlot(fiber)
     active--
     done++
   }
@@ -146,6 +289,10 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
       startNext()
 
       if (ready.length === 0) {
+        if (active === 0 && next < fxs.length) {
+          yield* runtime.waitForSlot()
+          continue
+        }
         if (active === 0) break
         ready.push(...(yield* wake.wait()))
         continue
@@ -159,59 +306,11 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
         continue
       }
 
-      let budget = config.yieldBudget
-      while (budget > 0 && fiber.status === 'ready') {
-        budget--
-        let ir: IteratorResult<unknown, unknown>
-        try {
-          ir = fiber.resume.type === 'throw'
-            ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
-            : fiber.iterator.next(fiber.resume.value)
-        } catch (e) {
-          failFiber(fiber, { error: wrapThrownFiberError(fiber, e) })
-          break
-        }
-        fiber.resume = { type: 'next', value: undefined }
-
-        if (ir.done) {
-          succeedFiber(fiber, ir.value)
-          break
-        }
-
-        if (Async.is(ir.value)) {
-          startCooperativeAsync(fiber, ir.value, wake, failFiber)
-          break
-        }
-
-        if (Concurrently.is(ir.value)) {
-          fiber.resume = { type: 'next', value: yield* runCooperativeConcurrently(config)(ir.value as Concurrently<ConcurrentPolicy, readonly Fx<unknown, unknown>[]>) }
-          continue
-        }
-
-        if (Fail.is(ir.value)) {
-          failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) })
-          break
-        }
-
-        if (InterruptMaskBegin.is(ir.value)) {
-          fiber.masks.mask(ir.value.arg)
-          fiber.resume = { type: 'next', value: undefined }
-          continue
-        }
-
-        if (InterruptMaskEnd.is(ir.value)) {
-          fiber.masks.unmask(ir.value.arg)
-          if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-            yield* closeFiber(fiber)
-            finish(fiber)
-            break
-          }
-          fiber.resume = { type: 'next', value: undefined }
-          continue
-        }
-
-        fiber.resume = { type: 'next', value: yield ir.value as any }
-      }
+      yield* stepFiber(runtime, fiber, wake, {
+        succeed: value => succeedFiber(fiber, value),
+        fail: error => failFiber(fiber, { error }),
+        cancel: () => finish(fiber)
+      })
 
       if (fiber.status === 'ready') ready.push(fiber)
     }
@@ -351,6 +450,87 @@ const startCooperativeAsync = (
   )
 }
 
+interface FiberCallbacks {
+  readonly succeed: (value: unknown) => void
+  readonly fail: (error: unknown) => void
+  readonly cancel?: () => void
+}
+
+function* stepFiber(
+  runtime: CooperativeRuntime,
+  fiber: Fiber,
+  wake: Wake,
+  callbacks: FiberCallbacks
+): Generator<unknown, void, unknown> {
+  let budget = runtime.config.yieldBudget
+  while (budget > 0 && fiber.status === 'ready') {
+    budget--
+    let ir: IteratorResult<unknown, unknown>
+    try {
+      ir = fiber.resume.type === 'throw'
+        ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
+        : fiber.iterator.next(fiber.resume.value)
+    } catch (e) {
+      callbacks.fail(wrapThrownFiberError(fiber, e))
+      break
+    }
+    fiber.resume = { type: 'next', value: undefined }
+
+    if (ir.done) {
+      callbacks.succeed(ir.value)
+      break
+    }
+
+    if (Async.is(ir.value)) {
+      startCooperativeAsync(fiber, ir.value, wake, (_fiber, failure) => {
+        callbacks.fail(failure.error)
+      })
+      break
+    }
+
+    if (Concurrently.is(ir.value)) {
+      fiber.resume = { type: 'next', value: yield* runtime.runConcurrently(ir.value as Concurrently<ConcurrentPolicy, readonly Fx<unknown, unknown>[]>) }
+      continue
+    }
+
+    if (Fork.is(ir.value)) {
+      fiber.resume = {
+        type: 'next',
+        value: runtime.startFork(ir.value, error => {
+          if (fiber.status === 'done') return
+          callbacks.fail(error)
+          wake.notify()
+        })
+      }
+      continue
+    }
+
+    if (Fail.is(ir.value)) {
+      callbacks.fail(wrapFiberFailure(fiber, ir.value))
+      break
+    }
+
+    if (InterruptMaskBegin.is(ir.value)) {
+      fiber.masks.mask(ir.value.arg)
+      fiber.resume = { type: 'next', value: undefined }
+      continue
+    }
+
+    if (InterruptMaskEnd.is(ir.value)) {
+      fiber.masks.unmask(ir.value.arg)
+      if (fiber.cancelRequested && fiber.masks.canInterrupt) {
+        yield* closeFiber(fiber)
+        callbacks.cancel?.()
+        break
+      }
+      fiber.resume = { type: 'next', value: undefined }
+      continue
+    }
+
+    fiber.resume = { type: 'next', value: yield ir.value as any }
+  }
+}
+
 function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
   fiber.abort?.abort()
   fiber.abort = undefined
@@ -385,6 +565,13 @@ function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
   }
 }
 
+const finishDetachedFiber = (runtime: CooperativeRuntime, fiber: Fiber) => {
+  if (fiber.status === 'done') return
+  fiber.status = 'done'
+  fiber.abort?.abort()
+  runtime.releaseSlot(fiber)
+}
+
 const cancelActiveFibers = (fibers: readonly Fiber[], except?: Fiber) => {
   for (const fiber of fibers) {
     if (fiber === except || fiber.status === 'done') continue
@@ -396,7 +583,7 @@ const cancelActiveFibers = (fibers: readonly Fiber[], except?: Fiber) => {
 }
 
 const wrapFiberFailure = (fiber: Fiber, failure: Fail<unknown>): ForkError => {
-  const context = runtimeContextOfEffect(failure)
+  const context = runtimeContextOfEffect(failure, fiber.runtimeContext)
   const causeTrace = getTrace(failure.arg)
   const trace = traceUnhandledFail(failure, causeTrace, fiber.traceOrigin.trace, context)
   const origin = originOfUnhandledFail(failure, causeTrace)
@@ -404,7 +591,7 @@ const wrapFiberFailure = (fiber: Fiber, failure: Fail<unknown>): ForkError => {
 }
 
 const wrapThrownFiberError = (fiber: Fiber, error: unknown): ForkError => {
-  const context = runtimeContextOfEffect(error)
+  const context = runtimeContextOfEffect(error, fiber.runtimeContext)
   return new ForkError('FX_UNHANDLED_EXCEPTION', 'Unhandled exception in forked task', fiber.traceOrigin.origin, traceWithCause(fiber.traceOrigin.trace, error, context, getTrace(error)), context, { cause: error })
 }
 

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -299,7 +299,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
           continue
         }
         if (active === 0) break
-        ready.push(...(yield* wake.wait()))
+        appendReady(ready, yield* wake.wait())
         continue
       }
 
@@ -377,13 +377,13 @@ const childFrameKind = (trace: TraceOrigin['trace'] | undefined) =>
   trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'
 
 const groupPolicy = (policy: ConcurrentPolicy): GroupPolicy<any> => {
-  if (policy === allPolicy) return allGroupPolicy()
-  if (policy === firstSettledPolicy) return raceGroupPolicy()
-  if (policy === firstSuccessPolicy) return firstSuccessGroupPolicy()
+  if (policy === allPolicy) return allGroupPolicy
+  if (policy === firstSettledPolicy) return raceGroupPolicy
+  if (policy === firstSuccessPolicy) return firstSuccessGroupPolicy
   throw new TypeError('Unknown concurrency policy')
 }
 
-const allGroupPolicy = (): GroupPolicy<{ readonly results: unknown[], completed: number }> => ({
+const allGroupPolicy: GroupPolicy<{ readonly results: unknown[], completed: number }> = {
   init: size => ({ results: sparseArray(size), completed: 0 }),
   onEmpty: state => ({ type: 'succeed', state, value: state.results, cancelRest: false }),
   onSuccess: (state, index, value) => {
@@ -394,26 +394,30 @@ const allGroupPolicy = (): GroupPolicy<{ readonly results: unknown[], completed:
       : { type: 'continue', state }
   },
   onFailure: (state, _index, error) => ({ type: 'fail', state, error, cancelRest: true })
-})
+}
 
-const raceGroupPolicy = (): GroupPolicy<void> => ({
+const raceGroupPolicy: GroupPolicy<void> = {
   init: () => undefined,
   onSuccess: (_state, _index, value) => ({ type: 'succeed', state: undefined, value, cancelRest: true }),
   onFailure: (_state, _index, error) => ({ type: 'fail', state: undefined, error, cancelRest: true })
-})
+}
 
-const firstSuccessGroupPolicy = (): GroupPolicy<{ readonly size: number, readonly failures: unknown[] }> => ({
-  init: size => ({ size, failures: sparseArray(size) }),
+const firstSuccessGroupPolicy: GroupPolicy<{ readonly size: number, readonly failures: unknown[], failed: number }> = {
+  init: size => ({ size, failures: sparseArray(size), failed: 0 }),
   onEmpty: state => ({ type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: false }),
   onSuccess: (state, _index, value) => ({ type: 'succeed', state, value, cancelRest: true }),
   onFailure: (state, index, error) => {
     state.failures[index] = error
-    const failed = state.failures.filter((_, i) => i in state.failures).length
-    return failed === state.size
+    state.failed++
+    return state.failed === state.size
       ? { type: 'fail', state, error: new RaceAllFailed(state.failures), cancelRest: true }
       : { type: 'continue', state }
   }
-})
+}
+
+const appendReady = (ready: Fiber[], fibers: readonly Fiber[]) => {
+  for (const fiber of fibers) ready.push(fiber)
+}
 
 const sparseArray = (length: number): unknown[] => {
   const array = [] as unknown[]

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -4,7 +4,7 @@ import { Concurrently, Fork, RaceAllFailed } from '../Concurrent.js'
 import type { ConcurrentPolicy, ConcurrentResult, EffectsOf, ErrorsOf } from '../Concurrent.js'
 import { Fail, fail } from '../Fail.js'
 import { Fx, fx, runPromise } from '../Fx.js'
-import { HandlerCapture } from '../HandlerCapture.js'
+import { HandlerCapture, handleCaptured } from '../HandlerCapture.js'
 import { Task } from '../Task.js'
 import type { TraceFrameKind, TraceOrigin } from '../Trace.js'
 import { captureTrace, getTrace } from '../Trace.js'
@@ -167,7 +167,7 @@ export class CooperativeRuntime {
           continue
         }
         if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-          await runPromise(fx(function* () { yield* closeFiber(fiber) }) as Fx<any, void>)
+          await runPromise(fx(function* (this: CooperativeRuntime) { yield* closeFiber(this, fiber) }.bind(this)) as Fx<any, void>)
           finishDetachedFiber(this, fiber)
           if (fiber.cleanupFailures.length > 0) done.reject(resourceReleaseFailed(fiber.cleanupFailures))
           return
@@ -325,7 +325,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
       }
       if (fiber.status !== 'ready') continue
       if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-        yield* closeFiber(fiber)
+        yield* closeFiber(runtime, fiber)
         finish(fiber)
         continue
       }
@@ -345,7 +345,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
       cancelActiveFibers(fibers)
       for (const fiber of fibers) {
         if (fiber.status !== 'done') {
-          yield* closeFiber(fiber)
+          yield* closeFiber(runtime, fiber)
           finish(fiber)
         }
       }
@@ -368,7 +368,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
       cancelActiveFibers(fibers)
       for (const fiber of fibers) {
         if (fiber.status !== 'done') {
-          yield* closeFiber(fiber)
+          yield* closeFiber(runtime, fiber)
           finish(fiber)
         }
       }
@@ -559,7 +559,7 @@ function* stepFiber(
     if (InterruptMaskEnd.is(ir.value)) {
       fiber.masks.unmask(ir.value.arg)
       if (fiber.cancelRequested && fiber.masks.canInterrupt) {
-        yield* closeFiber(fiber)
+        yield* closeFiber(runtime, fiber)
         callbacks.cancel?.()
         break
       }
@@ -585,7 +585,10 @@ function* reacquireSlot(
   while (!runtime.tryAcquireSlot(fiber)) yield* runtime.waitForSlot()
 }
 
-function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
+function* closeFiber(
+  runtime: CooperativeRuntime,
+  fiber: Fiber
+): Generator<unknown, void, unknown> {
   fiber.abort?.abort()
   fiber.abort = undefined
   let ir: IteratorResult<unknown, unknown>
@@ -600,6 +603,14 @@ function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
     try {
       if (Async.is(ir.value)) {
         ir = fiber.iterator.next(yield ir.value as any)
+      } else if (Concurrently.is(ir.value)) {
+        try {
+          ir = fiber.iterator.next(yield* runtime.runNestedConcurrently(ir.value as Concurrently<ConcurrentPolicy, readonly Fx<unknown, unknown>[]>, fiber))
+        } finally {
+          yield* reacquireSlot(runtime, fiber)
+        }
+      } else if (Fork.is(ir.value)) {
+        ir = fiber.iterator.next(runtime.startFork(ir.value))
       } else if (Fail.is(ir.value)) {
         fiber.cleanupFailures.push(ir.value.arg)
         return
@@ -609,8 +620,16 @@ function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
       } else if (InterruptMaskEnd.is(ir.value)) {
         fiber.masks.unmask(ir.value.arg)
         ir = fiber.iterator.next()
+      } else if (HandlerCapture.is(ir.value)) {
+        const releaseSlotBeforeResume = fiber.slotAcquired
+        if (releaseSlotBeforeResume) runtime.releaseSlot(fiber)
+        try {
+          ir = fiber.iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value))
+        } finally {
+          if (releaseSlotBeforeResume) yield* reacquireSlot(runtime, fiber)
+        }
       } else {
-        ir = fiber.iterator.next(yield ir.value as any)
+        ir = fiber.iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value))
       }
     } catch (e) {
       fiber.cleanupFailures.push(e)
@@ -618,6 +637,18 @@ function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
     }
   }
 }
+
+const runCleanupEffect = (
+  runtime: CooperativeRuntime,
+  fiber: Fiber,
+  effect: unknown
+) =>
+  fx(function* () {
+    return yield effect as any
+  }).pipe(
+    handleCaptured('fx/Concurrent/Concurrently', Concurrently, group => runtime.runNestedConcurrently(group, fiber)),
+    handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)
+  ) as Fx<unknown, unknown>
 
 const finishDetachedFiber = (runtime: CooperativeRuntime, fiber: Fiber) => {
   if (fiber.status === 'done') return

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -3,8 +3,8 @@ import { at, indexed } from '../Breadcrumb.js'
 import { Concurrently, Fork, RaceAllFailed } from '../Concurrent.js'
 import type { ConcurrentPolicy, ConcurrentResult, EffectsOf, ErrorsOf } from '../Concurrent.js'
 import { Fail, fail } from '../Fail.js'
-import { Fx, fx, runPromise } from '../Fx.js'
-import { HandlerCapture, handleCaptured } from '../HandlerCapture.js'
+import { flatMap, flatten, Fx, fx, ok, runPromise } from '../Fx.js'
+import { HandlerCapture, handleCaptured, withCapturedHandlers } from '../HandlerCapture.js'
 import { Task } from '../Task.js'
 import type { TraceFrameKind, TraceOrigin } from '../Trace.js'
 import { captureTrace, getTrace } from '../Trace.js'
@@ -643,11 +643,21 @@ const runCleanupEffect = (
   fiber: Fiber,
   effect: unknown
 ) =>
-  fx(function* () {
+  withCapturedHandlers('fx/Concurrent/Concurrently', fx(function* () {
     return yield effect as any
-  }).pipe(
-    handleCaptured('fx/Concurrent/Concurrently', Concurrently, group => runtime.runNestedConcurrently(group, fiber)),
-    handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)
+  })).pipe(
+    flatMap(fx =>
+      withCapturedHandlers(
+        'fx/Concurrent/Fork',
+        fx.pipe(handleCaptured('fx/Concurrent/Concurrently', Concurrently, group => runtime.runNestedConcurrently(group, fiber)))
+      )
+    ),
+    flatMap(fx =>
+      ok(fx.pipe(
+        handleCaptured('fx/Concurrent/Fork', Fork, runtime.runFork)
+      ))
+    ),
+    flatten
   ) as Fx<unknown, unknown>
 
 const finishDetachedFiber = (runtime: CooperativeRuntime, fiber: Fiber) => {

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -1,6 +1,6 @@
 import { Async } from '../Async.js'
 import { at, indexed } from '../Breadcrumb.js'
-import { Concurrently, Fork, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js'
+import { Concurrently, Fork, RaceAllFailed } from '../Concurrent.js'
 import type { ConcurrentPolicy, ConcurrentResult, EffectsOf, ErrorsOf } from '../Concurrent.js'
 import { Fail, fail } from '../Fail.js'
 import { Fx, fx, runPromise } from '../Fx.js'
@@ -393,10 +393,11 @@ const childFrameKind = (trace: TraceOrigin['trace'] | undefined) =>
   trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'
 
 const groupPolicy = (policy: ConcurrentPolicy): GroupPolicy<any> => {
-  if (policy === allPolicy) return allGroupPolicy
-  if (policy === firstSettledPolicy) return raceGroupPolicy
-  if (policy === firstSuccessPolicy) return firstSuccessGroupPolicy
-  throw new TypeError('Unknown concurrency policy')
+  switch (policy.tag) {
+    case 'all': return allGroupPolicy
+    case 'firstSettled': return raceGroupPolicy
+    case 'firstSuccess': return firstSuccessGroupPolicy
+  }
 }
 
 const allGroupPolicy: GroupPolicy<{ readonly results: unknown[], completed: number }> = {

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -4,6 +4,7 @@ import { Concurrently, Fork, RaceAllFailed, allPolicy, firstSettledPolicy, first
 import type { ConcurrentPolicy, ConcurrentResult, EffectsOf, ErrorsOf } from '../Concurrent.js'
 import { Fail, fail } from '../Fail.js'
 import { Fx, fx, runPromise } from '../Fx.js'
+import { HandlerCapture } from '../HandlerCapture.js'
 import { Task } from '../Task.js'
 import type { TraceFrameKind, TraceOrigin } from '../Trace.js'
 import { captureTrace, getTrace } from '../Trace.js'
@@ -55,6 +56,7 @@ interface Fiber {
   abort?: AbortController
   cancelRequested: boolean
   cleanupFailures: unknown[]
+  releaseSlotBeforeResume: boolean
 }
 
 type PrimaryFailure =
@@ -62,6 +64,7 @@ type PrimaryFailure =
 
 type GroupDecision<S> =
   | { readonly type: 'continue', readonly state: S }
+  | { readonly type: 'pending', readonly state: S }
   | { readonly type: 'succeed', readonly state: S, readonly value: unknown, readonly cancelRest: boolean }
   | { readonly type: 'fail', readonly state: S, readonly error: unknown, readonly cancelRest: boolean }
 
@@ -85,6 +88,12 @@ export class CooperativeRuntime {
   ): Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>> =>
     cooperativeGroupFx(this, group, groupPolicy(group.arg.policy)) as Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>>
 
+  readonly runNestedConcurrently = <const Policy extends ConcurrentPolicy, const Fxs extends readonly Fx<unknown, unknown>[]>(
+    group: Concurrently<Policy, Fxs>,
+    parent: Fiber
+  ): Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>> =>
+    cooperativeGroupFx(this, group, groupPolicy(group.arg.policy), parent) as Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>>
+
   readonly runFork = (fork: Fork): Fx<never, Task<unknown, unknown>> =>
     fx(function* (this: CooperativeRuntime) {
       return this.startFork(fork)
@@ -104,7 +113,8 @@ export class CooperativeRuntime {
       status: 'ready',
       resume: { type: 'next', value: undefined },
       cancelRequested: false,
-      cleanupFailures: []
+      cleanupFailures: [],
+      releaseSlotBeforeResume: false
     }
     const done = Promise.withResolvers<unknown>()
     const interrupted = Promise.withResolvers<void>()
@@ -219,7 +229,8 @@ export class CooperativeRuntime {
 const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S>(
   runtime: CooperativeRuntime,
   group: Concurrently<ConcurrentPolicy, Fxs>,
-  policy: GroupPolicy<S>
+  policy: GroupPolicy<S>,
+  borrowedSlotFrom?: Fiber
 ) => fx(function* () {
   const fxs = group.arg.fxs
   const fibers = [] as Fiber[]
@@ -251,9 +262,13 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
         status: 'ready',
         resume: { type: 'next', value: undefined },
         cancelRequested: false,
-        cleanupFailures: []
+        cleanupFailures: [],
+        releaseSlotBeforeResume: false
       }
-      if (!runtime.tryAcquireSlot(fiber)) break
+      if (borrowedSlotFrom?.slotAcquired) {
+        borrowedSlotFrom.slotAcquired = false
+        fiber.slotAcquired = true
+      } else if (!runtime.tryAcquireSlot(fiber)) break
       next++
       active++
       fibers.push(fiber)
@@ -274,7 +289,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
     state = decision.state
     if (decision.type === 'continue') return
     outcome ??= decision
-    if (decision.cancelRest) cancelActiveFibers(fibers)
+    if (decision.type !== 'pending' && decision.cancelRest) cancelActiveFibers(fibers)
   }
 
   const succeedFiber = (fiber: Fiber, value: unknown) => {
@@ -342,6 +357,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
           : cleanupFailures
         return (yield* fail(resourceReleaseFailed(failures))) as never
       }
+      if (outcome.type === 'pending') return yield* waitForInterruption()
       if (outcome.type === 'fail') return (yield* fail(outcome.error)) as never
       return outcome.value
     }
@@ -398,6 +414,7 @@ const allGroupPolicy: GroupPolicy<{ readonly results: unknown[], completed: numb
 
 const raceGroupPolicy: GroupPolicy<void> = {
   init: () => undefined,
+  onEmpty: state => ({ type: 'pending', state }),
   onSuccess: (_state, _index, value) => ({ type: 'succeed', state: undefined, value, cancelRest: true }),
   onFailure: (_state, _index, error) => ({ type: 'fail', state: undefined, error, cancelRest: true })
 }
@@ -479,6 +496,9 @@ function* stepFiber(
   while (budget > 0 && fiber.status === 'ready') {
     budget--
     let ir: IteratorResult<unknown, unknown>
+    const releaseSlotBeforeResume = fiber.releaseSlotBeforeResume && fiber.slotAcquired
+    fiber.releaseSlotBeforeResume = false
+    if (releaseSlotBeforeResume) runtime.releaseSlot(fiber)
     try {
       ir = fiber.resume.type === 'throw'
         ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
@@ -486,6 +506,8 @@ function* stepFiber(
     } catch (e) {
       callbacks.fail(wrapThrownFiberError(fiber, e))
       break
+    } finally {
+      if (releaseSlotBeforeResume) yield* reacquireSlot(runtime, fiber)
     }
     fiber.resume = { type: 'next', value: undefined }
 
@@ -502,7 +524,11 @@ function* stepFiber(
     }
 
     if (Concurrently.is(ir.value)) {
-      fiber.resume = { type: 'next', value: yield* runtime.runConcurrently(ir.value as Concurrently<ConcurrentPolicy, readonly Fx<unknown, unknown>[]>) }
+      try {
+        fiber.resume = { type: 'next', value: yield* runtime.runNestedConcurrently(ir.value as Concurrently<ConcurrentPolicy, readonly Fx<unknown, unknown>[]>, fiber) }
+      } finally {
+        yield* reacquireSlot(runtime, fiber)
+      }
       continue
     }
 
@@ -540,8 +566,22 @@ function* stepFiber(
       continue
     }
 
+    if (HandlerCapture.is(ir.value)) {
+      fiber.resume = { type: 'next', value: yield ir.value as any }
+      fiber.releaseSlotBeforeResume = true
+      continue
+    }
+
     fiber.resume = { type: 'next', value: yield ir.value as any }
   }
+}
+
+function* reacquireSlot(
+  runtime: CooperativeRuntime,
+  fiber: Fiber
+): Generator<unknown, void, unknown> {
+  if (fiber.status === 'done') return
+  while (!runtime.tryAcquireSlot(fiber)) yield* runtime.waitForSlot()
 }
 
 function* closeFiber(fiber: Fiber): Generator<unknown, void, unknown> {
@@ -667,6 +707,15 @@ const AsyncWait = (waiters: (() => void)[]) =>
     origin: at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait),
     trace: captureTrace(at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait), undefined, { kind: 'async' })
   }) as Fx<Async, void>
+
+const waitForInterruption = () =>
+  new Async({
+    run: signal => new Promise<never>((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+    }),
+    origin: at('fx/Concurrent/withCoopConcurrency/pending', waitForInterruption),
+    trace: captureTrace(at('fx/Concurrent/withCoopConcurrency/pending', waitForInterruption), undefined, { kind: 'async' })
+  }) as Fx<Async, never>
 
 const resourceReleaseFailed = (failures: readonly unknown[]) =>
   new AggregateError(failures, 'Resource release failed')

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -1,7 +1,7 @@
 import { Async } from '../Async.js'
 import { at, indexed } from '../Breadcrumb.js'
-import { All, Race, RaceAllFailed } from '../Concurrent.js'
-import type { EffectsOf, ErrorsOf, ResultOf } from '../Concurrent.js'
+import { Concurrently, RaceAllFailed, allPolicy, firstSettledPolicy, firstSuccessPolicy } from '../Concurrent.js'
+import type { ConcurrentPolicy, ConcurrentResult, EffectsOf, ErrorsOf } from '../Concurrent.js'
 import { Fail, fail } from '../Fail.js'
 import { Fx, fx } from '../Fx.js'
 import type { TraceFrameKind, TraceOrigin } from '../Trace.js'
@@ -16,13 +16,11 @@ export interface CooperativeConfig {
   readonly yieldBudget: number
 }
 
-export type CooperativeRacePolicy = 'firstSettled' | 'firstSuccess'
-
-type CooperativeRaceEffects<E> = Async | ErrorsOf<EffectsOfRace<E>> | FirstSuccessRaceFailure<E>
-type EffectsOfRace<E> = E extends Race<infer Fxs> ? EffectsOf<Fxs[number]> : never
-type FirstSuccessRaceFailure<E> = E extends Race<infer Fxs>
-  ? EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
+export type CooperativeConcurrentlyEffects<E> = E extends Concurrently<infer Policy, infer Fxs>
+  ? Policy['tag'] extends 'firstSuccess' ? Async | FirstSuccessFailure<Fxs> : Async | ErrorsOf<EffectsOf<Fxs[number]>>
   : never
+type FirstSuccessFailure<Fxs extends readonly Fx<unknown, unknown>[]> =
+  EveryFxCanFail<Fxs> extends true ? Fail<RaceAllFailed<FailuresOfFxs<Fxs>>> : never
 type EveryFxCanFail<Fxs extends readonly Fx<unknown, unknown>[]> = Fxs extends readonly []
   ? true
   : number extends Fxs['length']
@@ -71,25 +69,14 @@ interface GroupPolicy<S> {
   readonly onFailure: (state: S, index: number, error: unknown) => GroupDecision<S>
 }
 
-export const runCooperativeAll = (config: CooperativeConfig) =>
-  <const Fxs extends readonly Fx<unknown, unknown>[]>(
-    all: All<Fxs>
-  ): Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-    readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-  }> => cooperativeGroupFx(all, config, allPolicy()) as Fx<Async | ErrorsOf<EffectsOf<Fxs[number]>>, {
-  readonly [K in keyof Fxs]: ResultOf<Fxs[K]>
-}>
-
-export const runCooperativeRace = (config: CooperativeConfig, racePolicy: CooperativeRacePolicy) =>
-  <const Fxs extends readonly Fx<unknown, unknown>[]>(
-    race: Race<Fxs>
-  ): Fx<CooperativeRaceEffects<Race<Fxs>>, ResultOf<Fxs[number]>> => {
-    const policy: GroupPolicy<any> = racePolicy === 'firstSuccess' ? firstSuccessGroupPolicy() : raceGroupPolicy()
-    return cooperativeGroupFx(race, config, policy) as Fx<CooperativeRaceEffects<Race<Fxs>>, ResultOf<Fxs[number]>>
-  }
+export const runCooperativeConcurrently = (config: CooperativeConfig) =>
+  <const Policy extends ConcurrentPolicy, const Fxs extends readonly Fx<unknown, unknown>[]>(
+    group: Concurrently<Policy, Fxs>
+  ): Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>> =>
+    cooperativeGroupFx(group, config, groupPolicy(group.arg.policy)) as Fx<CooperativeConcurrentlyEffects<Concurrently<Policy, Fxs>>, ConcurrentResult<Policy, Fxs>>
 
 const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S>(
-  group: All<Fxs> | Race<Fxs>,
+  group: Concurrently<ConcurrentPolicy, Fxs>,
   config: CooperativeConfig,
   policy: GroupPolicy<S>
 ) => fx(function* () {
@@ -196,6 +183,11 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
           break
         }
 
+        if (Concurrently.is(ir.value)) {
+          fiber.resume = { type: 'next', value: yield* runCooperativeConcurrently(config)(ir.value as Concurrently<ConcurrentPolicy, readonly Fx<unknown, unknown>[]>) }
+          continue
+        }
+
         if (Fail.is(ir.value)) {
           failFiber(fiber, { error: wrapFiberFailure(fiber, ir.value) })
           break
@@ -270,13 +262,20 @@ const emptyOutcome = <S>(
   return decision?.type === 'continue' ? undefined : decision
 }
 
-const groupKind = (group: All<any> | Race<any>): TraceFrameKind =>
-  All.is(group) ? 'all' : 'race'
+const groupKind = (group: Concurrently<ConcurrentPolicy, any>): TraceFrameKind =>
+  group.arg.policy.tag === 'all' ? 'all' : 'race'
 
 const childFrameKind = (trace: TraceOrigin['trace'] | undefined) =>
   trace?.frame.kind === 'all' || trace?.frame.kind === 'race' ? trace.frame.kind : 'fork'
 
-const allPolicy = (): GroupPolicy<{ readonly results: unknown[], completed: number }> => ({
+const groupPolicy = (policy: ConcurrentPolicy): GroupPolicy<any> => {
+  if (policy === allPolicy) return allGroupPolicy()
+  if (policy === firstSettledPolicy) return raceGroupPolicy()
+  if (policy === firstSuccessPolicy) return firstSuccessGroupPolicy()
+  throw new TypeError('Unknown concurrency policy')
+}
+
+const allGroupPolicy = (): GroupPolicy<{ readonly results: unknown[], completed: number }> => ({
   init: size => ({ results: sparseArray(size), completed: 0 }),
   onEmpty: state => ({ type: 'succeed', state, value: state.results, cancelRest: false }),
   onSuccess: (state, index, value) => {
@@ -326,9 +325,17 @@ const startCooperativeAsync = (
   const context = getRuntimeContext(async)
   const run = () => async.arg.run(abort.signal)
   const promise = context === undefined ? run() : withActiveRuntimeContext(context, run)
+  const wakeOnAbort = () => {
+    if (fiber.status !== 'waiting') return
+    fiber.abort = undefined
+    fiber.status = 'ready'
+    wake.ready(fiber)
+  }
+  abort.signal.addEventListener('abort', wakeOnAbort, { once: true })
   promise.then(
     value => {
       if (fiber.status !== 'waiting') return
+      abort.signal.removeEventListener('abort', wakeOnAbort)
       fiber.abort = undefined
       fiber.resume = { type: 'next', value }
       fiber.status = 'ready'
@@ -336,6 +343,7 @@ const startCooperativeAsync = (
     },
     error => {
       if (fiber.status !== 'waiting') return
+      abort.signal.removeEventListener('abort', wakeOnAbort)
       fiber.abort = undefined
       failFiber(fiber, { error: wrapAsyncFiberError(fiber, async, error, context) })
       wake.notify()
@@ -454,8 +462,8 @@ const AsyncWait = (waiters: (() => void)[]) =>
       signal.addEventListener('abort', resolveOnce, { once: true })
       waiters.push(resolveOnce)
     }),
-    origin: at('fx/Concurrent/cooperativeStructured/wait', AsyncWait),
-    trace: captureTrace(at('fx/Concurrent/cooperativeStructured/wait', AsyncWait), undefined, { kind: 'async' })
+    origin: at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait),
+    trace: captureTrace(at('fx/Concurrent/withCoopConcurrency/wait', AsyncWait), undefined, { kind: 'async' })
   }) as Fx<Async, void>
 
 const resourceReleaseFailed = (failures: readonly unknown[]) =>

--- a/src/internal/withCoopConcurrency.ts
+++ b/src/internal/withCoopConcurrency.ts
@@ -73,7 +73,7 @@ interface GroupPolicy<S> {
 }
 
 export class CooperativeRuntime {
-  private readonly slotWaiters = [] as (() => void)[]
+  private slotWaiters = [] as (() => void)[]
   private availableSlots: number
 
   constructor(readonly config: CooperativeConfig) {
@@ -209,7 +209,9 @@ export class CooperativeRuntime {
   }
 
   private notifySlotWaiters() {
-    const waiters = this.slotWaiters.splice(0)
+    if (this.slotWaiters.length === 0) return
+    const waiters = this.slotWaiters
+    this.slotWaiters = []
     for (const waiter of waiters) waiter()
   }
 }
@@ -222,6 +224,7 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
   const fxs = group.arg.fxs
   const fibers = [] as Fiber[]
   const ready = [] as Fiber[]
+  let readyIndex = 0
   const wake = new Wake()
   const context = getRuntimeContext(group)
   const parentTraceOrigin = {
@@ -288,7 +291,9 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
     while (done < fxs.length || next < fxs.length) {
       startNext()
 
-      if (ready.length === 0) {
+      if (readyIndex >= ready.length) {
+        ready.length = 0
+        readyIndex = 0
         if (active === 0 && next < fxs.length) {
           yield* runtime.waitForSlot()
           continue
@@ -298,7 +303,11 @@ const cooperativeGroupFx = <const Fxs extends readonly Fx<unknown, unknown>[], S
         continue
       }
 
-      const fiber = ready.shift()!
+      const fiber = ready[readyIndex++]!
+      if (readyIndex > 64 && readyIndex * 2 > ready.length) {
+        ready.splice(0, readyIndex)
+        readyIndex = 0
+      }
       if (fiber.status !== 'ready') continue
       if (fiber.cancelRequested && fiber.masks.canInterrupt) {
         yield* closeFiber(fiber)
@@ -617,7 +626,7 @@ const throwIntoMissingIterator = (error: unknown): never => {
 
 class Wake {
   private readonly readyFibers = [] as Fiber[]
-  private readonly waiters = [] as (() => void)[]
+  private waiters = [] as (() => void)[]
 
   ready(fiber: Fiber) {
     this.readyFibers.push(fiber)
@@ -625,7 +634,9 @@ class Wake {
   }
 
   notify() {
-    const waiters = this.waiters.splice(0)
+    if (this.waiters.length === 0) return
+    const waiters = this.waiters
+    this.waiters = []
     for (const waiter of waiters) waiter()
   }
 

--- a/tsconfig.benchmarks.json
+++ b/tsconfig.benchmarks.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": ".benchmarks",
+    "sourceMap": false
+  },
+  "include": [
+    "src/**/*.ts",
+    "benchmarks/cooperative-all.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- refactor `withCoopConcurrency` to use a shared cooperative runtime for built-in `Concurrently` policies and explicit `Fork`
- add cooperative `Task` handling for `fork`/`wait`, task interruption, queued fork cancellation, unhandled fork diagnostics, nested fork/group execution, and shared concurrency slots
- update examples and benchmarks so `withCoopConcurrency` can be tried without a separate fork-backed handler

## Validation

- `node --import tsx --test src/Concurrent.test.ts`
- `node --import tsx --test src/Trace.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm benchmark:cooperative-all`
- `node --import tsx examples/advanced/incident-collector/cli.ts`
- `node --import tsx examples/advanced/diagnostics.ts`

## Benchmark Notes

- structured cooperative `all` remains faster than fork-backed unbounded fanout in the current benchmark
- nested cooperative race and first-success cases remain faster than fork-backed equivalents
- explicit cooperative fork fanout is currently slower than fork-backed unbounded fanout, which is useful follow-up optimization signal
