### PR TITLE
[codex] Implement unmetered timeout daemon forks

### DIFF
--- a/notes/2026-05-31-timeout-unmetered-daemon-forks.md
+++ b/notes/2026-05-31-timeout-unmetered-daemon-forks.md
@@ -64,26 +64,25 @@ independently of the work it is bounding.
 
 ## Proposed Direction
 
-Add an internal scheduling mode for daemon scope-owned timer forks:
+Add a scheduling mode for forked work:
 
 ```ts
-type ScopedForkContext = TraceOrigin & {
+type ForkScheduling = 'metered' | 'unmetered'
+
+interface ForkContext extends TraceOrigin {
   readonly fx: Fx<unknown, unknown>
-  readonly failure?: 'scope' | 'task' | 'join'
-} & (
-  | { readonly daemon?: false | undefined; readonly scheduling?: undefined }
-  | { readonly daemon: true; readonly scheduling?: 'metered' | 'unmetered' }
-)
+  readonly scheduling?: ForkScheduling
+}
 ```
 
-The exact name can change, but the semantics should be narrow:
+The semantics should be narrow and explicit:
 
-- `daemon: true` means the task does not keep scope success alive.
-- `scheduling: 'unmetered'` means a daemon task does not consume a concurrency
-  permit or cooperative concurrency slot.
-- non-daemon scoped forks cannot use `scheduling: 'unmetered'`.
+- `scheduling: 'metered'` is the default and consumes normal bounded or
+  cooperative concurrency admission.
+- `scheduling: 'unmetered'` skips concurrency admission, but keeps normal task
+  lifetime, interruption, cleanup, failure, trace, and handler-capture behavior.
 
-`timeoutInWithTrace` should mark only its internal timer fork as a daemon with
+`timeoutInWithTrace` should mark its internal timer fork as a daemon with
 unmetered scheduling:
 
 ```ts
@@ -95,8 +94,9 @@ new ScopedFork(scope, {
 })
 ```
 
-This keeps the fix local to internal runtime work. It does not introduce a
-public detached-fork API, and it does not change normal user fork admission.
+The public `fork` and `forkIn` constructors may expose the same advanced
+`scheduling` option. This makes the backpressure escape explicit rather than
+an accidental hidden flag.
 
 ## Why This Is Not General Detach
 
@@ -114,8 +114,8 @@ Timeout timers need something narrower. They remain scope-owned:
   unexpected failure escapes.
 
 They are only detached from the admission budget. Calling this `detached` would
-overload a lifetime term with a scheduling meaning. Use the scoped fork
-`scheduling` mode to make that distinction explicit.
+overload a lifetime term with a scheduling meaning. Use the fork `scheduling`
+mode to make that distinction explicit.
 
 ## Bounded Runtime Changes
 
@@ -125,13 +125,13 @@ smallest change is to let fork start choose whether to acquire:
 ```ts
 const runForkWith = (s: Semaphore) =>
   (fork: Fork): Fx<never, Task<unknown, unknown>> =>
-    ok(fork.arg.unmetered
+    ok(fork.arg.scheduling === 'unmetered'
       ? runForkUnmetered(fork.arg)
       : acquireAndRunFork(fork.arg, s))
 ```
 
-`ScopeController` should lower `scheduling: 'unmetered'` to this scheduler-level
-`ForkContext.unmetered` flag only when `daemon: true`.
+`ScopeController` should pass scoped-fork scheduling through to the lowered
+`ForkContext`.
 
 The unmetered path should still use the same child runtime machinery as normal
 forks:
@@ -183,24 +183,23 @@ The existing `daemon` behavior remains correct:
 - queued bounded timer work should not start after the scope has already been
   interrupted
 
-The new scheduling flag must not imply "ignore scope cleanup". It only says
+The new scheduling mode must not imply "ignore scope cleanup". It only says
 "do not count this work against the user's concurrency limit".
 
 ## API Surface
 
-Do not expose this publicly at first.
+Expose this publicly as an advanced option on `fork` and `forkIn`.
 
-Reasons:
+Docs should be clear and succinct:
 
-- The immediate use case is internal timeout machinery.
-- A public unmetered fork can bypass backpressure and would need a stronger
-  story about fairness and resource use.
-- The existing public design questions around attached and detached forks are
-  lifetime questions, and should not be coupled to this scheduling escape.
-- The name and exact semantics are easier to change while internal.
-
-If more internal uses appear, the flag can remain internal. If user demand
-emerges, evaluate a separate public API with explicit resource caveats.
+- default scheduling is `metered`
+- `unmetered` skips only concurrency admission
+- `unmetered` does not detach the task or bypass interruption, cleanup,
+  failures, traces, or handler capture
+- use `unmetered` only for control-plane work such as timers, watchdogs,
+  cancellation coordinators, and schedulers
+- do not use `unmetered` for ordinary application work that should respect
+  bounded concurrency backpressure
 
 ## Tests
 
@@ -214,13 +213,14 @@ Add focused tests before changing implementation:
    `withCoopConcurrency({ concurrency: 1 })`.
 4. `timeoutIn()` interrupts a caller-owned scope whose body is parked under
    `withCoopConcurrency({ concurrency: 1 })`.
-5. User forks still respect `withBoundedConcurrency(1)` and
-   `withCoopConcurrency({ concurrency: 1 })`; only the internal timer fork is
-   unmetered.
-6. Timer daemon behavior is unchanged: a normally completing scope does not
+5. User forks respect `withBoundedConcurrency(1)` and
+   `withCoopConcurrency({ concurrency: 1 })` by default.
+6. Explicit `fork(..., { scheduling: 'unmetered' })` can bypass bounded and
+   cooperative admission.
+7. Timer daemon behavior is unchanged: a normally completing scope does not
    wait for its timer, and the timeout reason is not produced after normal
    completion.
-7. Queued or not-yet-started timer work is still interrupted when the owning
+8. Queued or not-yet-started timer work is still interrupted when the owning
    scope exits for another reason.
 
 The first test is the regression that currently hangs:
@@ -243,15 +243,13 @@ Use the virtual clock for deterministic timer behavior.
 
 ## Risks
 
-The main risk is creating an accidental priority class. If many unmetered forks
+The main risk is creating an explicit priority class. If many unmetered forks
 exist, they can bypass the user's concurrency limit and reduce the meaning of
