### PR TITLE
[codex] Update concurrency docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ import {
   fx,
   runPromise
 } from "@briancavalier/fx"
-import { unbounded } from "@briancavalier/fx/concurrent"
+import { withUnboundedConcurrency } from "@briancavalier/fx/concurrent"
 import { andFinallyExit, recoverInterrupt, scope } from "@briancavalier/fx/scope"
 import { defaultTime, sleep } from "@briancavalier/fx/time"
 import { timeout } from "@briancavalier/fx/timeout"
@@ -137,7 +137,7 @@ await program.pipe(
   scope(RequestScope),
   recoverInterrupt(RequestScope, () => consoleLog("request timed out")),
   defaultTime,
-  unbounded,
+  withUnboundedConcurrency,
   defaultConsole,
   assertNoFail,
   runPromise

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -164,23 +164,23 @@ named boundary is real and useful for the application.
 
 ## Concurrency and resources
 
-Use `all` and `race` to describe structured concurrency, then choose semantics
-with handlers such as `defaultAll`, `firstSettled`, `firstSuccess`, `bounded`,
-and `unbounded`.
+Use `all` and `race` to describe structured concurrency. Use `firstSettled` or
+`firstSuccess` to choose race result policy, then choose an execution strategy
+with `withBoundedConcurrency`, `withUnboundedConcurrency`, or
+`withCoopConcurrency`.
 
 Use named scopes and finalization helpers when resources need cleanup. Keep
 acquire/register critical sections small and explicit.
 
 ```ts
 import { fx, runPromise } from "@briancavalier/fx"
-import { all, bounded, defaultAll } from "@briancavalier/fx/concurrent"
+import { all, withBoundedConcurrency } from "@briancavalier/fx/concurrent"
 
 const program = fx(function* () {
   const [user, posts] = yield* all([fetchUser, fetchPosts])
   return { user, posts }
 }).pipe(
-  defaultAll,
-  bounded(4),
+  withBoundedConcurrency(4),
   runPromise
 )
 ```

--- a/docs/recipes/use-structured-concurrency.md
+++ b/docs/recipes/use-structured-concurrency.md
@@ -4,7 +4,7 @@ Use this when related child computations should be owned by the parent.
 
 ```ts
 import { fx, runPromise } from "@briancavalier/fx"
-import { all, bounded, defaultAll } from "@briancavalier/fx/concurrent"
+import { all, withBoundedConcurrency } from "@briancavalier/fx/concurrent"
 
 const loadDashboard = fx(function* () {
   const [user, posts] = yield* all([
@@ -16,21 +16,21 @@ const loadDashboard = fx(function* () {
 })
 ```
 
-`all` describes the request. `defaultAll` chooses the default structured
-semantics, and `bounded` or `unbounded` chooses fork scheduling.
+`all` describes the request. The handler chooses the execution strategy:
+`withBoundedConcurrency`, `withUnboundedConcurrency`, or `withCoopConcurrency`.
 
 Handler pipeline:
 
 ```ts
 loadDashboard.pipe(
-  defaultAll,
-  bounded(4),
+  withBoundedConcurrency(4),
   runPromise
 )
 ```
 
 Use `race` with `firstSettled` for first-settled semantics, or `firstSuccess`
-when failures should be ignored until every child fails.
+when failures should be ignored until every child fails. Then choose an
+execution strategy handler for the race.
 
 Common mistake: using raw promises for child work that should be cancelled or
 disposed when the parent fails.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ Use the smallest example that demonstrates the task:
 | Minimal runnable program | `basic/hello.ts` | Shows one effect, one handler, and `run` without extra structure. |
 | Custom domain effects and pure tests | `basic/guessing-game` | Shows business logic written against effects and interpreted by handlers. |
 | HTTP boundary code | `basic/http-server-client` | Shows routes, request context, client/server boundaries, and in-memory handlers. |
-| Handler-chosen concurrency semantics | `intermediate/race-handlers.ts` | Shows one request interpreted by different race handlers. |
+| Handler-chosen concurrency semantics | `intermediate/concurrency-handlers.ts` | Shows one request interpreted with different race result policies and execution strategies. |
 | Interruption and cleanup | `intermediate/interrupt-safe-finalization.ts` | Shows cancellation, named scopes, and async finalizers. |
 | Scoped data-flow or early return | `intermediate/read-csv.ts` | Shows scoped `YieldFrom`, managed resources, transforms, and early return. |
 | Scoped producer/receiver pipelines | `intermediate/yield-sink-pipeline.ts` | Shows scoped `YieldFrom`, `Sink`, and explicit pipe outcomes. |
@@ -37,7 +37,7 @@ already matches the requested pattern.
 
 | Example | What it shows | Best for | Run |
 | --- | --- | --- | --- |
-| `intermediate/race-handlers.ts` | One `race` request interpreted with first-settled and first-success handlers. | Readers learning how handlers choose semantics. | `node --import tsx examples/intermediate/race-handlers.ts` |
+| `intermediate/concurrency-handlers.ts` | One `race` request interpreted with first-settled and first-success handlers, plus one program run with fork-backed and cooperative concurrency handlers. | Readers learning how handlers choose concurrency semantics. | `node --import tsx examples/intermediate/concurrency-handlers.ts` |
 | `intermediate/interrupt-safe-finalization.ts` | Race cancellation, named scopes, and async finalization for interrupted work. | Readers working with resources under structured concurrency. | `node --import tsx examples/intermediate/interrupt-safe-finalization.ts` |
 | `intermediate/uninterruptible-mask.ts` | Timeout-driven interruption after a protected acquire/register critical section. | Readers who need precise interruption boundaries. | `node --import tsx examples/intermediate/uninterruptible-mask.ts` |
 | `intermediate/scoped-state.ts` | Mutable state modeled as named scoped operations and handled state. | Readers exploring structured local state. | `node --import tsx examples/intermediate/scoped-state.ts` |

--- a/examples/intermediate/concurrency-handlers.ts
+++ b/examples/intermediate/concurrency-handlers.ts
@@ -1,15 +1,24 @@
-import { fail, Fail, fx, returnFail, runPromise } from '@briancavalier/fx'
-import { RaceAllFailed, firstSettled, firstSuccess, race, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
+import { fail, Fail, fx, returnFail, runPromise, wait } from '@briancavalier/fx'
+import {
+  RaceAllFailed,
+  all,
+  firstSettled,
+  firstSuccess,
+  fork,
+  race,
+  withBoundedConcurrency,
+  withCoopConcurrency,
+  withUnboundedConcurrency
+} from '@briancavalier/fx/concurrent'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { formatDiagnostic, formatError, snapshotError } from '@briancavalier/fx/trace'
 import { nodeSourceLookup } from '@briancavalier/fx/platform-node'
- 
-// This example builds one Race request and interprets it with two different
-// handlers. `firstSettled` is first-settled, like Promise.race: the fast failure
-// wins. `firstSuccess` is first-successful, like Promise.any: the fast failure
-// is ignored while another child can still succeed. This shows how fx can keep
-// one structured concurrency effect while choosing execution policy by handler.
+
+// This example shows two kinds of concurrency handler swaps:
+// - `firstSettled` and `firstSuccess` choose the result policy for one `race`.
+// - `withBoundedConcurrency` and `withCoopConcurrency` choose the execution
+//   strategy for one program that uses both `all` and explicit `fork`.
 
 const fastFailure = fx(function* () {
   yield* sleep(10)
@@ -21,10 +30,10 @@ const slowSuccess = fx(function* () {
   return 'replica succeeded'
 })
 
-// Construct a Race effect once. The handler applied later determines how this
-// same request is interpreted.
 const request = race([fastFailure, slowSuccess])
 const sourceLookup = nodeSourceLookup()
+
+console.log('\nresult policy handlers')
 
 const firstSettledResult = await request.pipe(
   // First-settled semantics: the fast failure wins and cancels the slow success.
@@ -73,6 +82,47 @@ if (Fail.is(allFailed) && allFailed.arg instanceof RaceAllFailed) {
   console.log('firstSuccess all failed:')
   printFailure(allFailed.arg)
 }
+
+const loadUser = fx(function* () {
+  yield* sleep(20)
+  return { id: 'user-123', name: 'Ada' }
+})
+
+const loadPosts = fx(function* () {
+  yield* sleep(30)
+  return ['effects as data', 'handlers as interpreters']
+})
+
+const refreshCache = fx(function* () {
+  yield* sleep(15)
+  return 'cache refreshed'
+})
+
+const loadDashboard = fx(function* () {
+  const cacheRefresh = yield* fork(refreshCache)
+  const [user, posts] = yield* all([loadUser, loadPosts])
+  const cache = yield* wait(cacheRefresh)
+
+  return { user, posts, cache }
+})
+
+console.log('\nexecution strategy handlers')
+
+const forkBackedDashboard = await loadDashboard.pipe(
+  withBoundedConcurrency(2),
+  defaultTime,
+  runPromise
+)
+
+console.log('withBoundedConcurrency:', forkBackedDashboard)
+
+const cooperativeDashboard = await loadDashboard.pipe(
+  withCoopConcurrency({ concurrency: 2, yieldBudget: 64 }),
+  defaultTime,
+  runPromise
+)
+
+console.log('withCoopConcurrency:', cooperativeDashboard)
 
 function printFailure(failure: unknown): void {
   console.log([

--- a/src/internal/concurrent/cooperative.ts
+++ b/src/internal/concurrent/cooperative.ts
@@ -25,7 +25,8 @@ export interface CoopConcurrencyOptions {
 }
 
 /**
- * Provide cooperative concurrency for built-in structured concurrency policies.
+ * Provide cooperative concurrency for built-in structured concurrency policies
+ * and explicit or nested Fork requests.
  */
 export const withCoopConcurrency = (options: CoopConcurrencyOptions = {}) => {
   const normalized = normalizeCoopOptions(options, 'withCoopConcurrency')


### PR DESCRIPTION
## Summary

- update concurrency docs and agent guidance to use current handler names
- rename and broaden the race handlers example into a concurrency handlers example
- document that cooperative concurrency handles structured policies and explicit/nested Fork requests

## Validation

- corepack pnpm build
- node --import tsx examples/intermediate/concurrency-handlers.ts
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm test