### PR TITLE
[codex] Optimize scope concurrency internals

### DIFF
--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -4,7 +4,7 @@ import { arch, platform, release } from 'node:os'
 import { performance } from 'node:perf_hooks'
 
 import { assertPromise } from '../src/Async.js'
-import { all, firstSuccess, fork, race, withCoopConcurrency, withUnboundedConcurrency } from '../src/Concurrent.js'
+import { all, firstSuccess, fork, forkIn, race, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
 import { fail, returnFail } from '../src/Fail.js'
 import { andFinally } from '../src/Finalization.js'
@@ -53,6 +53,7 @@ const CalibrationTargetMs = TargetSampleMs / 2
 const MaxCalibrationIterations = 65_536
 const NoiseSpreadThreshold = 1.25
 const CleanupScope = scope('benchmark/cooperative-all/Cleanup')
+const JoinScope = scope('benchmark/cooperative-all/Join')
 
 await runSemanticChecks()
 
@@ -81,6 +82,18 @@ const results = await runBenchmarks([
   }),
   benchmark('withCoopConcurrency explicit fork fanout 16', 'explicit fork fanout', async () => {
     await explicitForkFanout(okChildren(Fanout)).pipe(withCoopConcurrency(), runPromise)
+  }),
+  benchmark('withBoundedConcurrency explicit fork fanout 16 limit 1', 'queued slots', async () => {
+    await explicitForkFanout(asyncChildren(Fanout)).pipe(withBoundedConcurrency(1), runPromise)
+  }),
+  benchmark('withCoopConcurrency explicit fork fanout 16 limit 1', 'queued slots', async () => {
+    await explicitForkFanout(asyncChildren(Fanout)).pipe(withCoopConcurrency({ concurrency: 1 }), runPromise)
+  }),
+  benchmark('withUnboundedConcurrency scoped join fanout 16', 'scoped join', async () => {
+    await scopedJoinFanout(Fanout).pipe(withUnboundedConcurrency, returnFail, runPromise)
+  }),
+  benchmark('withCoopConcurrency scoped join fanout 16', 'scoped join', async () => {
+    await scopedJoinFanout(Fanout).pipe(withCoopConcurrency(), returnFail, runPromise)
   }),
   benchmark('withUnboundedConcurrency yielding 16x16', 'yielding fanout', async () => {
     await yieldingAll().pipe(handleStep(), withUnboundedConcurrency, runPromise)
@@ -294,6 +307,15 @@ function explicitForkFanout(children: readonly Fx<any, unknown>[]) {
     for (const task of tasks) results.push(yield* wait(task))
     return results
   })
+}
+
+function scopedJoinFanout(length: number) {
+  return fx(function* () {
+    for (let i = 0; i < length; i++) {
+      yield* forkIn(JoinScope, assertPromise(() => Promise.resolve(i)))
+    }
+    return 'parent'
+  }).pipe(withScope(JoinScope))
 }
 
 function nestedRace() {

--- a/benchmarks/results/2026-05-31-scope-concurrency-performance.md
+++ b/benchmarks/results/2026-05-31-scope-concurrency-performance.md
@@ -1,0 +1,63 @@
+# Scope/Concurrency Performance
+
+- Date: 2026-05-31
+- Worktree: `/private/tmp/fx-scope-concurrency-perf`
+- Branch: `codex/scope-concurrency-perf`
+- Baseline SHA: `e176462`
+- Node: v24.14.0
+- Platform: darwin 25.3.0 arm64
+- Command: `corepack pnpm benchmark:cooperative-all:js`
+
+## Baseline
+
+Baseline was captured from a clean worktree before edits.
+
+| Case | Baseline median ns/op | Baseline relative |
+| --- | ---: | ---: |
+| withCoopConcurrency ok fanout 16 | 881023 | 1.33x |
+| withCoopConcurrency async fanout 16 | 1282605 | 1.48x |
+| withCoopConcurrency explicit fork fanout 16 | 881563 | 1.32x |
+| withCoopConcurrency yielding 16x16 budget 1 | 1036615 | 1.32x |
+| withCoopConcurrency mixed parked async budget 1 | 635578 | 1.44x |
+| withCoopConcurrency nested race | 592626 | 1.83x |
+| withCoopConcurrency nested firstSuccess | 567548 | 1.60x |
+| withCoopConcurrency cancel cleanup | 498167 | 1.41x |
+
+Fairness rows were unchanged from the post-PR-216 baseline:
+
+| Case | Total steps | Max consecutive same-child steps | First-step spread |
+| --- | ---: | ---: | ---: |
+| withUnboundedConcurrency | 256 | 16 | 240 |
+| withCoopConcurrency budget 1 | 256 | 16 | 240 |
+| withCoopConcurrency budget 8 | 256 | 16 | 240 |
+| withCoopConcurrency budget 64 | 256 | 16 | 240 |
+
+## After Changes
+
+The post-change run used the same built benchmark command. The worktree was dirty with the implementation changes.
+
+| Case | Median ns/op | Relative |
+| --- | ---: | ---: |
+| withCoopConcurrency ok fanout 16 | 774405 | 1.40x |
+| withCoopConcurrency async fanout 16 | 1177433 | 1.52x |
+| withCoopConcurrency explicit fork fanout 16 | 891562 | 1.35x |
+| withCoopConcurrency yielding 16x16 budget 1 | 935009 | 1.39x |
+| withCoopConcurrency mixed parked async budget 1 | 529840 | 1.38x |
+| withCoopConcurrency nested race | 424632 | 1.50x |
+| withCoopConcurrency nested firstSuccess | 366561 | 1.37x |
+| withCoopConcurrency cancel cleanup | 461650 | 1.39x |
+
+New focused rows:
+
+| Case | Median ns/op | Relative |
+| --- | ---: | ---: |
+| withCoopConcurrency explicit fork fanout 16 limit 1 | 1286990 | 1.48x |
+| withCoopConcurrency scoped join fanout 16 | 1337027 | 1.52x |
+
+Fairness rows stayed intentionally unchanged. The `yieldBudget` issue remains deferred.
+
+## Notes
+
+- The largest improvements in this run were the nested structured cases, which now avoid repeated per-settlement `Promise.race(pending.map(...))` allocation.
+- `ok fanout`, `async fanout`, and cleanup rows remain noisy enough that only larger repeated movements should be treated as signal.
+- `benchmark:runtime-loops` was not used for this change. It is not currently build-clean under `tsconfig.benchmarks.json` because that config only supports the cooperative benchmark path.

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -1345,6 +1345,36 @@ describe('Fork', () => {
       await tasks[2].interrupt()
     })
 
+    it('does not instantiate queued cooperative fork iterators interrupted before admission', async () => {
+      let iteratorCreated = 0
+      const blocker = fx(function* () {
+        yield* awaitAbort()
+      })
+      const queued = {
+        [Symbol.iterator]() {
+          iteratorCreated++
+          return fx(function* () {
+            yield* awaitAbort()
+          })[Symbol.iterator]()
+        }
+      } as Fx<Async, void>
+
+      const tasks = await fx(function* () {
+        const first = yield* fork(blocker)
+        const second = yield* fork(queued)
+        return [first, second] as const
+      }).pipe(
+        withCoopConcurrency({ concurrency: 1 }),
+        runPromise
+      )
+
+      await tasks[1].interrupt('stop queued')
+      assert.equal(iteratorCreated, 0)
+
+      await tasks[0].interrupt('stop first')
+      assert.equal(iteratorCreated, 0)
+    })
+
     it('defers sibling cancellation while a child is interruption-masked', async () => {
       const TestScope = scope('test/Fork/CooperativeAllMaskedCancelScope')
       const events = [] as string[]

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -15,6 +15,7 @@ import { withBoundedConcurrency, withUnboundedConcurrency } from './internal/con
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
 import { InterruptedReturn, isInterpretingReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
+import { settledTaskQueue, type SettledQueue, type SettledTask } from './internal/settledQueue.js'
 import { ScopedFork } from './internal/scopedFork.js'
 import type { ScopedForkContext } from './internal/scopedFork.js'
 import type { AnyScope } from './Scope.js'
@@ -255,20 +256,18 @@ const waitAllTasks = <const Tasks extends readonly Task<unknown, unknown>[]>(
   tasks: Tasks
 ): Fx<Async | TaskErrors<Tasks[number]>, { readonly [K in keyof Tasks]: TaskResult<Tasks[K]> }> => fx(function* () {
   const results = [] as TaskResult<Tasks[number]>[]
-  const pending = tasks.map((task, index) =>
-    task.promise.then(
-      value => ({ type: 'success' as const, index, value: value as TaskResult<Tasks[number]> }),
-      failure => ({ type: 'failure' as const, index, failure })
-    )
-  )
+  const pending = new Set<Task<unknown, unknown>>(tasks)
+  const indexes = taskIndexes(tasks)
+  const settled = settledTaskQueue(tasks)
 
-  while (pending.length > 0) {
-    const { position, result } = yield* waitSettled(pending)
+  while (pending.size > 0) {
+    const result = yield* waitSettled(settled)
 
-    void pending.splice(position, 1)
-    if (tasks[result.index]?._interrupted) continue
+    pending.delete(result.task)
+    if (result.task._interrupted) continue
+    const index = indexes.get(result.task) ?? -1
     if (result.type === 'failure') return yield* fail(result.failure)
-    results[result.index] = result.value
+    results[index] = result.value as TaskResult<Tasks[number]>
   }
 
   return results.length === tasks.length
@@ -282,21 +281,15 @@ const waitFirstSettled = <const Tasks extends readonly Task<unknown, unknown>[]>
   tasks: Tasks
 ): Fx<Async | Fail<unknown>, FirstSettledResult<TaskResult<Tasks[number]>>> =>
   cooperativeAssertPromise(async () => {
-    const pending = tasks.map((task, index) =>
-      task.promise.then(
-        value => ({ type: 'success' as const, index, value: value as TaskResult<Tasks[number]> }),
-        failure => ({ type: 'failure' as const, index, failure })
-      )
-    )
+    const pending = new Set<Task<unknown, unknown>>(tasks)
+    const settled = settledTaskQueue(tasks)
 
-    while (pending.length > 0) {
-      const { position, result } = await Promise.race(pending.map((p, position) =>
-        p.then(result => ({ position, result }))
-      ))
+    while (pending.size > 0) {
+      const result = await settled.next()
 
-      void pending.splice(position, 1)
-      if (tasks[result.index]?._interrupted) continue
-      if (result.type === 'success') return { type: 'success', value: result.value }
+      pending.delete(result.task)
+      if (result.task._interrupted) continue
+      if (result.type === 'success') return { type: 'success', value: result.value as TaskResult<Tasks[number]> }
       return { type: 'failure', failure: result.failure }
     }
 
@@ -307,23 +300,18 @@ const waitFirstSuccess = <const Tasks extends readonly Task<unknown, unknown>[]>
   tasks: Tasks
 ): Fx<Async | Fail<unknown>, FirstSuccessResult<TaskResult<Tasks[number]>, TaskErrorsOf<Tasks>>> =>
   cooperativeAssertPromise(async () => {
-    const pending = tasks.map((task, index) =>
-      task.promise.then(
-        value => ({ type: 'success' as const, index, value: value as TaskResult<Tasks[number]> }),
-        failure => ({ type: 'failure' as const, index, failure })
-      )
-    )
+    const pending = new Set<Task<unknown, unknown>>(tasks)
+    const indexes = taskIndexes(tasks)
+    const settled = settledTaskQueue(tasks)
     const failures = [] as unknown[]
 
-    while (pending.length > 0) {
-      const { position, result } = await Promise.race(pending.map((p, position) =>
-        p.then(result => ({ position, result }))
-      ))
+    while (pending.size > 0) {
+      const result = await settled.next()
 
-      void pending.splice(position, 1)
-      if (tasks[result.index]?._interrupted) continue
-      if (result.type === 'success') return { type: 'success', value: result.value }
-      failures[result.index] = result.failure
+      pending.delete(result.task)
+      if (result.task._interrupted) continue
+      if (result.type === 'success') return { type: 'success', value: result.value as TaskResult<Tasks[number]> }
+      failures[indexes.get(result.task) ?? -1] = result.failure
     }
 
     return failures.length === 0
@@ -342,11 +330,19 @@ type FirstSuccessResult<A, E extends readonly unknown[]> =
 const pendingPromise = <A>(): Promise<A> => new Promise(() => { })
 
 const waitSettled = <A>(
-  pending: readonly Promise<A>[]
-): Fx<Async, { readonly position: number, readonly result: A }> =>
-  cooperativeAssertPromise(() => Promise.race(pending.map((p, position) =>
-    p.then(result => ({ position, result }))
-  )), at('fx/Concurrent/waitSettled', waitSettled))
+  settled: SettledQueue<SettledTask<Task<unknown, unknown>>>
+): Fx<Async, TaskSettlement<A>> =>
+  cooperativeAssertPromise(() => settled.next() as Promise<TaskSettlement<A>>, at('fx/Concurrent/waitSettled', waitSettled))
+
+type TaskSettlement<A> =
+  | { readonly task: Task<unknown, unknown>, readonly type: 'success', readonly value: A }
+  | { readonly task: Task<unknown, unknown>, readonly type: 'failure', readonly failure: unknown }
+
+const taskIndexes = (tasks: readonly Task<unknown, unknown>[]): Map<Task<unknown, unknown>, number> => {
+  const indexes = new Map<Task<unknown, unknown>, number>()
+  for (let i = 0; i < tasks.length; i++) indexes.set(tasks[i], i)
+  return indexes
+}
 
 class RuntimeCloseBoundary<E, A> implements Fx<E, A>, Pipeable {
   public readonly pipe = pipeThis as Pipeable['pipe']

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -14,6 +14,7 @@ import { drainIteratorReturn, isInterpretingReturn, isInterruptedReturn } from '
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
 import { ScopeTypeId, sameScope, scopeId, type ScopeIdentity } from './internal/scopeIdentity.js'
+import { settledTaskQueue } from './internal/settledQueue.js'
 import { ScopedFork } from './internal/scopedFork.js'
 import type { ScopedForkContext } from './internal/scopedFork.js'
 import type { Task } from './Task.js'
@@ -292,6 +293,7 @@ class ScopeBoundary<E, A, Scope extends AnyScope> implements Fx<unknown, A>, Pip
 class ScopeController<Scope extends AnyScope> {
   readonly finalizers = [] as Finalizer<unknown>[]
   private readonly tasks = new Map<Task<unknown, unknown>, ScopedForkContext>()
+  private readonly joinFailures = [] as unknown[]
   private settled?: Exit<Scope>
   private readonly exitRequested = Promise.withResolvers<Exit<Scope>>()
   private readonly exitSource = {
@@ -329,6 +331,9 @@ class ScopeController<Scope extends AnyScope> {
 
   join(exit: Exit<Scope>): Fx<Async, { readonly exit: Exit<Scope>, readonly failures: readonly unknown[] }> {
     if (exit.type !== 'success' && this.settled === undefined) this.settle(exit)
+    if (this.joinFailures.length > 0 && this.settled === undefined) {
+      this.settle({ type: 'failure', failure: new Fail(this.joinFailures[0]) })
+    }
     if (this.tasks.size === 0) return ok({ exit: this.settled ?? exit, failures: [] })
     return cooperativeAssertPromise(() => this.joinTasks(exit), at('fx/Scope/withScope/join', withScope))
   }
@@ -336,29 +341,30 @@ class ScopeController<Scope extends AnyScope> {
   private async joinTasks(initialExit: Exit<Scope>): Promise<{ readonly exit: Exit<Scope>, readonly failures: readonly unknown[] }> {
     const failures = [] as unknown[]
     const pending = new Set(this.tasks.keys())
+    const settled = settledTaskQueue(pending)
 
     while (pending.size > 0) {
-      removeInterruptedTasks(pending)
+      removeInterruptedTasks(pending, this.tasks)
       const exit = this.settled
       if (exit !== undefined && exit.type !== 'success') break
+      if (this.joinFailures.length > 0) {
+        this.settle({ type: 'failure', failure: new Fail(this.joinFailures[0]) })
+        break
+      }
       if (initialExit.type === 'success' && !hasNonDaemonTask(pending, this.tasks)) break
 
-      const result = await Promise.race([...pending].map(task =>
-        task.promise.then(
-          value => ({ task, status: 'fulfilled' as const, value }),
-          reason => ({ task, status: 'rejected' as const, reason })
-        )
-      ))
+      const result = await settled.next()
       pending.delete(result.task)
+      this.tasks.delete(result.task)
 
-      if (result.status === 'rejected') {
-        this.settle({ type: 'failure', failure: new Fail(result.reason) })
+      if (result.type === 'failure' && !result.task._interrupted) {
+        this.settle({ type: 'failure', failure: new Fail(result.failure) })
         break
       }
     }
 
     const exit = this.settled ?? initialExit
-    removeInterruptedTasks(pending)
+    removeInterruptedTasks(pending, this.tasks)
     if (pending.size > 0 || exit.type !== 'success') {
       failures.push(...await this.interruptPending(pending, interruptReason(exit)))
     }
@@ -375,12 +381,26 @@ class ScopeController<Scope extends AnyScope> {
 
   private watchTask(task: Task<unknown, unknown>) {
     const failure = this.tasks.get(task)?.failure
-    if (failure === 'task' || failure === 'join') return
-    task.promise.catch(reason => {
-      if (!task._interrupted) {
-        this.requestExit({ type: 'failure', failure: new Fail(reason) })
+    task.promise.then(
+      () => {
+        this.tasks.delete(task)
+      },
+      reason => {
+        const context = this.tasks.get(task)
+        if (context === undefined) return
+        if (task._interrupted) {
+          this.tasks.delete(task)
+        } else if (failure === 'task') {
+          this.tasks.delete(task)
+        } else if (failure === 'join') {
+          this.joinFailures.push(reason)
+          this.tasks.delete(task)
+        } else {
+          this.tasks.delete(task)
+          this.requestExit({ type: 'failure', failure: new Fail(reason) })
+        }
       }
-    })
+    )
   }
 
   private settle(exit: Exit<Scope>) {
@@ -398,9 +418,15 @@ const hasNonDaemonTask = (
   return false
 }
 
-const removeInterruptedTasks = (pending: Set<Task<unknown, unknown>>) => {
+const removeInterruptedTasks = (
+  pending: Set<Task<unknown, unknown>>,
+  tasks: Map<Task<unknown, unknown>, ScopedForkContext>
+) => {
   for (const task of pending) {
-    if (task._interrupted) pending.delete(task)
+    if (task._interrupted) {
+      pending.delete(task)
+      tasks.delete(task)
+    }
   }
 }
 

--- a/src/internal/concurrent/cooperative.ts
+++ b/src/internal/concurrent/cooperative.ts
@@ -12,8 +12,7 @@ import { captureTrace, getTrace } from '../../Trace.js'
 import { ForkError, capturePrependTraceWithContext, originOfUnhandledFail, runtimeContextOfEffect, traceUnhandledFail, traceWithCause } from '../forkDiagnostics.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from '../interrupt.js'
 import { withInterpretedReturn } from '../iteratorClose.js'
-import { attachRuntimeContext, currentRuntimeContext, getRuntimeContext, RuntimeScopeExit, withActiveRuntimeContext } from '../runtimeContext.js'
-import type { RuntimeContext } from '../runtimeContext.js'
+import { attachRuntimeContext, currentRuntimeContext, getRuntimeContext, runtimeScopeExit, RuntimeScopeExit, withActiveRuntimeContext } from '../runtimeContext.js'
 import { shouldReleaseSlotForAsync } from './cooperativeAsync.js'
 
 export interface CooperativeConfig {
@@ -52,10 +51,11 @@ type Resume =
 
 interface Fiber {
   readonly index: number
-  readonly iterator: Iterator<unknown, unknown, unknown>
+  readonly fx: Fx<unknown, unknown>
   readonly traceOrigin: TraceOrigin
   readonly masks: InterruptMaskState
   readonly runtimeContext: ReturnType<typeof getRuntimeContext>
+  iterator?: Iterator<unknown, unknown, unknown>
   slotAcquired: boolean
   status: 'ready' | 'waiting' | 'done'
   resume: Resume
@@ -90,7 +90,7 @@ export class CooperativeRuntime {
     const trace = fork.arg.trace
     const fiber: Fiber = {
       index: -1,
-      iterator: fork.arg.fx[Symbol.iterator](),
+      fx: fork.arg.fx,
       traceOrigin: { origin, trace },
       runtimeContext: context,
       masks: new InterruptMaskState(),
@@ -111,7 +111,7 @@ export class CooperativeRuntime {
       reason => {
         fiber.cancelRequested = true
         if (fiber.masks.canInterrupt) fiber.abort?.abort(reason)
-        this.notifySlotWaiters()
+        this.notifySlotWaiters(true)
         if (!running) {
           cleanup = this.drainFork(fiber, done)
           running = true
@@ -148,7 +148,7 @@ export class CooperativeRuntime {
       }
       while (fiber.status !== 'done') {
         if (fiber.status === 'waiting') {
-          await runPromise(wake.wait())
+          await wake.wait()
           continue
         }
         while (!fiber.slotAcquired) {
@@ -212,10 +212,13 @@ export class CooperativeRuntime {
     return new Promise<void>(resolve => this.slotWaiters.push(resolve))
   }
 
-  private notifySlotWaiters() {
+  private notifySlotWaiters(forceAll = false) {
     if (this.slotWaiters.length === 0) return
-    const waiters = this.slotWaiters
-    this.slotWaiters = []
+    const count = forceAll || this.availableSlots === Infinity
+      ? this.slotWaiters.length
+      : Math.min(this.slotWaiters.length, Math.max(0, this.availableSlots))
+    if (count === 0) return
+    const waiters = this.slotWaiters.splice(0, count)
     for (const waiter of waiters) waiter()
   }
 
@@ -259,7 +262,7 @@ const startCooperativeAsync = (
   const context = getRuntimeContext(async)
   const run = () => async.arg.run(abort.signal)
   const promise = context === undefined ? run() : withActiveRuntimeContext(context, run)
-  const scopeExit = fiber.masks.canInterrupt ? raceScopeExits(context) : undefined
+  const scopeExit = fiber.masks.canInterrupt ? runtimeScopeExit(context) : undefined
   const wakeOnAbort = () => {
     if (fiber.status !== 'waiting') return
     fiber.abort = undefined
@@ -287,13 +290,6 @@ const startCooperativeAsync = (
   )
 }
 
-const raceScopeExits = (context: RuntimeContext | undefined): Promise<RuntimeScopeExit> | undefined => {
-  if (context?.clearScopeExitSources === true) return undefined
-  const sources = context?.scopeExitSources
-  if (sources === undefined || sources.length === 0) return undefined
-  return Promise.race(sources.map(source => source.promise))
-}
-
 interface FiberCallbacks {
   readonly succeed: (value: unknown) => void
   readonly fail: (error: unknown) => void
@@ -314,9 +310,10 @@ function* stepFiber(
     fiber.releaseSlotBeforeResume = false
     if (releaseSlotBeforeResume) runtime.releaseSlot(fiber)
     try {
+      const iterator = fiberIterator(fiber)
       ir = fiber.resume.type === 'throw'
-        ? fiber.iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
-        : fiber.iterator.next(fiber.resume.value)
+        ? iterator.throw?.(fiber.resume.error) ?? throwIntoMissingIterator(fiber.resume.error)
+        : iterator.next(fiber.resume.value)
     } catch (e) {
       callbacks.fail(wrapThrownFiberError(fiber, e))
       break
@@ -395,9 +392,11 @@ function* closeFiber(
 ): Generator<unknown, void, unknown> {
   fiber.abort?.abort()
   fiber.abort = undefined
+  const iterator = fiber.iterator
+  if (iterator === undefined) return
   let ir: IteratorResult<unknown, unknown>
   try {
-    ir = withInterpretedReturn(() => fiber.iterator.return?.() ?? { done: true, value: undefined })
+    ir = withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined })
   } catch (e) {
     fiber.cleanupFailures.push(e)
     return
@@ -406,28 +405,28 @@ function* closeFiber(
   while (!ir.done) {
     try {
       if (Async.is(ir.value)) {
-        ir = fiber.iterator.next(yield ir.value as any)
+        ir = iterator.next(yield ir.value as any)
       } else if (Fork.is(ir.value)) {
-        ir = fiber.iterator.next(runtime.startFork(runtime.wrapFork(ir.value)))
+        ir = iterator.next(runtime.startFork(runtime.wrapFork(ir.value)))
       } else if (Fail.is(ir.value)) {
         fiber.cleanupFailures.push(ir.value.arg)
         return
       } else if (InterruptMaskBegin.is(ir.value)) {
         fiber.masks.mask(ir.value.arg)
-        ir = fiber.iterator.next()
+        ir = iterator.next()
       } else if (InterruptMaskEnd.is(ir.value)) {
         fiber.masks.unmask(ir.value.arg)
-        ir = fiber.iterator.next()
+        ir = iterator.next()
       } else if (HandlerCapture.is(ir.value)) {
         const releaseSlotBeforeResume = fiber.slotAcquired
         if (releaseSlotBeforeResume) runtime.releaseSlot(fiber)
         try {
-          ir = fiber.iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value))
+          ir = iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value))
         } finally {
           if (releaseSlotBeforeResume) yield* reacquireSlot(runtime, fiber)
         }
       } else {
-        ir = fiber.iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value))
+        ir = iterator.next(yield* runCleanupEffect(runtime, fiber, ir.value))
       }
     } catch (e) {
       fiber.cleanupFailures.push(e)
@@ -483,29 +482,38 @@ const throwIntoMissingIterator = (error: unknown): never => {
 }
 
 class Wake {
-  private readonly readyFibers = [] as Fiber[]
+  private signaled = false
   private waiters = [] as (() => void)[]
 
-  ready(fiber: Fiber) {
-    this.readyFibers.push(fiber)
+  ready(_fiber: Fiber) {
     this.notify()
   }
 
   notify() {
-    if (this.waiters.length === 0) return
+    if (this.waiters.length === 0) {
+      this.signaled = true
+      return
+    }
     const waiters = this.waiters
     this.waiters = []
     for (const waiter of waiters) waiter()
   }
 
   wait() {
-    return fx(function* (this: Wake) {
-      if (this.readyFibers.length === 0) {
-        yield* AsyncWait(this.waiters)
-      }
-      return this.readyFibers.splice(0)
-    }.bind(this))
+    if (this.signaled) {
+      this.signaled = false
+      return Promise.resolve()
+    }
+    return new Promise<void>(resolve => this.waiters.push(resolve))
   }
+}
+
+const fiberIterator = (fiber: Fiber): Iterator<unknown, unknown, unknown> => {
+  if (fiber.iterator !== undefined) return fiber.iterator
+  fiber.iterator = fiber.runtimeContext === undefined
+    ? fiber.fx[Symbol.iterator]()
+    : withActiveRuntimeContext(fiber.runtimeContext, () => fiber.fx[Symbol.iterator]())
+  return fiber.iterator
 }
 
 const AsyncWait = (waiters: (() => void)[]) =>

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -15,7 +15,7 @@ import { ForkError, capturePrependTraceWithContext, captureTraceWithContext, for
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './interrupt.js'
 import { isInterruptedReturn, withInterpretedReturn } from './iteratorClose.js'
 import type { RuntimeContext } from './runtimeContext.js'
-import { currentRuntimeContext, getRuntimeContext, RuntimeScopeExit, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
+import { currentRuntimeContext, getRuntimeContext, runtimeScopeExit, RuntimeScopeExit, withActiveRuntimeContext, withInterruptionReason } from './runtimeContext.js'
 
 export type RunForkOptions = TraceOptions & {
   readonly maxConcurrency?: number
@@ -165,7 +165,7 @@ const runIterator = async <const E, const A>(
       const promise = t.promise.finally(() => disposables.removeTask(t))
       let a
       try {
-        const scopeExit = disposables.canDeliverInterrupt ? raceScopeExits(effectContext) : undefined
+        const scopeExit = disposables.canDeliverInterrupt ? runtimeScopeExit(effectContext) : undefined
         a = await Promise.race(scopeExit === undefined ? [promise, unhandled] : [promise, unhandled, scopeExit])
       } catch (e) {
         if (e instanceof UnhandledForkError) throw e.error
@@ -424,13 +424,6 @@ const returnWithRuntimeContext = <E, A>(
       withInterpretedReturn(() => iterator.return?.() ?? { done: true, value: undefined as A }))
 
 const never = <A>(): Promise<A> => new Promise(() => { })
-
-const raceScopeExits = (context: RuntimeContext | undefined): Promise<RuntimeScopeExit> | undefined => {
-  if (context?.clearScopeExitSources === true) return undefined
-  const sources = context?.scopeExitSources
-  if (sources === undefined || sources.length === 0) return undefined
-  return Promise.race(sources.map(source => source.promise))
-}
 
 class DisposableAbortController extends AbortController {
   [Symbol.dispose]() { this.abort() }

--- a/src/internal/runtimeContext.ts
+++ b/src/internal/runtimeContext.ts
@@ -15,6 +15,7 @@ export interface RuntimeContext {
   readonly activeScopes?: readonly ActiveScopeDiagnostic[]
   readonly interruptionReason?: unknown
   readonly scopeExitSources?: readonly RuntimeScopeExitSource[]
+  readonly scopeExit?: Promise<RuntimeScopeExit>
   readonly clearScopeExitSources?: boolean
 }
 
@@ -112,10 +113,13 @@ export const withActiveScope = <E, A>(scope: ActiveScopeDiagnostic, fx: Fx<E, A>
 }
 
 export const withScopeExitSource = <E, A>(source: RuntimeScopeExitSource, fx: Fx<E, A>): Fx<E, A> =>
-  withRuntimeContext({ scopeExitSources: [source] }, fx)
+  withRuntimeContext({ scopeExitSources: [source], scopeExit: source.promise }, fx)
 
 export const withoutScopeExitSources = <E, A>(fx: Fx<E, A>): Fx<E, A> =>
-  withRuntimeContext({ scopeExitSources: [], clearScopeExitSources: true }, fx)
+  withRuntimeContext({ scopeExitSources: [], scopeExit: undefined, clearScopeExitSources: true }, fx)
+
+export const runtimeScopeExit = (context: RuntimeContext | undefined): Promise<RuntimeScopeExit> | undefined =>
+  context?.clearScopeExitSources === true ? undefined : context?.scopeExit
 
 const mergeRuntimeContext = (
   previous: RuntimeContext | undefined,
@@ -128,10 +132,18 @@ const mergeRuntimeContext = (
     : next.scopeExitSources === undefined
       ? previous.scopeExitSources
       : [...previous.scopeExitSources, ...next.scopeExitSources]
+  const scopeExit = next.clearScopeExitSources === true
+    ? next.scopeExit
+    : previous?.scopeExit === undefined
+    ? next.scopeExit
+    : next.scopeExit === undefined
+      ? previous.scopeExit
+      : Promise.race([previous.scopeExit, next.scopeExit])
   return {
     ...previous,
     ...next,
-    scopeExitSources
+    scopeExitSources,
+    scopeExit
   }
 }
 

--- a/src/internal/settledQueue.ts
+++ b/src/internal/settledQueue.ts
@@ -1,0 +1,37 @@
+export type SettledTask<Task> =
+  | { readonly task: Task, readonly type: 'success', readonly value: unknown }
+  | { readonly task: Task, readonly type: 'failure', readonly failure: unknown }
+
+export class SettledQueue<A> {
+  private readonly values = [] as A[]
+  private waiters = [] as ((value: A) => void)[]
+
+  push(value: A) {
+    const waiter = this.waiters.shift()
+    if (waiter === undefined) {
+      this.values.push(value)
+    } else {
+      waiter(value)
+    }
+  }
+
+  next(): Promise<A> {
+    const value = this.values.shift()
+    return value === undefined
+      ? new Promise(resolve => this.waiters.push(resolve))
+      : Promise.resolve(value)
+  }
+}
+
+export const settledTaskQueue = <Task extends { readonly promise: Promise<unknown> }>(
+  tasks: Iterable<Task>
+): SettledQueue<SettledTask<Task>> => {
+  const queue = new SettledQueue<SettledTask<Task>>()
+  for (const task of tasks) {
+    task.promise.then(
+      value => queue.push({ task, type: 'success', value }),
+      failure => queue.push({ task, type: 'failure', failure })
+    )
+  }
+  return queue
+}


### PR DESCRIPTION
## Summary

- Replace repeated task-settlement `Promise.race(pending.map(...))` loops with an internal settled queue.
- Cache composed runtime scope-exit promises and reuse them at async runtime boundaries.
- Reduce cooperative scheduler overhead by limiting slot waiter wakeups, using direct wake promises, and deferring queued fork iterator creation until slot admission.
- Prune completed scoped tasks while preserving scoped fork failure and cleanup semantics.
- Extend the built cooperative benchmark with queued-slot and scoped-join rows, and record before/after results.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm build:benchmarks`
- `corepack pnpm benchmark:cooperative-all:js`

## Notes

The deferred `yieldBudget` fairness issue is intentionally unchanged in this PR. The benchmark note is in `benchmarks/results/2026-05-31-scope-concurrency-performance.md`.