-bounded concurrency. Keeping the flag internal and timeout-only controls that
-risk.
+bounded concurrency. Public docs should reserve the option for control-plane
+work.
 
-The second risk is confusing lifetime and scheduling. The scoped-fork union
-keeps them related but not independent: only daemon scoped forks may choose a
-non-default scheduling mode, and `scheduling: 'unmetered'` still does not imply
-detached lifetime ownership.
+The second risk is confusing lifetime and scheduling. `scheduling:
+'unmetered'` still does not imply detached lifetime ownership.
 
 The third risk is duplicated runtime paths. The unmetered bounded path should
 reuse the same underlying fork runner as `acquireAndRunFork`; it should only
@@ -259,10 +257,11 @@ skip semaphore acquisition.
 
 ## Recommendation
 
-Implement internal unmetered daemon forks for timeout timers.
+Implement advanced unmetered scheduling for forks and use it for timeout
+timers.
 
 This is the smallest design that matches the semantic requirement: a timeout's
 timer must not need the resource it is bounding. It preserves the existing
 scope-owned timeout architecture, avoids adding time-budget policy to
-concurrency handlers, and avoids committing to a public detached-fork API before
-the broader lifetime design is settled.
+concurrency handlers, and avoids overloading detached lifetime semantics with a
+scheduling concern.

--- a/notes/2026-05-31-timeout-unmetered-daemon-forks.md
+++ b/notes/2026-05-31-timeout-unmetered-daemon-forks.md
@@ -64,30 +64,34 @@ independently of the work it is bounding.
 
 ## Proposed Direction
 
-Add an internal scheduling flag for scope-owned timer forks:
+Add an internal scheduling mode for daemon scope-owned timer forks:
 
 ```ts
-interface ForkContext {
-  readonly daemon?: boolean
-  readonly unmetered?: boolean
-}
+type ScopedForkContext = TraceOrigin & {
+  readonly fx: Fx<unknown, unknown>
+  readonly failure?: 'scope' | 'task' | 'join'
+} & (
+  | { readonly daemon?: false | undefined; readonly scheduling?: undefined }
+  | { readonly daemon: true; readonly scheduling?: 'metered' | 'unmetered' }
+)
 ```
 
 The exact name can change, but the semantics should be narrow:
 
 - `daemon: true` means the task does not keep scope success alive.
-- `unmetered: true` means the task does not consume a concurrency permit or
-  cooperative concurrency slot.
+- `scheduling: 'unmetered'` means a daemon task does not consume a concurrency
+  permit or cooperative concurrency slot.
+- non-daemon scoped forks cannot use `scheduling: 'unmetered'`.
 
-`timeoutInWithTrace` should mark only its internal timer fork as both daemon and
-unmetered:
+`timeoutInWithTrace` should mark only its internal timer fork as a daemon with
+unmetered scheduling:
 
 ```ts
 new ScopedFork(scope, {
   fx,
   ...traceOrigin,
   daemon: true,
-  unmetered: true
+  scheduling: 'unmetered'
 })
 ```
 
@@ -110,8 +114,8 @@ Timeout timers need something narrower. They remain scope-owned:
   unexpected failure escapes.
 
 They are only detached from the admission budget. Calling this `detached` would
-overload a lifetime term with a scheduling meaning. Prefer a name such as
-`unmetered`, `system`, or `schedulerUnbounded` internally.
+overload a lifetime term with a scheduling meaning. Use the scoped fork
+`scheduling` mode to make that distinction explicit.
 
 ## Bounded Runtime Changes
 
