### PR TITLE
[codex] Fix timeout scheduling under bounded concurrency

### DIFF
--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -13,6 +13,7 @@ import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync
 import { drainIteratorReturn, isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
+import { ScopeExit } from './internal/scopeExit.js'
 import { ScopeTypeId, sameScope, scopeId, type ScopeIdentity } from './internal/scopeIdentity.js'
 import { settledTaskQueue } from './internal/settledQueue.js'
 import { ScopedFork } from './internal/scopedFork.js'
@@ -113,6 +114,7 @@ type HandleScopeEffect<E, Scope extends AnyScope> =
   E extends Finally<Scope, any> ? never
   : E extends ReturnFrom<Scope, any> ? never
   : E extends ScopedFork<Scope> ? never
+  : E extends ScopeExit<Scope> ? never
   : E
 
 type ScopedForkEffects<E, Scope extends AnyScope> =
@@ -214,6 +216,8 @@ class ScopeBoundary<E, A, Scope extends AnyScope> implements Fx<unknown, A>, Pip
           if (matchesScope && Finally.is(effect)) {
             controller.addFinalizer(effect.arg)
             ir = i.next(undefined)
+          } else if (matchesScope && ScopeExit.is(effect)) {
+            ir = i.next((exit: Exit<Scope>) => controller.requestExit(exit))
           } else if (matchesScope && ScopedFork.is(effect)) {
             const task = yield* controller.fork(effect.arg)
             ir = i.next(task)
@@ -353,7 +357,12 @@ class ScopeController<Scope extends AnyScope> {
       }
       if (initialExit.type === 'success' && !hasNonDaemonTask(pending, this.tasks)) break
 
-      const result = await settled.next()
+      const result = await Promise.race([
+        settled.next(),
+        this.exitRequested.promise.then(exit => ({ type: 'scope-exit', exit }) as const)
+      ])
+      if (result.type === 'scope-exit') break
+
       pending.delete(result.task)
       this.tasks.delete(result.task)
 

--- a/src/Time.ts
+++ b/src/Time.ts
@@ -4,6 +4,7 @@ import { Fx, ok } from './Fx.js'
 import { Handle, handle } from './Handler.js'
 import { dispose } from './internal/disposable.js'
 import { Clock, RealClock } from './internal/time.js'
+import { Schedule } from './internal/timeSchedule.js'
 
 export { VirtualClock } from './internal/time.js'
 
@@ -40,6 +41,7 @@ export const sleep = (ms: number) => new Sleep(ms)
 export const withClock = (c: Clock) => <E, A>(f: Fx<E, A>): Fx<Handle<Handle<E, Sleep, Async>, Now | Monotonic>, A> => f.pipe(
   handle(Now, () => ok(c.now())),
   handle(Monotonic, () => ok(c.monotonic())),
+  handle(Schedule, schedule => ok(c.schedule(schedule.arg.ms, schedule.arg.task))),
   handle(Sleep, sleep => assertPromise(signal => new Promise(resolve => {
     const d = c.schedule(sleep.arg, () => {
       signal.removeEventListener('abort', disposeOnAbort)

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { Fail, fail, returnFail } from './Fail.js'
-import { forkIn, withBoundedConcurrency, withUnboundedConcurrency } from './Concurrent.js'
+import { forkIn, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
 import { andFinallyExit } from './Finalization.js'
 import type { Fx } from './Fx.js'
@@ -61,6 +61,44 @@ describe('Timeout', () => {
 
     assert.ok(!Fail.is(r))
     assert.equal(r, 'fast')
+  })
+
+  it('interrupts long protected work under bounded concurrency', async () => {
+    const c = new VirtualClock(0)
+
+    const p = sleep(100).pipe(
+      timeout({ ms: 10 }),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withBoundedConcurrency(1),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await p
+
+    assert.ok(!Fail.is(r))
+    assert.ok(r instanceof TimeoutInterrupt)
+  })
+
+  it('interrupts long protected work under cooperative concurrency', async () => {
+    const c = new VirtualClock(0)
+
+    const p = sleep(100).pipe(
+      timeout({ ms: 10 }),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withCoopConcurrency({ concurrency: 1 }),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await p
+
+    assert.ok(!Fail.is(r))
+    assert.ok(r instanceof TimeoutInterrupt)
   })
 
   it('interrupts the scope with the timeout reason when the timeout wins', async () => {
@@ -258,6 +296,66 @@ describe('Timeout', () => {
     assert.equal(r, reason)
     assert.equal(completed, false)
     assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope, reason }])
+  })
+
+  it('timeoutIn interrupts scope-owned work occupying the only bounded concurrency permit', async () => {
+    const c = new VirtualClock(0)
+    const reason = { type: 'scope-timeout' }
+    const events = [] as string[]
+
+    const p = fx(function* () {
+      yield* timeoutIn(TestScope, { ms: 10, reason: () => reason })
+      yield* forkIn(TestScope, fx(function* () {
+        events.push('child:start')
+        yield* andFinallyExit(TestScope, exit => fx(function* () {
+          events.push(`child:finalize:${exit.type}`)
+        }))
+        yield* sleep(100)
+      }))
+    }).pipe(
+      withScope(TestScope),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withBoundedConcurrency(1),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await p
+
+    assert.equal(r, reason)
+    assert.deepEqual(events, ['child:start', 'child:finalize:interrupted'])
+  })
+
+  it('timeoutIn interrupts scope-owned work occupying the only cooperative concurrency permit', async () => {
+    const c = new VirtualClock(0)
+    const reason = { type: 'scope-timeout' }
+    const events = [] as string[]
+
+    const p = fx(function* () {
+      yield* timeoutIn(TestScope, { ms: 10, reason: () => reason })
+      yield* forkIn(TestScope, fx(function* () {
+        events.push('child:start')
+        yield* andFinallyExit(TestScope, exit => fx(function* () {
+          events.push(`child:finalize:${exit.type}`)
+        }))
+        yield* sleep(100)
+      }))
+    }).pipe(
+      withScope(TestScope),
+      control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
+      withCoopConcurrency({ concurrency: 1 }),
+      returnFail,
+      withClock(c),
+      runPromise
+    )
+
+    await c.step(10)
+    const r = await p
+
+    assert.equal(r, reason)
+    assert.deepEqual(events, ['child:start', 'child:finalize:interrupted'])
   })
 
   it('timeoutIn interrupts the owning scope while the parent body is parked', async () => {

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -1,17 +1,18 @@
-import { Async, assertPromise } from './Async.js'
+import { Async } from './Async.js'
 import { at } from './Breadcrumb.js'
 import { Fork, forkIn } from './Concurrent.js'
 import { Fail, catchAll, fail } from './Fail.js'
-import { Finally, andFinallyExit } from './Finalization.js'
+import { Finally, andFinally } from './Finalization.js'
 import { Fx, flatMap, fx, map, ok } from './Fx.js'
-import { withCapturedHandlers, type HandlerCapture } from './HandlerCapture.js'
-import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
+import { InterruptFrom } from './InterruptFrom.js'
 import { returnFrom } from './ReturnFrom.js'
 import { scope, scopeLabel, withScope, type AnyScope, type Exit } from './Scope.js'
-import { Sleep, sleep } from './Time.js'
+import { Sleep } from './Time.js'
 import type { TraceOrigin } from './Trace.js'
 import { attachTrace, captureTrace } from './Trace.js'
-import { ScopedFork } from './internal/scopedFork.js'
+import { dispose } from './internal/disposable.js'
+import { scopeExit } from './internal/scopeExit.js'
+import { schedule } from './internal/timeSchedule.js'
 
 /**
  * Run an Fx with a time limit, interrupting a private timeout scope when the
@@ -50,37 +51,40 @@ export function timeout<const Options extends AnyTimeoutOptions>(
 /**
  * Schedule a delayed interruption for a caller-owned scope.
  *
- * `timeoutIn` does not install a scope boundary and does not schedule the timer
- * by itself. The caller must handle the same scope with {@link withScope} and
- * place a fork scheduler outside that scope boundary. The timer fork is
- * scope-owned, but it is internal daemon work: it can interrupt the scope while
- * other scope-owned work keeps the scope alive, but it does not keep the scope
- * alive by itself.
+ * `timeoutIn` does not install a scope boundary. The caller must handle the same
+ * scope with {@link withScope}. The timer is scope-owned cleanup: it can
+ * interrupt the scope while other scope-owned work keeps the scope alive, but it
+ * does not keep the scope alive by itself.
  */
 export function timeoutIn<const Scope extends AnyScope, const Options extends AnyTimeoutOptions>(
   scope: Scope,
   options: Options
-): Fx<Sleep | InterruptFrom<Scope, TimeoutReasonOf<Options>> | Fork | Finally<Scope, Async> | ScopedFork<Scope> | HandlerCapture<'fx/Concurrent/ForkIn'>, void> {
+): Fx<Sleep | InterruptFrom<Scope, TimeoutReasonOf<Options>> | Finally<Scope>, void> {
   const origin = at(`Timeout interrupted ${options.label ?? scopeLabel(scope)} after ${options.ms}ms`, timeoutIn)
   const trace = captureTrace(origin, undefined, { kind: 'timeout' })
 
-  return timeoutInWithTrace(scope, options, { origin, trace })
+  return timeoutInWithTrace(scope, options, { origin, trace }) as Fx<Sleep | InterruptFrom<Scope, TimeoutReasonOf<Options>> | Finally<Scope>, void>
 }
 
 function timeoutInWithTrace<const Scope extends AnyScope, const Options extends AnyTimeoutOptions>(
   scope: Scope,
   options: Options,
   traceOrigin: TraceOrigin
-): Fx<Sleep | InterruptFrom<Scope, TimeoutReasonOf<Options>> | Fork | Finally<Scope, Async> | ScopedFork<Scope> | HandlerCapture<'fx/Concurrent/ForkIn'>, void> {
+): Fx<unknown, void> {
   const trace = traceOrigin.trace
   const reasonOrigin = traceOrigin.origin
   return fx(function* () {
-    const task = yield* withCapturedHandlers('fx/Concurrent/ForkIn', sleep(options.ms).pipe(
-      flatMap(() => interruptFrom(scope, makeTimeoutReason(options, { ms: options.ms, origin: reasonOrigin, trace })))
-    )).pipe(
-      flatMap(fx => new ScopedFork(scope, { fx, ...traceOrigin, daemon: true }))
-    )
-    yield* andFinallyExit(scope, exit => assertPromise(() => task.interrupt(exitReason(exit))))
+    const requestExit = yield* scopeExit(scope)
+    const timer = yield* schedule(options.ms, () => {
+      try {
+        requestExit(interruptedExit(scope, makeTimeoutReason(options, { ms: options.ms, origin: reasonOrigin, trace })))
+      } catch (error) {
+        requestExit({ type: 'failure', failure: new Fail(error) })
+      }
+    })
+    yield* andFinally(scope, fx(function* () {
+      dispose(timer)
+    }))
   })
 }
 
@@ -144,8 +148,13 @@ const makeTimeoutReason = <const Options extends AnyTimeoutOptions>(
     ? makeTimeoutInterrupt(expired) as TimeoutReasonOf<Options>
     : options.reason(expired) as TimeoutReasonOf<Options>
 
-const exitReason = (exit: Exit) =>
-  exit.type === 'interrupted' ? exit.reason : undefined
+const interruptedExit = <const Scope extends AnyScope>(
+  scope: Scope,
+  reason: unknown
+): Exit<Scope> =>
+  reason === undefined
+    ? { type: 'interrupted', scope }
+    : { type: 'interrupted', scope, reason }
 
 type AttemptResult<E, A> = Success<A> | Failure<E>
 

--- a/src/internal/scopeExit.ts
+++ b/src/internal/scopeExit.ts
@@ -1,0 +1,13 @@
+import { ScopedEffect } from '../Effect.js'
+import type { Fx } from '../Fx.js'
+import type { AnyScope, Exit } from '../Scope.js'
+
+export type ScopeExitRequest<Scope extends AnyScope> = (exit: Exit<Scope>) => void
+
+export class ScopeExit<const Scope extends AnyScope>
+  extends ScopedEffect('fx/internal/Scope/Exit')<Scope, void, ScopeExitRequest<Scope>> { }
+
+export const scopeExit = <const Scope extends AnyScope>(
+  scope: Scope
+): Fx<ScopeExit<Scope>, ScopeExitRequest<Scope>> =>
+  new ScopeExit(scope, undefined)

--- a/src/internal/timeSchedule.ts
+++ b/src/internal/timeSchedule.ts
@@ -1,0 +1,12 @@
+import { Effect } from '../Effect.js'
+import type { Fx } from '../Fx.js'
+
+export interface ScheduleContext {
+  readonly ms: number
+  readonly task: () => void
+}
+
+export class Schedule extends Effect('fx/internal/Time/Schedule')<ScheduleContext, Disposable> { }
+
+export const schedule = (ms: number, task: () => void): Fx<Schedule, Disposable> =>
+  new Schedule({ ms, task })


### PR DESCRIPTION
## Summary

- schedule timeout callbacks through the Time clock instead of daemon timer forks
- add an internal scoped exit handle so scheduled callbacks can request scope interruption
- wake scope joins when a scheduled scope exit is requested
- cover bounded and cooperative concurrency regressions for `timeout()` and `timeoutIn()`

## Why

`timeout()` previously used a daemon `forkIn` timer. Under `withBoundedConcurrency(1)`, long protected work could hold the only fork permit, leaving the internal timer fork queued so the timeout never scheduled.

## Validation

- `node --import tsx --test src/Timeout.test.ts`
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- `git diff --check`