@@ -125,6 +129,9 @@ const runForkWith = (s: Semaphore) =>
       ? runForkUnmetered(fork.arg)
       : acquireAndRunFork(fork.arg, s))
 ```
+
+`ScopeController` should lower `scheduling: 'unmetered'` to this scheduler-level
+`ForkContext.unmetered` flag only when `daemon: true`.
 
 The unmetered path should still use the same child runtime machinery as normal
 forks:
@@ -241,9 +248,10 @@ exist, they can bypass the user's concurrency limit and reduce the meaning of
 bounded concurrency. Keeping the flag internal and timeout-only controls that
 risk.
 
-The second risk is confusing `daemon` and `unmetered`. They must remain
-orthogonal. A daemon task may still be metered in future use cases, and an
-unmetered internal task is not necessarily detached from lifetime ownership.
+The second risk is confusing lifetime and scheduling. The scoped-fork union
+keeps them related but not independent: only daemon scoped forks may choose a
+non-default scheduling mode, and `scheduling: 'unmetered'` still does not imply
+detached lifetime ownership.
 
 The third risk is duplicated runtime paths. The unmetered bounded path should
 reuse the same underlying fork runner as `acquireAndRunFork`; it should only

--- a/notes/2026-05-31-timeout-unmetered-daemon-forks.md
+++ b/notes/2026-05-31-timeout-unmetered-daemon-forks.md
@@ -1,0 +1,260 @@
+# Timeout Timers And Unmetered Daemon Forks
+
+## Question
+
+`timeout()` and `timeoutIn()` schedule timer work as scope-owned daemon forks.
+That preserves lifetime semantics: the timer belongs to the target scope, can
+interrupt that scope, and does not keep the scope alive after normal
+completion.
+
+After PR 216, bounded fork scheduling exposes a liveness problem. With
+`withBoundedConcurrency(1)`, the protected computation can acquire the only
+fork permit and then park in async work such as `sleep`. The internal timeout
+timer is queued behind the same permit, so it never starts and cannot interrupt
+the protected computation.
+
+Should timer work be detached from concurrency permits?
+
+## Current Shape
+
+`timeout()` builds a private scope and starts two scope-owned forks:
+
+1. The protected computation, wrapped in `attempt(...)`, returns from the
+   private scope when it completes.
+2. The timer sleeps for the configured duration, then interrupts the same
+   scope with the timeout reason.
+
+`timeoutIn(scope, options)` schedules only the second piece for a caller-owned
+scope. The timer is represented as:
+
+```ts
+new ScopedFork(scope, { fx, ...traceOrigin, daemon: true })
+```
+
+The `daemon` flag is a lifetime flag. It means the timer can interrupt the
+scope, but it does not keep a normally completing scope alive. It does not
+currently affect scheduling.
+
+`withBoundedConcurrency` handles all `Fork` requests by calling
+`acquireAndRunFork` with the same semaphore. `withCoopConcurrency` similarly
+shares its `concurrency` slots across structured children and explicit forks.
+Neither handler distinguishes user work from internal timer work.
+
+## Failure Mode
+
+This should time out:
+
+```ts
+sleep(100).pipe(
+  timeout({ ms: 10 }),
+  withBoundedConcurrency(1)
+)
+```
+
+Instead, the protected computation starts first and consumes the only permit.
+The timer fork is queued. Advancing the clock to 10ms does not help because the
+timer has not started its `sleep(10)` yet. The timeout cannot win until the
+protected computation releases the permit, which is exactly the work the
+timeout is supposed to bound.
+
+This is not just ordering. Scheduling the timer before the protected
+computation would make fast computations wait behind their own timeout timer
+under `withBoundedConcurrency(1)`. A timeout timer must be able to run
+independently of the work it is bounding.
+
+## Proposed Direction
+
+Add an internal scheduling flag for scope-owned timer forks:
+
+```ts
+interface ForkContext {
+  readonly daemon?: boolean
+  readonly unmetered?: boolean
+}
+```
+
+The exact name can change, but the semantics should be narrow:
+
+- `daemon: true` means the task does not keep scope success alive.
+- `unmetered: true` means the task does not consume a concurrency permit or
+  cooperative concurrency slot.
+
+`timeoutInWithTrace` should mark only its internal timer fork as both daemon and
+unmetered:
+
+```ts
+new ScopedFork(scope, {
+  fx,
+  ...traceOrigin,
+  daemon: true,
+  unmetered: true
+})
+```
+
+This keeps the fix local to internal runtime work. It does not introduce a
+public detached-fork API, and it does not change normal user fork admission.
+
+## Why This Is Not General Detach
+
+The broader detached-fork question is about lifetime ownership: whether a fork
+is attached to a concurrency or scope boundary, and how the caller can take
+responsibility for it.
+
+Timeout timers need something narrower. They remain scope-owned:
+
+- The target scope interrupts them during cleanup.
+- Their finalizers and async cleanup still run through the normal task
+  interruption path.
+- They still use captured handlers and runtime context.
+- They still report failures through the existing fork/task diagnostics if an
+  unexpected failure escapes.
+
+They are only detached from the admission budget. Calling this `detached` would
+overload a lifetime term with a scheduling meaning. Prefer a name such as
+`unmetered`, `system`, or `schedulerUnbounded` internally.
+
+## Bounded Runtime Changes
+
+`withBoundedConcurrency` delegates fork start to `acquireAndRunFork`. The
+smallest change is to let fork start choose whether to acquire:
+
+```ts
+const runForkWith = (s: Semaphore) =>
+  (fork: Fork): Fx<never, Task<unknown, unknown>> =>
+    ok(fork.arg.unmetered
+      ? runForkUnmetered(fork.arg)
+      : acquireAndRunFork(fork.arg, s))
+```
+
+The unmetered path should still use the same child runtime machinery as normal
+forks:
+
+- captured handlers are applied in the same place
+- runtime context and trace propagation are preserved
+- active child tasks are interruptible by their parent runtime
+- unhandled failure diagnostics stay consistent
+
+Implementation detail: this may be a new internal function next to
+`acquireAndRunFork`, rather than a boolean parameter threaded through call
+sites. Keep the public `runFork` options unchanged.
+
+## Cooperative Runtime Changes
+
+`withCoopConcurrency` currently creates a `Fiber`, attempts to acquire a slot,
+and waits until a slot is available before stepping the fiber.
+
+For unmetered forks, the runtime should create a fiber that never participates
+in slot accounting:
+
+- initialize the fiber as unmetered
+- skip initial slot acquisition
+- skip `waitForSlotPromise`
+- do not call `releaseSlot` for that fiber
+- continue to honor async waiting, interruption, masks, cleanup, traces, and
+  handler capture
+
+This should be implemented as a property of the fiber, not as a separate
+runtime. Timer fibers still need the same scheduler semantics, just without
+slot admission.
+
+The existing cooperative async escape hatch,
+`markReleaseSlotAsync`, is not enough. It releases a slot after a fiber has
+started and reached a marked async operation. The timer bug happens before the
+timer fiber starts.
+
+## Scope Semantics
+
+No public scope semantics should change.
+
+`ScopeController` should continue to register timer tasks through
+`ScopedFork`, mark them handled, and watch them like other scope-owned tasks.
+The existing `daemon` behavior remains correct:
+
+- on normal scope success, daemon-only pending work does not keep the scope
+  alive
+- on interruption, failure, abort, or return-from, pending work is interrupted
+- queued bounded timer work should not start after the scope has already been
+  interrupted
+
+The new scheduling flag must not imply "ignore scope cleanup". It only says
+"do not count this work against the user's concurrency limit".
+
+## API Surface
+
+Do not expose this publicly at first.
+
+Reasons:
+
+- The immediate use case is internal timeout machinery.
+- A public unmetered fork can bypass backpressure and would need a stronger
+  story about fairness and resource use.
+- The existing public design questions around attached and detached forks are
+  lifetime questions, and should not be coupled to this scheduling escape.
+- The name and exact semantics are easier to change while internal.
+
+If more internal uses appear, the flag can remain internal. If user demand
+emerges, evaluate a separate public API with explicit resource caveats.
+
+## Tests
+
+Add focused tests before changing implementation:
+
+1. `timeout()` interrupts a parked protected computation under
+   `withBoundedConcurrency(1)`.
+2. `timeoutIn()` interrupts a caller-owned scope whose body is parked under
+   `withBoundedConcurrency(1)`.
+3. `timeout()` interrupts a parked protected computation under
+   `withCoopConcurrency({ concurrency: 1 })`.
+4. `timeoutIn()` interrupts a caller-owned scope whose body is parked under
+   `withCoopConcurrency({ concurrency: 1 })`.
+5. User forks still respect `withBoundedConcurrency(1)` and
+   `withCoopConcurrency({ concurrency: 1 })`; only the internal timer fork is
+   unmetered.
+6. Timer daemon behavior is unchanged: a normally completing scope does not
+   wait for its timer, and the timeout reason is not produced after normal
+   completion.
+7. Queued or not-yet-started timer work is still interrupted when the owning
+   scope exits for another reason.
+
+The first test is the regression that currently hangs:
+
+```ts
+const p = sleep(100).pipe(
+  timeout({ ms: 10, reason: () => 'timeout' }),
+  control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+  withBoundedConcurrency(1),
+  returnFail,
+  withClock(c),
+  runPromise
+)
+
+await c.step(10)
+assert.equal(await p, 'timeout')
+```
+
+Use the virtual clock for deterministic timer behavior.
+
+## Risks
+
+The main risk is creating an accidental priority class. If many unmetered forks
+exist, they can bypass the user's concurrency limit and reduce the meaning of
+bounded concurrency. Keeping the flag internal and timeout-only controls that
+risk.
+
+The second risk is confusing `daemon` and `unmetered`. They must remain
+orthogonal. A daemon task may still be metered in future use cases, and an
+unmetered internal task is not necessarily detached from lifetime ownership.
+
+The third risk is duplicated runtime paths. The unmetered bounded path should
+reuse the same underlying fork runner as `acquireAndRunFork`; it should only
+skip semaphore acquisition.
+
+## Recommendation
+
+Implement internal unmetered daemon forks for timeout timers.
+
+This is the smallest design that matches the semantic requirement: a timeout's
+timer must not need the resource it is bounding. It preserves the existing
+scope-owned timeout architecture, avoids adding time-budget policy to
+concurrency handlers, and avoids committing to a public detached-fork API before
+the broader lifetime design is settled.

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -655,6 +655,32 @@ describe('Fork', () => {
       assert.deepEqual(events, ['start 1', 'end 1', 'start 2', 'end 2', 'start 3', 'end 3'])
     })
 
+    it('allows advanced unmetered forks to bypass bounded concurrency admission', async () => {
+      const events = [] as string[]
+      let releaseMetered!: () => void
+
+      const result = await fx(function* () {
+        yield* fork(assertPromise<void>(() => new Promise(resolve => {
+          events.push('metered start')
+          releaseMetered = resolve
+        })))
+        yield* asyncValue(undefined)
+        const unmetered = yield* fork(fx(function* () {
+          events.push('unmetered start')
+          return 'unmetered' as const
+        }), { scheduling: 'unmetered' })
+        return yield* wait(unmetered)
+      }).pipe(
+        withBoundedConcurrency(1),
+        runPromise
+      )
+
+      releaseMetered()
+
+      assert.equal(result, 'unmetered')
+      assert.deepEqual(events, ['metered start', 'unmetered start'])
+    })
+
     it('cancels mapped siblings when a child fails', async () => {
       const cause = new Error('mapAll failed')
       let cancelled = false
@@ -1315,6 +1341,32 @@ describe('Fork', () => {
 
       assert.deepEqual(await promise, [undefined, 'all'])
       assert.deepEqual(events, ['fork start', 'all start'])
+    })
+
+    it('allows advanced unmetered forks to bypass cooperative concurrency admission', async () => {
+      const events = [] as string[]
+      let releaseMetered!: () => void
+
+      const result = await fx(function* () {
+        yield* fork(assertPromise<void>(() => new Promise(resolve => {
+          events.push('metered start')
+          releaseMetered = resolve
+        })))
+        yield* asyncValue(undefined)
+        const unmetered = yield* fork(fx(function* () {
+          events.push('unmetered start')
+          return 'unmetered' as const
+        }), { scheduling: 'unmetered' })
+        return yield* wait(unmetered)
+      }).pipe(
+        withCoopConcurrency({ concurrency: 1 }),
+        runPromise
+      )
+
+      releaseMetered()
+
+      assert.equal(result, 'unmetered')
+      assert.deepEqual(events, ['metered start', 'unmetered start'])
     })
 
     it('interrupts queued explicit cooperative forks before they start', async () => {

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -10,7 +10,7 @@ import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
 import { withCoopConcurrency } from './internal/concurrent/cooperative.js'
 import { Fork, RaceAllFailed } from './internal/concurrent/effects.js'
-import type { EffectsOf, ErrorsOf, ResultOf } from './internal/concurrent/effects.js'
+import type { EffectsOf, ErrorsOf, ForkScheduling, ResultOf } from './internal/concurrent/effects.js'
 import { withBoundedConcurrency, withUnboundedConcurrency } from './internal/concurrent/fork.js'
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
 import { InterruptedReturn, isInterpretingReturn } from './internal/iteratorClose.js'
@@ -31,9 +31,20 @@ export type {
   EffectsOf,
   ErrorsOf,
   ForkContext,
+  ForkScheduling,
   ResultOf
 } from './internal/concurrent/effects.js'
 export type { CoopConcurrencyOptions } from './internal/concurrent/cooperative.js'
+
+export type ForkOptions = TraceOptions & {
+  /**
+   * Advanced scheduling mode. Defaults to `metered`.
+   *
+   * Use `unmetered` only for control-plane work that must not consume bounded
+   * or cooperative concurrency admission.
+   */
+  readonly scheduling?: ForkScheduling
+}
 
 /**
  * Start an Fx concurrently and return a {@link Task} handle.
@@ -42,17 +53,21 @@ export type { CoopConcurrencyOptions } from './internal/concurrent/cooperative.j
  * lifetime. Use {@link all} or {@link race} when the caller only needs the
  * structured result.
  *
+ * Advanced: `scheduling: 'unmetered'` skips only concurrency admission for
+ * control-plane work. It does not change task lifetime, cleanup, failures,
+ * traces, or handler capture.
+ *
  * @example
  * const task = yield* fork(fetchUser)
  * const user = yield* wait(task)
  */
 export const fork = <const E, const A>(
   f: Fx<E, A>,
-  options?: TraceOptions
+  options?: ForkOptions
 ): Fx<Exclude<E, Async | Fail<any>> | Fork | HandlerCapture<'fx/Concurrent/Fork'>, Task<A, ErrorsOf<E>>> => {
   const trace = traceOrigin(options, 'fx/Concurrent/fork', fork, 'fork')
   return withCapturedHandlers('fx/Concurrent/Fork', f).pipe(
-    flatMap(fx => new Fork({ fx, ...trace }) as Fx<Fork, Task<A, ErrorsOf<E>>>)
+    flatMap(fx => new Fork({ fx, ...trace, scheduling: options?.scheduling }) as Fx<Fork, Task<A, ErrorsOf<E>>>)
   )
 }
 
@@ -65,6 +80,9 @@ export const fork = <const E, const A>(
  * inside an outer fork scheduler, for example
  * `program.pipe(withScope(scope), withUnboundedConcurrency)`.
  *
+ * Advanced: `scheduling: 'unmetered'` is passed through to the fork scheduler
+ * without changing scope ownership.
+ *
  * The types follow normal effect elimination: `forkIn` introduces a
  * `ScopedFork<Scope>`, `withScope(scope)` handles it and may introduce `Fork`,
  * and a fork scheduler handles `Fork` before execution.
@@ -72,11 +90,11 @@ export const fork = <const E, const A>(
 export const forkIn = <const Scope extends AnyScope, const E, const A>(
   scope: Scope,
   f: Fx<E, A>,
-  options?: TraceOptions
+  options?: ForkOptions
 ): Fx<Exclude<E, Async | Fail<any>> | ScopedFork<Scope> | HandlerCapture<'fx/Concurrent/ForkIn'>, Task<A, ErrorsOf<E>>> => {
   const trace = traceOrigin(options, 'fx/Concurrent/forkIn', forkIn, 'fork')
   return withCapturedHandlers('fx/Concurrent/ForkIn', f).pipe(
-    flatMap(fx => new ScopedFork(scope, { fx, ...trace }) as Fx<ScopedFork<Scope>, Task<A, ErrorsOf<E>>>)
+    flatMap(fx => new ScopedFork(scope, { fx, ...trace, scheduling: options?.scheduling }) as Fx<ScopedFork<Scope>, Task<A, ErrorsOf<E>>>)
   )
 }
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -315,7 +315,12 @@ class ScopeController<Scope extends AnyScope> {
   }
 
   *fork(context: ScopedForkContext): Generator<unknown, Task<unknown, unknown>, unknown> {
-    const task = yield* withoutScopeExitSources(new Fork(context) as Fx<Fork, Task<unknown, unknown>>)
+    const task = yield* withoutScopeExitSources(new Fork({
+      fx: context.fx,
+      origin: context.origin,
+      trace: context.trace,
+      unmetered: context.daemon === true && context.scheduling === 'unmetered'
+    }) as Fx<Fork, Task<unknown, unknown>>)
     task._markHandled()
     this.tasks.set(task, context)
     this.watchTask(task)

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -319,7 +319,7 @@ class ScopeController<Scope extends AnyScope> {
       fx: context.fx,
       origin: context.origin,
       trace: context.trace,
-      unmetered: context.daemon === true && context.scheduling === 'unmetered'
+      scheduling: context.scheduling
     }) as Fx<Fork, Task<unknown, unknown>>)
     task._markHandled()
     this.tasks.set(task, context)

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
+import { at } from './Breadcrumb.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { forkIn, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
@@ -12,6 +13,7 @@ import { TimeoutInterrupt, timeout, timeoutIn } from './Timeout.js'
 import { sleep, withClock } from './Time.js'
 import { getTrace } from './Trace.js'
 import { VirtualClock } from './internal/time.js'
+import type { ScopedForkContext } from './internal/scopedFork.js'
 
 describe('Timeout', () => {
   const TestScope = scope('test/Timeout')
@@ -264,6 +266,15 @@ describe('Timeout', () => {
     void hasTimeoutInterrupt
     void effectIsNotAny
     void resultIsNotAny
+  })
+
+  it('requires daemon scoped forks for unmetered scheduling', () => {
+    const origin = at('test/Timeout/scoped-fork-scheduling', timeout)
+    const valid: ScopedForkContext = { fx: ok(undefined), origin, daemon: true, scheduling: 'unmetered' }
+    // @ts-expect-error Non-daemon scoped forks cannot opt out of concurrency admission.
+    const invalid: ScopedForkContext = { fx: ok(undefined), origin, scheduling: 'unmetered' }
+    void valid
+    void invalid
   })
 
   it('timeoutIn can interrupt a caller-owned scope while non-daemon work keeps it alive', async () => {

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Fail, fail, returnFail } from './Fail.js'
-import { forkIn, withBoundedConcurrency, withUnboundedConcurrency } from './Concurrent.js'
+import { forkIn, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
 import { andFinallyExit } from './Finalization.js'
 import type { Fx } from './Fx.js'
@@ -61,6 +61,44 @@ describe('Timeout', () => {
 
     assert.ok(!Fail.is(r))
     assert.equal(r, 'fast')
+  })
+
+  it('interrupts a parked protected computation under bounded concurrency', async () => {
+    const c = new VirtualClock(0)
+    const reason = { type: 'timeout' }
+
+    const p = sleep(100).pipe(
+      timeout({ ms: 10, reason: () => reason }),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withBoundedConcurrency(1),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await mustSettle(p)
+
+    assert.equal(r, reason)
+  })
+
+  it('interrupts a parked protected computation under cooperative concurrency', async () => {
+    const c = new VirtualClock(0)
+    const reason = { type: 'timeout' }
+
+    const p = sleep(100).pipe(
+      timeout({ ms: 10, reason: () => reason }),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withCoopConcurrency({ concurrency: 1 }),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await mustSettle(p)
+
+    assert.equal(r, reason)
   })
 
   it('interrupts the scope with the timeout reason when the timeout wins', async () => {
@@ -285,6 +323,60 @@ describe('Timeout', () => {
     assert.equal(completed, false)
   })
 
+  it('timeoutIn interrupts a scope while a bounded child holds the only permit', async () => {
+    const c = new VirtualClock(0)
+    const reason = { type: 'scope-timeout' }
+    let completed = false
+
+    const p = fx(function* () {
+      yield* forkIn(TestScope, fx(function* () {
+        yield* sleep(100)
+        completed = true
+      }))
+      yield* timeoutIn(TestScope, { ms: 10, reason: () => reason })
+    }).pipe(
+      withScope(TestScope),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withBoundedConcurrency(1),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await mustSettle(p)
+
+    assert.equal(r, reason)
+    assert.equal(completed, false)
+  })
+
+  it('timeoutIn interrupts a scope while a cooperative child holds the only permit', async () => {
+    const c = new VirtualClock(0)
+    const reason = { type: 'scope-timeout' }
+    let completed = false
+
+    const p = fx(function* () {
+      yield* forkIn(TestScope, fx(function* () {
+        yield* sleep(100)
+        completed = true
+      }))
+      yield* timeoutIn(TestScope, { ms: 10, reason: () => reason })
+    }).pipe(
+      withScope(TestScope),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withCoopConcurrency({ concurrency: 1 }),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await mustSettle(p)
+
+    assert.equal(r, reason)
+    assert.equal(completed, false)
+  })
+
   it('timeoutIn daemon timer does not delay normal scope completion', async () => {
     const c = new VirtualClock(0)
     let reasons = 0
@@ -390,3 +482,9 @@ type EffectOf<T> = T extends Fx<infer E, unknown> ? E : never
 type ResultOf<T> = T extends Fx<unknown, infer A> ? A : never
 type HasEffect<T, E> = [Extract<EffectOf<T>, E>] extends [never] ? false : true
 type IsAny<T> = 0 extends 1 & T ? true : false
+
+const mustSettle = <A>(p: Promise<A>): Promise<A> =>
+  Promise.race([
+    p,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Expected timeout program to settle')), 100))
+  ])

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { at } from './Breadcrumb.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { forkIn, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
@@ -13,7 +12,6 @@ import { TimeoutInterrupt, timeout, timeoutIn } from './Timeout.js'
 import { sleep, withClock } from './Time.js'
 import { getTrace } from './Trace.js'
 import { VirtualClock } from './internal/time.js'
-import type { ScopedForkContext } from './internal/scopedFork.js'
 
 describe('Timeout', () => {
   const TestScope = scope('test/Timeout')
@@ -266,15 +264,6 @@ describe('Timeout', () => {
     void hasTimeoutInterrupt
     void effectIsNotAny
     void resultIsNotAny
-  })
-
-  it('requires daemon scoped forks for unmetered scheduling', () => {
-    const origin = at('test/Timeout/scoped-fork-scheduling', timeout)
-    const valid: ScopedForkContext = { fx: ok(undefined), origin, daemon: true, scheduling: 'unmetered' }
-    // @ts-expect-error Non-daemon scoped forks cannot opt out of concurrency admission.
-    const invalid: ScopedForkContext = { fx: ok(undefined), origin, scheduling: 'unmetered' }
-    void valid
-    void invalid
   })
 
   it('timeoutIn can interrupt a caller-owned scope while non-daemon work keeps it alive', async () => {

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -78,7 +78,7 @@ function timeoutInWithTrace<const Scope extends AnyScope, const Options extends 
     const task = yield* withCapturedHandlers('fx/Concurrent/ForkIn', sleep(options.ms).pipe(
       flatMap(() => interruptFrom(scope, makeTimeoutReason(options, { ms: options.ms, origin: reasonOrigin, trace })))
     )).pipe(
-      flatMap(fx => new ScopedFork(scope, { fx, ...traceOrigin, daemon: true, unmetered: true }))
+      flatMap(fx => new ScopedFork(scope, { fx, ...traceOrigin, daemon: true, scheduling: 'unmetered' }))
     )
     yield* andFinallyExit(scope, exit => assertPromise(() => task.interrupt(exitReason(exit))))
   })

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -78,7 +78,7 @@ function timeoutInWithTrace<const Scope extends AnyScope, const Options extends 
     const task = yield* withCapturedHandlers('fx/Concurrent/ForkIn', sleep(options.ms).pipe(
       flatMap(() => interruptFrom(scope, makeTimeoutReason(options, { ms: options.ms, origin: reasonOrigin, trace })))
     )).pipe(
-      flatMap(fx => new ScopedFork(scope, { fx, ...traceOrigin, daemon: true }))
+      flatMap(fx => new ScopedFork(scope, { fx, ...traceOrigin, daemon: true, unmetered: true }))
     )
     yield* andFinallyExit(scope, exit => assertPromise(() => task.interrupt(exitReason(exit))))
   })

--- a/src/internal/concurrent/cooperative.ts
+++ b/src/internal/concurrent/cooperative.ts
@@ -94,7 +94,7 @@ export class CooperativeRuntime {
       fx: fork.arg.fx,
       traceOrigin: { origin, trace },
       runtimeContext: context,
-      unmetered: fork.arg.unmetered === true,
+      unmetered: fork.arg.scheduling === 'unmetered',
       masks: new InterruptMaskState(),
       slotAcquired: false,
       status: 'ready',

--- a/src/internal/concurrent/cooperative.ts
+++ b/src/internal/concurrent/cooperative.ts
@@ -55,6 +55,7 @@ interface Fiber {
   readonly traceOrigin: TraceOrigin
   readonly masks: InterruptMaskState
   readonly runtimeContext: ReturnType<typeof getRuntimeContext>
+  readonly unmetered: boolean
   iterator?: Iterator<unknown, unknown, unknown>
   slotAcquired: boolean
   status: 'ready' | 'waiting' | 'done'
@@ -93,6 +94,7 @@ export class CooperativeRuntime {
       fx: fork.arg.fx,
       traceOrigin: { origin, trace },
       runtimeContext: context,
+      unmetered: fork.arg.unmetered === true,
       masks: new InterruptMaskState(),
       slotAcquired: false,
       status: 'ready',
@@ -138,7 +140,7 @@ export class CooperativeRuntime {
 
   private async drainFork(fiber: Fiber, done: PromiseWithResolvers<unknown>, wake = new Wake()): Promise<void> {
     try {
-      while (!fiber.slotAcquired) {
+      while (!hasSlot(fiber)) {
         if (fiber.cancelRequested) {
           finishDetachedFiber(this, fiber)
           return
@@ -151,7 +153,7 @@ export class CooperativeRuntime {
           await wake.wait()
           continue
         }
-        while (!fiber.slotAcquired) {
+        while (!hasSlot(fiber)) {
           if (this.tryAcquireSlot(fiber)) break
           await this.waitForSlotPromise()
         }
@@ -189,6 +191,7 @@ export class CooperativeRuntime {
   }
 
   tryAcquireSlot(fiber: Fiber): boolean {
+    if (fiber.unmetered) return true
     if (fiber.slotAcquired) return true
     if (this.availableSlots <= 0) return false
     this.availableSlots--
@@ -197,6 +200,7 @@ export class CooperativeRuntime {
   }
 
   releaseSlot(fiber: Fiber) {
+    if (fiber.unmetered) return
     if (!fiber.slotAcquired) return
     fiber.slotAcquired = false
     this.availableSlots++
@@ -382,7 +386,7 @@ function* reacquireSlot(
   runtime: CooperativeRuntime,
   fiber: Fiber
 ): Generator<unknown, void, unknown> {
-  if (fiber.status === 'done') return
+  if (fiber.status === 'done' || fiber.unmetered) return
   while (!runtime.tryAcquireSlot(fiber)) yield* runtime.waitForSlot()
 }
 
@@ -457,6 +461,9 @@ const finishDetachedFiber = (runtime: CooperativeRuntime, fiber: Fiber) => {
   fiber.abort?.abort()
   runtime.releaseSlot(fiber)
 }
+
+const hasSlot = (fiber: Fiber): boolean =>
+  fiber.unmetered || fiber.slotAcquired
 
 const wrapFiberFailure = (fiber: Fiber, failure: Fail<unknown>): ForkError => {
   const context = runtimeContextOfEffect(failure, fiber.runtimeContext)

--- a/src/internal/concurrent/effects.ts
+++ b/src/internal/concurrent/effects.ts
@@ -14,6 +14,11 @@ export class Fork extends Effect('fx/Concurrent/Fork')<ForkContext, Task<unknown
 
 export interface ForkContext extends TraceOrigin {
   readonly fx: Fx<unknown, unknown>
+  /**
+   * Internal scheduler work that remains lifecycle-owned by its caller but does
+   * not consume concurrency admission.
+   */
+  readonly unmetered?: boolean
 }
 
 /**

--- a/src/internal/concurrent/effects.ts
+++ b/src/internal/concurrent/effects.ts
@@ -15,11 +15,15 @@ export class Fork extends Effect('fx/Concurrent/Fork')<ForkContext, Task<unknown
 export interface ForkContext extends TraceOrigin {
   readonly fx: Fx<unknown, unknown>
   /**
-   * Internal scheduler work that remains lifecycle-owned by its caller but does
-   * not consume concurrency admission.
+   * Advanced scheduling mode. Defaults to `metered`.
+   *
+   * Unmetered forks skip only concurrency admission. They keep normal lifetime,
+   * cleanup, failure, trace, and handler-capture behavior.
    */
-  readonly unmetered?: boolean
+  readonly scheduling?: ForkScheduling
 }
+
+export type ForkScheduling = 'metered' | 'unmetered'
 
 /**
  * Failure returned by `firstSuccess` when every raced child fails.

--- a/src/internal/concurrent/fork.ts
+++ b/src/internal/concurrent/fork.ts
@@ -3,7 +3,7 @@ import { Handle } from '../../Handler.js'
 import { HandlerCapture, handleCaptured, withCapturedHandlers } from '../../HandlerCapture.js'
 import { Task } from '../../Task.js'
 import { Semaphore } from '../Semaphore.js'
-import { acquireAndRunFork } from '../runFork.js'
+import { acquireAndRunFork, runForkUnmetered } from '../runFork.js'
 import { Fork } from './effects.js'
 
 /**
@@ -30,7 +30,7 @@ export const withUnboundedConcurrency = withBoundedConcurrency(Infinity)
 
 const runForkWith = (s: Semaphore) =>
   (fork: Fork): Fx<never, Task<unknown, unknown>> =>
-    ok(acquireAndRunFork(fork.arg, s))
+    ok(fork.arg.unmetered === true ? runForkUnmetered(fork.arg, s) : acquireAndRunFork(fork.arg, s))
 
 type WithConcurrencyHandledEffects<E> =
   Handle<Handle<E, Fork>, HandlerCapture<'fx/Concurrent/Fork'>>

--- a/src/internal/concurrent/fork.ts
+++ b/src/internal/concurrent/fork.ts
@@ -30,7 +30,7 @@ export const withUnboundedConcurrency = withBoundedConcurrency(Infinity)
 
 const runForkWith = (s: Semaphore) =>
   (fork: Fork): Fx<never, Task<unknown, unknown>> =>
-    ok(fork.arg.unmetered === true ? runForkUnmetered(fork.arg, s) : acquireAndRunFork(fork.arg, s))
+    ok(fork.arg.scheduling === 'unmetered' ? runForkUnmetered(fork.arg, s) : acquireAndRunFork(fork.arg, s))
 
 type WithConcurrencyHandledEffects<E> =
   Handle<Handle<E, Fork>, HandlerCapture<'fx/Concurrent/Fork'>>

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -240,7 +240,7 @@ const runForkWithAdmission = (
   s: Semaphore,
   context: readonly CapturedHandler[],
   runtimeContext: RuntimeContext | undefined
-) => f.unmetered === true
+) => f.scheduling === 'unmetered'
   ? runForkUnmetered(f, s, context, runtimeContext)
   : acquireAndRunFork(f, s, context, runtimeContext)
 

--- a/src/internal/runFork.ts
+++ b/src/internal/runFork.ts
@@ -52,6 +52,19 @@ export const acquireAndRunFork = (f: ForkContext, s: Semaphore, context: readonl
   return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
 }
 
+export const runForkUnmetered = (f: ForkContext, s: Semaphore, context: readonly CapturedHandler[] = [], runtimeContext: RuntimeContext | undefined = currentRuntimeContext()): Task<unknown, unknown> => {
+  const disposables = new InterruptState()
+  const disposed = Promise.withResolvers<void>()
+
+  const promise = runForkInternal(withHandlerContext(context, f.fx), context, s, disposables, disposed, f.origin, f.trace, runtimeContext)
+    .finally(() => {
+      disposables.interruptActive()
+      disposed.resolve()
+    })
+
+  return taskWithRuntimeContext(promise, reason => disposables.interrupt(reason), runtimeContext, disposed.promise)
+}
+
 const runForkInternal = <const E, const A>(
   f: Fx<E, A>,
   context: readonly CapturedHandler[],
@@ -185,7 +198,7 @@ const runIterator = async <const E, const A>(
       const effectContext = runtimeContextOfEffect(ir.value, runtimeContext)
       const forkOrigin = ir.value.arg.origin
       const forkTrace = capturePrependTraceWithContext(effectContext, forkOrigin, trace, forkFrameMetadata(ir.value.arg.trace))
-      const t = acquireAndRunFork({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext)
+      const t = runForkWithAdmission({ ...ir.value.arg, trace: forkTrace }, semaphore, context, effectContext)
       disposables.addTask(t)
       t.promise
         .finally(() => disposables.removeTask(t))
@@ -221,6 +234,15 @@ const runIterator = async <const E, const A>(
   }
   return ir.value as A
 }
+
+const runForkWithAdmission = (
+  f: ForkContext,
+  s: Semaphore,
+  context: readonly CapturedHandler[],
+  runtimeContext: RuntimeContext | undefined
+) => f.unmetered === true
+  ? runForkUnmetered(f, s, context, runtimeContext)
+  : acquireAndRunFork(f, s, context, runtimeContext)
 
 class InterruptState {
   private readonly disposables = new DisposableSet()

--- a/src/internal/scopedFork.ts
+++ b/src/internal/scopedFork.ts
@@ -8,17 +8,32 @@ export class ScopedFork<
   const Scope extends AnyScope = AnyScope
 > extends ScopedEffect('fx/Scope/ScopedFork')<Scope, ScopedForkContext, Task<unknown, unknown>> { }
 
-export interface ScopedForkContext extends TraceOrigin {
+export type ScopedForkContext = TraceOrigin & {
   readonly fx: Fx<unknown, unknown>
+  readonly failure?: 'scope' | 'task' | 'join'
+} & (
+  | MeteredScopedForkContext
+  | DaemonScopedForkContext
+)
+
+interface MeteredScopedForkContext {
   /**
-   * Internal scheduler work that remains scope-owned but does not consume
-   * concurrency admission.
+   * Non-daemon scoped forks are always metered and keep their scope open on
+   * normal completion.
    */
-  readonly unmetered?: boolean
+  readonly daemon?: false | undefined
+  readonly scheduling?: undefined
+}
+
+interface DaemonScopedForkContext {
   /**
    * Internal daemon scoped forks are still owned by their scope, but do not
    * hold the scope open on normal completion.
    */
-  readonly daemon?: boolean
-  readonly failure?: 'scope' | 'task' | 'join'
+  readonly daemon: true
+  /**
+   * Daemon scoped forks may opt out of concurrency admission for internal
+   * scheduler work such as timeout timers.
+   */
+  readonly scheduling?: 'metered' | 'unmetered'
 }

--- a/src/internal/scopedFork.ts
+++ b/src/internal/scopedFork.ts
@@ -11,6 +11,11 @@ export class ScopedFork<
 export interface ScopedForkContext extends TraceOrigin {
   readonly fx: Fx<unknown, unknown>
   /**
+   * Internal scheduler work that remains scope-owned but does not consume
+   * concurrency admission.
+   */
+  readonly unmetered?: boolean
+  /**
    * Internal daemon scoped forks are still owned by their scope, but do not
    * hold the scope open on normal completion.
    */

--- a/src/internal/scopedFork.ts
+++ b/src/internal/scopedFork.ts
@@ -3,37 +3,26 @@ import type { Fx } from '../Fx.js'
 import type { AnyScope } from '../Scope.js'
 import type { Task } from '../Task.js'
 import type { TraceOrigin } from '../Trace.js'
+import type { ForkScheduling } from './concurrent/effects.js'
 
 export class ScopedFork<
   const Scope extends AnyScope = AnyScope
 > extends ScopedEffect('fx/Scope/ScopedFork')<Scope, ScopedForkContext, Task<unknown, unknown>> { }
 
-export type ScopedForkContext = TraceOrigin & {
+export interface ScopedForkContext extends TraceOrigin {
   readonly fx: Fx<unknown, unknown>
-  readonly failure?: 'scope' | 'task' | 'join'
-} & (
-  | MeteredScopedForkContext
-  | DaemonScopedForkContext
-)
-
-interface MeteredScopedForkContext {
   /**
-   * Non-daemon scoped forks are always metered and keep their scope open on
-   * normal completion.
+   * Advanced scheduling mode. Defaults to `metered`.
+   *
+   * Unmetered scoped forks skip only concurrency admission. They remain
+   * scope-owned and keep normal cleanup, failure, trace, and handler-capture
+   * behavior.
    */
-  readonly daemon?: false | undefined
-  readonly scheduling?: undefined
-}
-
-interface DaemonScopedForkContext {
+  readonly scheduling?: ForkScheduling
   /**
    * Internal daemon scoped forks are still owned by their scope, but do not
    * hold the scope open on normal completion.
    */
-  readonly daemon: true
-  /**
-   * Daemon scoped forks may opt out of concurrency admission for internal
-   * scheduler work such as timeout timers.
-   */
-  readonly scheduling?: 'metered' | 'unmetered'
+  readonly daemon?: boolean
+  readonly failure?: 'scope' | 'task' | 'join'
 }


### PR DESCRIPTION
## Summary
- expose advanced `scheduling: 'metered' | 'unmetered'` fork options for `fork` and `forkIn`
- use unmetered scheduling for timeout daemon timers so they do not consume bounded or cooperative concurrency admission
- add public unmetered fork coverage, timeout regressions, and the design note

## Root cause
- timeout timers are scope-owned daemon forks, but bounded and cooperative schedulers treated them like ordinary metered work
- with a concurrency limit of 1, the protected computation could hold the only permit while parked, preventing the timer fork from starting

## Semantics
- default fork scheduling remains `metered`
- `unmetered` skips only concurrency admission
- `unmetered` does not change task lifetime, scope ownership, cleanup, failures, traces, handler capture, or interruption

## Validation
- node --import tsx --test src/Timeout.test.ts src/Concurrent.test.ts src/internal/runFork.test.ts
- corepack pnpm build
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm lint
- git diff --check