### PR TITLE
[codex] Normalize scope finalization names

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ import {
   runPromise
 } from "@briancavalier/fx"
 import { withUnboundedConcurrency } from "@briancavalier/fx/concurrent"
-import { andFinallyExit, InterruptFrom, scope, withScope } from "@briancavalier/fx/scope"
+import { andFinallyIn, InterruptFrom, scope, withScope } from "@briancavalier/fx/scope"
 import { defaultTime, sleep } from "@briancavalier/fx/time"
 import { timeout, timeoutIn } from "@briancavalier/fx/timeout"
 
 const RequestScope = scope("request")
 
 const loadUser = fx(function* () {
-  yield* andFinallyExit(RequestScope, exit =>
+  yield* andFinallyIn(RequestScope, exit =>
     consoleLog(`request cleanup after ${exit.type}`)
   )
 

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -7,7 +7,7 @@ import { assertPromise } from '../src/Async.js'
 import { all, firstSuccess, fork, forkIn, race, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
 import { fail, returnFail } from '../src/Fail.js'
-import { andFinally } from '../src/Finalization.js'
+import { andFinallyIn } from '../src/Finalization.js'
 import { fx, ok, runPromise } from '../src/Fx.js'
 import { handle } from '../src/Handler.js'
 import { scope, withScope } from '../src/Scope.js'
@@ -352,7 +352,7 @@ function cleanupFailureProgram() {
   const primary = new Error('primary')
   const release = new Error('release')
   const slow = fx(function* () {
-    yield* andFinally(CleanupScope, fail(release))
+    yield* andFinallyIn(CleanupScope, fail(release))
     yield* assertPromise<void>(signal => new Promise(resolve => {
       signal.addEventListener('abort', () => resolve(), { once: true })
     }))

--- a/benchmarks/runtime-loops.ts
+++ b/benchmarks/runtime-loops.ts
@@ -5,7 +5,7 @@ import { performance } from 'node:perf_hooks'
 import { assertPromise } from '../src/Async.js'
 import { all, withBoundedConcurrency, fork, race, withUnboundedConcurrency } from '../src/Concurrent.js'
 import { Effect } from '../src/Effect.js'
-import { andFinally } from '../src/Finalization.js'
+import { andFinallyIn } from '../src/Finalization.js'
 import { fx, ok, run, runPromise, runTask } from '../src/Fx.js'
 import { control, handle } from '../src/Handler.js'
 import { captureHandlers, closeHandlerCapture, mapCapturedHandlers, withHandlerContext } from '../src/HandlerCapture.js'
@@ -69,7 +69,7 @@ const allFanout16 = all(fanoutValues(16))
 const raceFanout16 = race(fanoutValues(16))
 const blocked = assertPromise<void>(() => new Promise(() => { }))
 const blockedWithFinalizer = fx(function* () {
-  yield* andFinally(InterruptScope, ok(undefined))
+  yield* andFinallyIn(InterruptScope, ok(undefined))
   return yield* blocked
 }).pipe(withScope(InterruptScope))
 
@@ -367,7 +367,7 @@ function applyScopes(f: Fx<unknown, unknown>, depth: number) {
 function finalizerProgram(count: number) {
   return fx(function* () {
     for (let i = 0; i < count; i++) {
-      yield* andFinally(ScopeFinalizer, ok(undefined))
+      yield* andFinallyIn(ScopeFinalizer, ok(undefined))
     }
   })
 }

--- a/docs/recipes/manage-resources-and-finalizers.md
+++ b/docs/recipes/manage-resources-and-finalizers.md
@@ -5,9 +5,9 @@ exits.
 
 ```ts
 import { fx, runPromise } from "@briancavalier/fx"
-import { managed, scope, usingManaged } from "@briancavalier/fx/scope"
+import { managed, scope, usingManagedIn, withScope } from "@briancavalier/fx/scope"
 
-const RequestScope = "app/Request" as const
+const RequestScope = scope("app/Request")
 
 const openConnection = fx(function* () {
   return managed(
@@ -17,16 +17,17 @@ const openConnection = fx(function* () {
 })
 
 const program = fx(function* () {
-  const connection = yield* usingManaged(RequestScope, openConnection)
+  const connection = yield* usingManagedIn(RequestScope, openConnection)
   return yield* query(connection)
 }).pipe(
-  scope(RequestScope)
+  withScope(RequestScope)
 )
 ```
 
-Use `using` or `usingManaged` to acquire and register cleanup in a small
-uninterruptible region. `using` finalizers receive the acquired value and the
-scope exit, and may ignore the exit when cleanup does not depend on it.
+Use `usingIn` or `usingManagedIn` to acquire and register cleanup in a named
+scope in a small uninterruptible region. Use `using` or `usingManaged` for the
+current scope. `usingIn` finalizers receive the acquired value and the scope
+exit, and may ignore the exit when cleanup does not depend on it.
 
 Handler pipeline:
 

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -1,7 +1,7 @@
 import { all, firstSuccess, mapAll, type Fork } from '@briancavalier/fx/concurrent'
 import { Async, Effect, fail, type Fail, fx, type Fx, handle, type Interrupt, ok } from '@briancavalier/fx'
 
-import { managed, scope, using, usingManaged, type Finally, type Managed } from '@briancavalier/fx/scope'
+import { managed, scope, usingIn, usingManagedIn, type Finally, type Managed } from '@briancavalier/fx/scope'
 
 import { info, type Log } from '@briancavalier/fx/log'
 import { sleep, type Time } from '@briancavalier/fx/time'
@@ -124,7 +124,7 @@ export const fetchRuntimeStatus = (source: string) => new FetchRuntimeStatus(sou
 export const collectIncidentSnapshot = (
   request: SnapshotRequest
 ): Fx<IncidentCollectorEffects | Interrupt, SnapshotSummary> => fx(function* () {
-  const bundle = yield* usingManaged(BundleScope, openBundle(request.incidentId))
+  const bundle = yield* usingManagedIn(BundleScope, openBundle(request.incidentId))
   yield* info('snapshot started', { incidentId: request.incidentId, bundle: bundle.id })
 
   const [logs, _metrics, deploy, runtime] = yield* all([
@@ -303,8 +303,8 @@ const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function*
 }))
 
 const withCollector = <E, A>(collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<typeof CollectorScope, Log> | Interrupt, A> => fx(function* () {
-  const name = yield* usingManaged(CollectorScope, startCollector(collector))
-  yield* using(
+  const name = yield* usingManagedIn(CollectorScope, startCollector(collector))
+  yield* usingIn(
     CollectorScope,
     ok(name),
     (name, exit) => info('collector finalized', { name, exit: exit.type })

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -1,7 +1,7 @@
 import { mapAll, type Fork } from '@briancavalier/fx/concurrent'
 import { Async, Effect, fail, type Fail, fx, type Fx, type Interrupt } from '@briancavalier/fx'
 
-import { scope, type Finally, type Managed, usingManaged, type YieldFrom, type Yielding } from '@briancavalier/fx/scope'
+import { scope, type Finally, type Managed, usingManagedIn, type YieldFrom, type Yielding } from '@briancavalier/fx/scope'
 import { info, type Log } from '@briancavalier/fx/log'
 
 import { type Time } from '@briancavalier/fx/time'
@@ -100,7 +100,7 @@ export const startAgentSession = (task: string) => new StartAgentSession(task)
 export const runAgent = (
   task: string
 ): Fx<ToolAgentEffects, AgentAnswer> => fx(function* () {
-  const session = yield* usingManaged(AgentSessionScope, startAgentSession(task))
+  const session = yield* usingManagedIn(AgentSessionScope, startAgentSession(task))
   yield* info('agent session started', { session: session.id, task })
 
   const plan = yield* askModel({ type: 'plan', task })

--- a/examples/intermediate/interrupt-safe-finalization.ts
+++ b/examples/intermediate/interrupt-safe-finalization.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { race, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
-import { scope, withScope, using } from '@briancavalier/fx/scope'
+import { scope, withScope, usingIn } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 
@@ -12,7 +12,7 @@ import { defaultTime, sleep } from '@briancavalier/fx/time'
  * `race` interrupts the losing database branch and waits for its
  * scoped async finalizer before the program logs the result.
  *
- * The example shows exit-aware cleanup with `using`, named finalization
+ * The example shows exit-aware cleanup with `usingIn`, named finalization
  * with `scope`, and structured race cancellation.
  */
 
@@ -31,7 +31,7 @@ const fetchFromCache = fx(function* () {
 })
 
 const fetchFromDatabase = fx(function* () {
-  const connection = yield* using(
+  const connection = yield* usingIn(
     RequestScope,
     openConnection,
     (_, exit) => fx(function* () {

--- a/examples/intermediate/read-csv.ts
+++ b/examples/intermediate/read-csv.ts
@@ -1,6 +1,6 @@
 import { assert as assertNoFail, type Console, consoleLog, defaultConsole, fx, type Fx, handleScoped, run } from '@briancavalier/fx'
 
-import { managed, returnFrom, scope, withScope, usingManaged, yieldFrom, YieldFrom, type Control, type Yielding } from '@briancavalier/fx/scope'
+import { managed, returnFrom, scope, withScope, usingManagedIn, yieldFrom, YieldFrom, type Control, type Yielding } from '@briancavalier/fx/scope'
 
 const ImportCsv = scope<Control>()('examples/intermediate/ImportCsv')
 
@@ -93,7 +93,7 @@ const importRows = (file: CsvFile) => fx(function* () {
 })
 
 const importCsv = (path: string, text: string): Fx<Console, ImportResult> => fx(function* () {
-  const file = yield* usingManaged(ImportCsv, openCsv(path, text))
+  const file = yield* usingManagedIn(ImportCsv, openCsv(path, text))
   const count = yield* importRows(file)
 
   return { type: 'imported', count } satisfies ImportResult

--- a/examples/intermediate/restart-on-abort.ts
+++ b/examples/intermediate/restart-on-abort.ts
@@ -1,4 +1,4 @@
-import { abort, managed, orReturn, restartOnAbort, scope, usingManaged, type Control } from '@briancavalier/fx/scope'
+import { abort, managed, orReturn, restartOnAbort, scope, usingManagedIn, type Control } from '@briancavalier/fx/scope'
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, run } from '@briancavalier/fx'
 
 const SubmitOrder = scope<Control>()('examples/intermediate/restart-on-abort/SubmitOrder')
@@ -52,7 +52,7 @@ const submitToGateway = (session: OrderSession) => fx(function* () {
 })
 
 const submitOrder = fx(function* () {
-  const session = yield* usingManaged(SubmitOrder, openOrderSession())
+  const session = yield* usingManagedIn(SubmitOrder, openOrderSession())
   return yield* submitToGateway(session)
 }).pipe(
   restartOnAbort(SubmitOrder, { restarts: 1 }),

--- a/examples/intermediate/scope-owned-forks.ts
+++ b/examples/intermediate/scope-owned-forks.ts
@@ -1,6 +1,6 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { forkIn, withBoundedConcurrency } from '@briancavalier/fx/concurrent'
-import { andFinallyExit, currentScope, recoverInterrupt, scope, withScope } from '@briancavalier/fx/scope'
+import { andFinally, currentScope, recoverInterrupt, scope, withScope } from '@briancavalier/fx/scope'
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { timeoutIn } from '@briancavalier/fx/timeout'
 
@@ -9,7 +9,7 @@ const RequestScope = scope('examples/intermediate/scope-owned-forks', {
 })
 
 const child = (name: string, ms: number) => fx(function* () {
-  yield* andFinallyExit(currentScope, exit =>
+  yield* andFinally(exit =>
     consoleLog(`${name}: cleanup after ${exit.type}`)
   )
 

--- a/examples/intermediate/uninterruptible-mask.ts
+++ b/examples/intermediate/uninterruptible-mask.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, control, defaultConsole, fx, runPromise, uninterruptibleMask } from '@briancavalier/fx'
 import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
-import { andFinallyExit, InterruptFrom, scope, withScope } from '@briancavalier/fx/scope'
+import { andFinallyIn, InterruptFrom, scope, withScope } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { timeout } from '@briancavalier/fx/timeout'
@@ -32,7 +32,7 @@ const useResource = (resource: string) => fx(function* () {
 
 const slow = uninterruptibleMask(restore => fx(function* () {
   const resource = yield* acquireResource
-  yield* andFinallyExit(ExampleScope, exit => fx(function* () {
+  yield* andFinallyIn(ExampleScope, exit => fx(function* () {
     const reason = exit.type === 'interrupted' && exit.reason instanceof Error
       ? ` (${exit.reason.message})`
       : ''

--- a/examples/package-import-inference.test.ts
+++ b/examples/package-import-inference.test.ts
@@ -17,7 +17,7 @@ import {
   withCoopConcurrency,
   withUnboundedConcurrency
 } from '@briancavalier/fx/concurrent'
-import { sameScope, scope, scopeId, scopeLabel, withScope, type AnyScope } from '@briancavalier/fx/scope'
+import { andFinally, andFinallyIn, sameScope, scope, scopeId, scopeLabel, using, usingIn, usingManaged, usingManagedIn, withScope, type AnyScope } from '@briancavalier/fx/scope'
 import { TimeoutInterrupt, timeout, timeoutIn } from '@briancavalier/fx/timeout'
 
 type EffectOf<T> = T extends Fx<infer E, unknown> ? E : never
@@ -43,6 +43,12 @@ describe('package import inference', () => {
     assert.equal(typeof scopeLabel, 'function')
     assert.equal(typeof sameScope, 'function')
     assert.equal(typeof withScope, 'function')
+    assert.equal(typeof andFinally, 'function')
+    assert.equal(typeof andFinallyIn, 'function')
+    assert.equal(typeof using, 'function')
+    assert.equal(typeof usingIn, 'function')
+    assert.equal(typeof usingManaged, 'function')
+    assert.equal(typeof usingManagedIn, 'function')
 
     assert.equal(typeof timeout, 'function')
     assert.equal(typeof timeoutIn, 'function')

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -4,7 +4,7 @@ import { abort, Abort, orReturn, restartOnAbort } from './Abort.js'
 import { at } from './Breadcrumb.js'
 import { originOf, withOrigin } from './Effect.js'
 import { fail, Fail, returnFail } from './Fail.js'
-import { andFinally } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import { fx, ok, run, type Fx } from './Fx.js'
 import { returnFrom } from './ReturnFrom.js'
 import { scope, withScope, type Control } from './Scope.js'
@@ -98,7 +98,7 @@ describe('Abort', () => {
       const result = fx(function* () {
         attempts += 1
         const attempt = attempts
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push(`release:${attempt}`)
         }))
 
@@ -180,7 +180,7 @@ describe('Abort', () => {
 
       const result = fx(function* () {
         attempts += 1
-        yield* andFinally(TestScope, fail(cleanupFailure))
+        yield* andFinallyIn(TestScope, fail(cleanupFailure))
         yield* abort(TestScope)
       }).pipe(
         restartOnAbort(TestScope, { restarts: 2 }),

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -4,7 +4,7 @@ import { assertPromise, type Async } from './Async.js'
 import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { RaceAllFailed, all, withBoundedConcurrency, withCoopConcurrency, firstSuccess, fork, forkEach, forkIn, mapAll, race, withUnboundedConcurrency } from './Concurrent.js'
-import { andFinally, andFinallyExit } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import { bracket, flatMap, fx, ok, runPromise, runTask, type Fx } from './Fx.js'
 import { handle } from './Handler.js'
 import { type HandlerCapture } from './HandlerCapture.js'
@@ -461,7 +461,7 @@ describe('Fork', () => {
       const cause = new Error('all scope failed')
 
       const result = await all([fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push('child')
         }))
         yield* fail(cause)
@@ -483,7 +483,7 @@ describe('Fork', () => {
       const cause = new Error('all failed')
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push('slow')
         }))
         yield* awaitAbort()
@@ -511,7 +511,7 @@ describe('Fork', () => {
       const releaseFailure = new Error('release failed')
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* andFinallyIn(TestScope, fail(releaseFailure))
         yield* awaitAbort()
       })
       const bad = fx(function* () {
@@ -541,7 +541,7 @@ describe('Fork', () => {
       const secondReleaseFailure = new Error('second release failed')
 
       const slow = (releaseFailure: Error) => fx(function* () {
-        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* andFinallyIn(TestScope, fail(releaseFailure))
         yield* awaitAbort()
       })
       const bad = fx(function* () {
@@ -978,7 +978,7 @@ describe('Fork', () => {
       const cause = new Error('cooperative all failed')
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push('slow')
         }))
         yield* awaitAbort()
@@ -1005,7 +1005,7 @@ describe('Fork', () => {
       const events = [] as string[]
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           events.push('cleanup before')
           yield* all([fx(function* () {
             events.push('cleanup all child')
@@ -1039,7 +1039,7 @@ describe('Fork', () => {
       const events = [] as string[]
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           events.push('cleanup before')
           const task = yield* fork(fx(function* () {
             events.push('cleanup fork child')
@@ -1075,7 +1075,7 @@ describe('Fork', () => {
       const events = [] as string[]
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           events.push('cleanup before')
           const task = yield* fork(new CurrentValue())
           events.push(yield* wait(task))
@@ -1296,7 +1296,7 @@ describe('Fork', () => {
 
       const task = taskOrThrow(await fx(function* () {
         return yield* fork(fx(function* () {
-          yield* andFinallyExit(TestScope, exit => fx(function* () {
+          yield* andFinallyIn(TestScope, exit => fx(function* () {
             exits.push(exit)
           }))
           yield* awaitAbort()
@@ -1434,7 +1434,7 @@ describe('Fork', () => {
       let releaseMasked!: () => void
 
       const masked = uninterruptible(fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           events.push('released')
         }))
         events.push('masked start')
@@ -1807,7 +1807,7 @@ describe('Fork', () => {
       let releaseMasked!: () => void
 
       const masked = uninterruptible(fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           events.push('released')
         }))
         events.push('masked start')
@@ -1909,7 +1909,7 @@ describe('Fork', () => {
       const released = [] as string[]
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push('slow')
         }))
         yield* awaitAbort()
@@ -1931,7 +1931,7 @@ describe('Fork', () => {
       const releaseFailure = new Error('release failed')
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* andFinallyIn(TestScope, fail(releaseFailure))
         yield* awaitAbort()
       })
 
@@ -2015,7 +2015,7 @@ describe('Fork', () => {
       const releaseFailure = new Error('release failed')
 
       const slow = fx(function* () {
-        yield* andFinally(TestScope, fail(releaseFailure))
+        yield* andFinallyIn(TestScope, fail(releaseFailure))
         yield* awaitAbort()
       })
 
@@ -2102,7 +2102,7 @@ describe('Scope-owned fork lifetime', () => {
     const exits = [] as Exit[]
 
     const child = () => fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* awaitAbort()
@@ -2140,7 +2140,7 @@ describe('Scope-owned fork lifetime', () => {
       }))
 
       yield* forkIn(RaceScope, fx(function* () {
-        yield* andFinallyExit(RaceScope, exit => fx(function* () {
+        yield* andFinallyIn(RaceScope, exit => fx(function* () {
           events.push(exit.type)
         }))
         yield* awaitAbort()
@@ -2171,7 +2171,7 @@ describe('Scope-owned fork lifetime', () => {
       }))
 
       yield* fx(function* () {
-        yield* andFinally(InnerScope, fx(function* () {
+        yield* andFinallyIn(InnerScope, fx(function* () {
           events.push('inner cleanup')
         }))
         yield* awaitAbort()
@@ -2204,7 +2204,7 @@ describe('Scope-owned fork lifetime', () => {
       }))
 
       yield* forkIn(TestScope, fx(function* () {
-        yield* andFinallyExit(TestScope, exit => fx(function* () {
+        yield* andFinallyIn(TestScope, exit => fx(function* () {
           exits.push(exit)
         }))
         yield* awaitAbort()
@@ -2236,7 +2236,7 @@ describe('Scope-owned fork lifetime', () => {
       }))
 
       yield* forkIn(TestScope, fx(function* () {
-        yield* andFinallyExit(TestScope, exit => fx(function* () {
+        yield* andFinallyIn(TestScope, exit => fx(function* () {
           exits.push(exit.type)
         }))
         yield* awaitAbort()
@@ -2291,7 +2291,7 @@ describe('Scope-owned fork lifetime', () => {
       }))
 
       yield* forkIn(TestScope, fx(function* () {
-        yield* andFinally(TestScope, fail(cleanup))
+        yield* andFinallyIn(TestScope, fail(cleanup))
         yield* awaitAbort()
       }))
 
@@ -2417,7 +2417,7 @@ describe('Scope-owned fork lifetime', () => {
     const program = fx(function* () {
       const task = yield* forkIn(TestScope, fx(function* () {
         started()
-        yield* andFinallyExit(TestScope, exit => fx(function* () {
+        yield* andFinallyIn(TestScope, exit => fx(function* () {
           events.push(`finalize ${exit.type}`)
         }))
         yield* awaitAbort()
@@ -2464,7 +2464,7 @@ describe('Scope-owned fork lifetime', () => {
 
     const child = (label: string) => fx(function* () {
       events.push(`start ${label}`)
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         events.push(`finalize ${label} ${exit.type}`)
       }))
       yield* awaitAbort()
@@ -2513,7 +2513,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push('task')
         }))
         yield* awaitAbort()
@@ -2536,7 +2536,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           released.push('task')
         }))
         yield* awaitAbort()
@@ -2560,7 +2560,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinallyExit(TestScope, exit => fx(function* () {
+        yield* andFinallyIn(TestScope, exit => fx(function* () {
           exits.push(exit)
         }))
         yield* awaitAbort()
@@ -2610,7 +2610,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           yield* asyncValue(undefined)
           released.push('task')
         }))
@@ -2661,7 +2661,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinally(TestScope, fx(function* () {
+        yield* andFinallyIn(TestScope, fx(function* () {
           yield* asyncValue(undefined)
           released.push('scope')
         }))
@@ -2691,7 +2691,7 @@ describe('Task interruption finalization', () => {
     const releaseFailure = new Error('async release failed')
 
     const slow = fx(function* () {
-      yield* andFinally(TestScope, assertPromise(() => Promise.reject(releaseFailure)))
+      yield* andFinallyIn(TestScope, assertPromise(() => Promise.reject(releaseFailure)))
       yield* awaitAbort()
     })
 
@@ -2715,7 +2715,7 @@ describe('Task interruption finalization', () => {
     const innerFailure = new Error('inner release failed')
 
     const slow = fx(function* () {
-      yield* andFinally(TestScope, fail(scopeFailure))
+      yield* andFinallyIn(TestScope, fail(scopeFailure))
       yield* bracket(
         ok(undefined),
         () => fail(innerFailure),
@@ -2754,7 +2754,7 @@ describe('Task interruption finalization', () => {
     })
 
     const slow = fx(function* () {
-      yield* andFinally(TestScope, fail(scopeFailure))
+      yield* andFinallyIn(TestScope, fail(scopeFailure))
       yield* throwsOnReturn()
     })
 
@@ -2775,7 +2775,7 @@ describe('Task interruption finalization', () => {
     const TestScope = scope('test/Fork/InterruptedCleanupTypeError')
 
     const slow = fx(function* () {
-      yield* andFinally(TestScope, fx(function* () {
+      yield* andFinallyIn(TestScope, fx(function* () {
         const value = undefined as any
         return value.property
       }))
@@ -2804,7 +2804,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinally(TestScope, new Release())
+        yield* andFinallyIn(TestScope, new Release())
         yield* awaitAbort()
       }))
     }).pipe(
@@ -2829,7 +2829,7 @@ describe('Task interruption finalization', () => {
 
     const task = taskOrThrow(await fx(function* () {
       return yield* fork(fx(function* () {
-        yield* andFinally(TestScope, new Release())
+        yield* andFinallyIn(TestScope, new Release())
         yield* awaitAbort()
       }))
     }).pipe(

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -4,10 +4,10 @@ import { describe, it } from 'node:test'
 import { abort, Abort, orReturn } from './Abort.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { fx, ok, run, type Fx } from './Fx.js'
-import { andFinally, andFinallyExit, managed, using, usingManaged, type Finally, type Managed } from './Finalization.js'
+import { andFinally, andFinallyIn, managed, using, usingIn, usingManaged, usingManagedIn, type Finally, type Managed } from './Finalization.js'
 import type { Interrupt } from './Interrupt.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control, type Exit } from './Scope.js'
+import { currentScope, scope, withScope, type Control, type Exit } from './Scope.js'
 import { collectFrom, YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 describe('Finalization', () => {
@@ -16,21 +16,32 @@ describe('Finalization', () => {
 
   it('preserves finalizer effects in constructor types', () => {
     const releaseFailure = new Error('release failed')
-    const finalizer = andFinally(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
-    const exitFinalizer = andFinallyExit(TestScope, () => fail(releaseFailure))
+    const finalizer = andFinallyIn(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
+    const exitFinalizer = andFinallyIn(TestScope, () => fail(releaseFailure))
+    const currentFinalizer = andFinally(yieldFrom(CleanupEvents, 'cleanup'))
+    const currentExitFinalizer = andFinally(() => fail(releaseFailure))
 
     const _: typeof finalizer extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>>, void> ? true : false = true
     const __: typeof exitFinalizer extends Fx<Finally<typeof TestScope, Fail<Error>>, void> ? true : false = true
+    const ___: typeof currentFinalizer extends Fx<Finally<typeof currentScope, YieldFrom<typeof CleanupEvents>>, void> ? true : false = true
+    const ____: typeof currentExitFinalizer extends Fx<Finally<typeof currentScope, Fail<Error>>, void> ? true : false = true
 
     assert.equal(typeof _, 'boolean')
     assert.equal(typeof __, 'boolean')
+    assert.equal(typeof ___, 'boolean')
+    assert.equal(typeof ____, 'boolean')
   })
 
   it('preserves finalizer effects in resource helper types', () => {
     const releaseFailure = new Error('release failed')
-    const resource = using(TestScope, ok('resource'), () => yieldFrom(CleanupEvents, 'cleanup'))
-    const exitResource = using(TestScope, ok('resource'), () => fail(releaseFailure))
-    const managedResource = usingManaged(TestScope, ok(managed(
+    const resource = usingIn(TestScope, ok('resource'), () => yieldFrom(CleanupEvents, 'cleanup'))
+    const exitResource = usingIn(TestScope, ok('resource'), () => fail(releaseFailure))
+    const managedResource = usingManagedIn(TestScope, ok(managed(
+      'resource',
+      () => yieldFrom(CleanupEvents, 'cleanup')
+    )))
+    const currentResource = using(ok('resource'), () => yieldFrom(CleanupEvents, 'cleanup'))
+    const currentManagedResource = usingManaged(ok(managed(
       'resource',
       () => yieldFrom(CleanupEvents, 'cleanup')
     )))
@@ -38,15 +49,35 @@ describe('Finalization', () => {
     const _: typeof resource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
     const __: typeof exitResource extends Fx<Finally<typeof TestScope, Fail<Error>> | Interrupt, 'resource'> ? true : false = true
     const ___: typeof managedResource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
+    const ____: typeof currentResource extends Fx<Finally<typeof currentScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
+    const _____: typeof currentManagedResource extends Fx<Finally<typeof currentScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
 
     assert.equal(typeof _, 'boolean')
     assert.equal(typeof __, 'boolean')
     assert.equal(typeof ___, 'boolean')
+    assert.equal(typeof ____, 'boolean')
+    assert.equal(typeof _____, 'boolean')
+  })
+
+  it('eliminates current-scope resource helpers at a scope boundary', () => {
+    const scoped = fx(function* () {
+      yield* andFinally(yieldFrom(CleanupEvents, 'cleanup'))
+      const resource = yield* using(ok('resource' as const), () => yieldFrom(CleanupEvents, 'cleanup'))
+      const managedResource = yield* usingManaged(ok(managed(
+        'managed' as const,
+        () => yieldFrom(CleanupEvents, 'cleanup')
+      )))
+      return [resource, managedResource] as const
+    }).pipe(withScope(TestScope))
+
+    const _: typeof scoped extends Fx<YieldFrom<typeof CleanupEvents> | Fail<AggregateError> | Interrupt, readonly ['resource', 'managed']> ? true : false = true
+
+    assert.equal(typeof _, 'boolean')
   })
 
   it('exposes non-failure finalizer effects after scope', () => {
     const scoped = fx(function* () {
-      yield* andFinally(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
+      yield* andFinallyIn(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
       return 'done'
     }).pipe(withScope(TestScope))
 
@@ -64,7 +95,7 @@ describe('Finalization', () => {
   it('exposes cleanup failures as AggregateError after scope', () => {
     const releaseFailure = new Error('release failed')
     const scoped = fx(function* () {
-      yield* andFinally(TestScope, fail(releaseFailure))
+      yield* andFinallyIn(TestScope, fail(releaseFailure))
       return 'done'
     }).pipe(withScope(TestScope))
 
@@ -81,7 +112,7 @@ describe('Finalization', () => {
   it('leaves finalizers from a different scope visible after scope', () => {
     const OtherScope = scope<Control>()('test/Finalization/other')
     const scoped = fx(function* () {
-      yield* andFinally(OtherScope, yieldFrom(CleanupEvents, 'cleanup'))
+      yield* andFinallyIn(OtherScope, yieldFrom(CleanupEvents, 'cleanup'))
       return 'done'
     }).pipe(withScope(TestScope))
 
@@ -97,9 +128,9 @@ describe('Finalization', () => {
     const released = [] as string[]
 
     const result = run(fx(function* () {
-      yield* andFinally(TestScope, record(released, 'A'))
-      yield* andFinally(TestScope, record(released, 'B'))
-      yield* andFinally(TestScope, record(released, 'C'))
+      yield* andFinallyIn(TestScope, record(released, 'A'))
+      yield* andFinallyIn(TestScope, record(released, 'B'))
+      yield* andFinallyIn(TestScope, record(released, 'C'))
       return 'done'
     }).pipe(withScope(TestScope), returnFail))
 
@@ -112,9 +143,9 @@ describe('Finalization', () => {
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* andFinally(TestScope, record(released, 'A'))
-      yield* andFinally(TestScope, record(released, 'B'))
-      yield* andFinally(TestScope, record(released, 'C'))
+      yield* andFinallyIn(TestScope, record(released, 'A'))
+      yield* andFinallyIn(TestScope, record(released, 'B'))
+      yield* andFinallyIn(TestScope, record(released, 'C'))
       yield* fail(programFailure)
     }).pipe(withScope(TestScope), returnFail))
 
@@ -129,9 +160,9 @@ describe('Finalization', () => {
     const cFailure = new Error('C release failed')
 
     const result = run(fx(function* () {
-      yield* andFinally(TestScope, record(released, 'A', aFailure))
-      yield* andFinally(TestScope, record(released, 'B'))
-      yield* andFinally(TestScope, record(released, 'C', cFailure))
+      yield* andFinallyIn(TestScope, record(released, 'A', aFailure))
+      yield* andFinallyIn(TestScope, record(released, 'B'))
+      yield* andFinallyIn(TestScope, record(released, 'C', cFailure))
       return 'done'
     }).pipe(withScope(TestScope), returnFail))
 
@@ -148,9 +179,9 @@ describe('Finalization', () => {
     const cFailure = new Error('C release failed')
 
     const result = run(fx(function* () {
-      yield* andFinally(TestScope, record(released, 'A', aFailure))
-      yield* andFinally(TestScope, record(released, 'B'))
-      yield* andFinally(TestScope, record(released, 'C', cFailure))
+      yield* andFinallyIn(TestScope, record(released, 'A', aFailure))
+      yield* andFinallyIn(TestScope, record(released, 'B'))
+      yield* andFinallyIn(TestScope, record(released, 'C', cFailure))
       yield* fail(programFailure)
     }).pipe(withScope(TestScope), returnFail))
 
@@ -164,7 +195,7 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
 
     const result = run(fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       return 'done'
@@ -179,7 +210,7 @@ describe('Finalization', () => {
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* fail(programFailure)
@@ -198,11 +229,11 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
 
     const result = run(fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         released.push('A')
         exits.push(exit)
       }))
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         released.push('B')
         exits.push(exit)
       }))
@@ -216,11 +247,11 @@ describe('Finalization', () => {
     assert.deepEqual(exits[0], { type: 'success', value: 'done' })
   })
 
-  it('using returns the initialized value and registers cleanup', () => {
+  it('usingIn returns the initialized value and registers cleanup', () => {
     const released = [] as string[]
 
     const result = run(fx(function* () {
-      return yield* using(TestScope, ok('resource'),
+      return yield* usingIn(TestScope, ok('resource'),
         resource => record(released, resource)
       )
     }).pipe(withScope(TestScope), returnFail))
@@ -229,12 +260,12 @@ describe('Finalization', () => {
     assert.deepEqual(released, ['resource'])
   })
 
-  it('using does not register cleanup when initialization fails', () => {
+  it('usingIn does not register cleanup when initialization fails', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
 
     const result = run(fx(function* () {
-      return yield* using(TestScope, fail(initFailure),
+      return yield* usingIn(TestScope, fail(initFailure),
         resource => record(released, String(resource))
       )
     }).pipe(withScope(TestScope), returnFail))
@@ -244,12 +275,12 @@ describe('Finalization', () => {
     assert.deepEqual(released, [])
   })
 
-  it('using runs cleanup when later work fails', () => {
+  it('usingIn runs cleanup when later work fails', () => {
     const released = [] as string[]
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* using(TestScope,
+      yield* usingIn(TestScope,
         ok('resource'),
         resource => record(released, resource)
       )
@@ -261,11 +292,11 @@ describe('Finalization', () => {
     assert.deepEqual(released, ['resource'])
   })
 
-  it('using delays finalizer construction until scope exit', () => {
+  it('usingIn delays finalizer construction until scope exit', () => {
     const events = [] as string[]
 
     const result = run(fx(function* () {
-      const resource = yield* using(TestScope, ok('resource'),
+      const resource = yield* usingIn(TestScope, ok('resource'),
         resource => {
           events.push(`release ${resource}`)
           return record(events, 'cleanup')
@@ -279,12 +310,12 @@ describe('Finalization', () => {
     assert.deepEqual(events, ['use resource', 'release resource', 'cleanup'])
   })
 
-  it('using provides the resource and success exit', () => {
+  it('usingIn provides the resource and success exit', () => {
     const released = [] as string[]
     const exits = [] as Exit[]
 
     const result = run(fx(function* () {
-      return yield* using(TestScope, ok('resource'),
+      return yield* usingIn(TestScope, ok('resource'),
         (resource, exit) => fx(function* () {
           released.push(resource)
           exits.push(exit)
@@ -297,13 +328,13 @@ describe('Finalization', () => {
     assert.deepEqual(exits, [{ type: 'success', value: 'resource' }])
   })
 
-  it('using provides the resource and failure exit', () => {
+  it('usingIn provides the resource and failure exit', () => {
     const released = [] as string[]
     const exits = [] as Exit[]
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* using(TestScope,
+      yield* usingIn(TestScope,
         ok('resource'),
         (resource, exit) => fx(function* () {
           released.push(resource)
@@ -322,12 +353,12 @@ describe('Finalization', () => {
     if (exit.type === 'failure') assert.equal(exit.failure.arg, programFailure)
   })
 
-  it('using release failure participates in cleanup aggregation', () => {
+  it('usingIn release failure participates in cleanup aggregation', () => {
     const programFailure = new Error('program failed')
     const releaseFailure = new Error('release failed')
 
     const result = run(fx(function* () {
-      yield* using(TestScope,
+      yield* usingIn(TestScope,
         ok('resource'),
         () => fail(releaseFailure)
       )
@@ -350,11 +381,11 @@ describe('Finalization', () => {
     assert.deepEqual(exits, ['success'])
   })
 
-  it('usingManaged returns the managed value and registers its finalizer', () => {
+  it('usingManagedIn returns the managed value and registers its finalizer', () => {
     const released = [] as string[]
 
     const result = run(fx(function* () {
-      return yield* usingManaged(TestScope, ok(managed(
+      return yield* usingManagedIn(TestScope, ok(managed(
         'resource',
         () => record(released, 'resource')
       )))
@@ -364,12 +395,12 @@ describe('Finalization', () => {
     assert.deepEqual(released, ['resource'])
   })
 
-  it('usingManaged does not register cleanup when initialization fails', () => {
+  it('usingManagedIn does not register cleanup when initialization fails', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
 
     const result = run(fx(function* () {
-      return yield* usingManaged(TestScope, fail(initFailure) as Fx<Fail<Error>, Managed<string>>)
+      return yield* usingManagedIn(TestScope, fail(initFailure) as Fx<Fail<Error>, Managed<string>>)
     }).pipe(withScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
@@ -377,12 +408,12 @@ describe('Finalization', () => {
     assert.deepEqual(released, [])
   })
 
-  it('usingManaged finalizer receives the scope exit', () => {
+  it('usingManagedIn finalizer receives the scope exit', () => {
     const exits = [] as Exit[]
     const programFailure = new Error('program failed')
 
     const result = run(fx(function* () {
-      yield* usingManaged(TestScope, ok(managed(
+      yield* usingManagedIn(TestScope, ok(managed(
         'resource',
         exit => fx(function* () {
           exits.push(exit)
@@ -403,8 +434,8 @@ describe('Finalization', () => {
     const released = [] as string[]
 
     const result = run(fx(function* () {
-      yield* andFinally(TestScope, record(released, 'A'))
-      yield* andFinally(TestScope, record(released, 'B'))
+      yield* andFinallyIn(TestScope, record(released, 'A'))
+      yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* returnFrom(TestScope, 'returned')
     }).pipe(withScope(TestScope), returnFail))
 
@@ -416,7 +447,7 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
 
     const result = run(fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* returnFrom(TestScope, 'returned')
@@ -434,8 +465,8 @@ describe('Finalization', () => {
     const released = [] as string[]
 
     const result = run(fx(function* () {
-      yield* andFinally(TestScope, record(released, 'A'))
-      yield* andFinally(TestScope, record(released, 'B'))
+      yield* andFinallyIn(TestScope, record(released, 'A'))
+      yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* abort(TestScope)
     }).pipe(withScope(TestScope), orReturn(TestScope, 'aborted'), returnFail))
 
@@ -447,7 +478,7 @@ describe('Finalization', () => {
     const exits = [] as Exit[]
 
     const f = fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* abort(TestScope)
@@ -464,7 +495,7 @@ describe('Finalization', () => {
     const released = [] as string[]
 
     const f = fx(function* () {
-      yield* andFinally(OtherScope, record(released, 'other'))
+      yield* andFinallyIn(OtherScope, record(released, 'other'))
       return 'done'
     }).pipe(withScope(TestScope))
 

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -2,13 +2,13 @@ import { ScopedEffect } from './Effect.js'
 import { Fx, fx } from './Fx.js'
 import { uninterruptible } from './Interrupt.js'
 import type { Interrupt } from './Interrupt.js'
-import type { AnyLifetimeScope, Exit } from './Scope.js'
+import { currentScope, type AnyLifetimeScope, type Exit } from './Scope.js'
 
 // ----------------------------------------------------------------------
-// Guaranteed finalization effects within a named scope
+// Guaranteed finalization effects within a scope
 
 /**
- * A value paired with cleanup for a named scope.
+ * A value paired with cleanup for a scope.
  *
  * The finalizer receives the scope's exit, not the managed value.
  */
@@ -20,7 +20,7 @@ export interface Managed<A, E = never> {
 export type Finalizer<E = unknown> = (exit: Exit) => Fx<E, void>
 
 /**
- * Request that a cleanup operation be run when the named scope exits.
+ * Request that a cleanup operation be run when the scope exits.
  *
  * A `withScope(...)` handler interprets `Finally` requests for its matching scope
  * and runs registered finalizers when that scope succeeds, fails, returns,
@@ -29,27 +29,49 @@ export type Finalizer<E = unknown> = (exit: Exit) => Fx<E, void>
 export class Finally<const Scope extends AnyLifetimeScope, E = never> extends ScopedEffect('fx/Finally')<Scope, Finalizer<E>, void> { }
 
 /**
+ * Register a cleanup operation to run when the current scope exits.
+ *
+ * Use this when the finalizer does not need to inspect the scope exit.
+ */
+export function andFinally<E>(f: Fx<E, void>): Fx<Finally<typeof currentScope, E>, void>
+/**
+ * Register a cleanup operation that receives the current scope's exit.
+ *
+ * Use this when cleanup behavior depends on whether the scope succeeded,
+ * failed, returned, aborted, or was interrupted.
+ */
+export function andFinally<E>(f: (exit: Exit) => Fx<E, void>): Fx<Finally<typeof currentScope, E>, void>
+export function andFinally<E>(
+  f: Fx<E, void> | ((exit: Exit) => Fx<E, void>)
+): Fx<Finally<typeof currentScope, E>, void> {
+  return new Finally(currentScope, typeof f === 'function' ? f : () => f)
+}
+
+/**
  * Register a cleanup operation to run when the named scope exits.
  *
  * Use this when the finalizer does not need to inspect the scope exit.
  */
-export const andFinally = <const Scope extends AnyLifetimeScope, E>(
+export function andFinallyIn<const Scope extends AnyLifetimeScope, E>(
   scope: Scope,
   f: Fx<E, void>
-): Fx<Finally<Scope, E>, void> =>
-  new Finally(scope, () => f)
-
+): Fx<Finally<Scope, E>, void>
 /**
  * Register a cleanup operation that receives the named scope's exit.
  *
  * Use this when cleanup behavior depends on whether the scope succeeded,
  * failed, returned, aborted, or was interrupted.
  */
-export const andFinallyExit = <const Scope extends AnyLifetimeScope, E>(
+export function andFinallyIn<const Scope extends AnyLifetimeScope, E>(
   scope: Scope,
   f: (exit: Exit) => Fx<E, void>
-): Fx<Finally<Scope, E>, void> =>
-  new Finally(scope, f)
+): Fx<Finally<Scope, E>, void>
+export function andFinallyIn<const Scope extends AnyLifetimeScope, E>(
+  scope: Scope,
+  f: Fx<E, void> | ((exit: Exit) => Fx<E, void>)
+): Fx<Finally<Scope, E>, void> {
+  return new Finally(scope, typeof f === 'function' ? f : () => f)
+}
 
 /**
  * Run an initial operation, register cleanup for its result, and return it.
@@ -57,13 +79,26 @@ export const andFinallyExit = <const Scope extends AnyLifetimeScope, E>(
  * Acquisition and finalizer registration happen in an uninterruptible region so
  * an acquired resource is not left without cleanup.
  */
-export const using = <const Scope extends AnyLifetimeScope, const IE, const FE, const R>(
+export const using = <const IE, const FE, const R>(
+  initially: Fx<IE, R>,
+  finally_: (r: R, exit: Exit) => Fx<FE, void>
+): Fx<IE | Finally<typeof currentScope, FE> | Interrupt, R> =>
+    usingIn(currentScope, initially, finally_)
+
+/**
+ * Run an initial operation, register cleanup for its result in a named scope,
+ * and return it.
+ *
+ * Acquisition and finalizer registration happen in an uninterruptible region so
+ * an acquired resource is not left without cleanup.
+ */
+export const usingIn = <const Scope extends AnyLifetimeScope, const IE, const FE, const R>(
   scope: Scope,
   initially: Fx<IE, R>,
   finally_: (r: R, exit: Exit) => Fx<FE, void>
 ): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
   const r = yield* initially
-  yield* andFinallyExit(scope, exit => finally_(r, exit))
+  yield* andFinallyIn(scope, exit => finally_(r, exit))
   return r
 }))
 
@@ -85,11 +120,23 @@ export const managed = <const A, const E>(
  * Use this when acquisition naturally returns the value and its finalizer
  * together.
  */
-export const usingManaged = <const Scope extends AnyLifetimeScope, const IE, const FE, const A>(
+export const usingManaged = <const IE, const FE, const A>(
+  initially: Fx<IE, Managed<A, FE>>
+): Fx<IE | Finally<typeof currentScope, FE> | Interrupt, A> =>
+    usingManagedIn(currentScope, initially)
+
+/**
+ * Run an initial operation that returns a managed value, register its cleanup in
+ * a named scope, and return its value.
+ *
+ * Use this when acquisition naturally returns the value and its finalizer
+ * together.
+ */
+export const usingManagedIn = <const Scope extends AnyLifetimeScope, const IE, const FE, const A>(
   scope: Scope,
   initially: Fx<IE, Managed<A, FE>>
 ): Fx<IE | Finally<Scope, FE> | Interrupt, A> => uninterruptible(fx(function* () {
   const m = yield* initially
-  yield* andFinallyExit(scope, m.finalizer)
+  yield* andFinallyIn(scope, m.finalizer)
   return m.value
 }))

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -4,7 +4,7 @@ import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { fail, Fail, returnFail } from './Fail.js'
 import { race, withUnboundedConcurrency } from './Concurrent.js'
-import { andFinally, andFinallyExit, managed, using, usingManaged } from './Finalization.js'
+import { andFinallyIn, managed, usingIn, usingManagedIn } from './Finalization.js'
 import { bracket, fx, ok, run, runPromise, runTask, type Fx } from './Fx.js'
 import { control, handle } from './Handler.js'
 import { InterruptFrom, interruptFrom, recoverInterrupt } from './InterruptFrom.js'
@@ -20,7 +20,7 @@ describe('Typed interruption', () => {
     let recoveredReason: unknown
 
     const result = fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* interruptFrom(TestScope, reason)
@@ -85,7 +85,7 @@ describe('Typed interruption', () => {
     const cleanupFailure = new Error('cleanup failed')
 
     const result = fx(function* () {
-      yield* andFinally(TestScope, fail(cleanupFailure))
+      yield* andFinallyIn(TestScope, fail(cleanupFailure))
       yield* interruptFrom(TestScope)
     }).pipe(
       withScope(TestScope),
@@ -104,7 +104,7 @@ describe('Typed interruption', () => {
     const exits = [] as Exit[]
 
     const result = fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* interruptFrom(TestScope, reason)
@@ -144,7 +144,7 @@ describe('Typed interruption', () => {
     const cleanupFailure = new Error('cleanup failed')
 
     const result = fx(function* () {
-      yield* andFinally(TestScope, fail(cleanupFailure))
+      yield* andFinallyIn(TestScope, fail(cleanupFailure))
       yield* interruptFrom(TestScope)
     }).pipe(
       withScope(TestScope),
@@ -240,12 +240,12 @@ describe('Interrupt masking', () => {
   })
 
   it('runs registered finalizers when interrupted after masked acquire/register', async () => {
-    const TestScope = scope('test/Interrupt/using')
+    const TestScope = scope('test/Interrupt/usingIn')
     const exits = [] as Exit[]
     let resolve!: (value: string) => void
 
     const task = fx(function* () {
-      yield* using(
+      yield* usingIn(
         TestScope,
         assertPromise<string>(() => new Promise(r => {
           resolve = r
@@ -268,13 +268,13 @@ describe('Interrupt masking', () => {
     assert.deepEqual(exits, [{ type: 'interrupted', scope: TestScope }])
   })
 
-  it('usingManaged registers finalizers when interrupted after masked acquire/register', async () => {
-    const TestScope = scope('test/Interrupt/usingManaged')
+  it('usingManagedIn registers finalizers when interrupted after masked acquire/register', async () => {
+    const TestScope = scope('test/Interrupt/usingManagedIn')
     const exits = [] as Exit[]
     let resolve!: (value: ReturnType<typeof managed<string, never>>) => void
 
     const task = fx(function* () {
-      yield* usingManaged(
+      yield* usingManagedIn(
         TestScope,
         assertPromise(() => new Promise<ReturnType<typeof managed<string, never>>>(r => {
           resolve = r
@@ -450,7 +450,7 @@ describe('Interrupt masking', () => {
     let settled = false
 
     const loser = fx(function* () {
-      yield* using(
+      yield* usingIn(
         TestScope,
         assertPromise<string>(() => new Promise(r => {
           resolveAcquire = r

--- a/src/NodeRuntime.test.ts
+++ b/src/NodeRuntime.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { assertPromise, type Async } from './Async.js'
 import { assert as assertNoFail } from './Fail.js'
-import { andFinally } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import { fx, type Fx } from './Fx.js'
 import { runNodeMain, runNodePromise, type NodeSignalName, type NodeSignalProcess } from './NodeRuntime.js'
 import { scope, withScope } from './Scope.js'
@@ -42,7 +42,7 @@ describe('NodeRuntime', () => {
     let released = false
 
     const running = runNodePromise(fx(function* () {
-      yield* andFinally(TestScope, fx(function* () {
+      yield* andFinallyIn(TestScope, fx(function* () {
         released = true
       }))
       yield* awaitAbort(() => {

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { abort, Abort } from './Abort.js'
 import { forkIn, withUnboundedConcurrency } from './Concurrent.js'
 import { assert as assertNoFail, fail, Fail, returnFail } from './Fail.js'
-import { andFinally, andFinallyExit } from './Finalization.js'
+import { andFinally, andFinallyIn } from './Finalization.js'
 import { fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { interruptFrom, InterruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { returnFrom, ReturnFrom } from './ReturnFrom.js'
@@ -16,7 +16,7 @@ import { yieldFrom } from './YieldFrom.js'
 describe('currentScope', () => {
   it('is eliminated by withScope', () => {
     const TestScope = scope('test/CurrentScope/type')
-    const program = andFinally(currentScope, ok(undefined)).pipe(withScope(TestScope))
+    const program = andFinally(ok(undefined)).pipe(withScope(TestScope))
 
     const _: typeof program extends Fx<Fail<AggregateError>, void> ? true : false = true
 
@@ -27,7 +27,7 @@ describe('currentScope', () => {
     const events: string[] = []
 
     const result = await scoped(fx(function* () {
-      yield* andFinally(currentScope, fx(function* () {
+      yield* andFinally(fx(function* () {
         events.push('cleanup')
       }))
       yield* forkIn(currentScope, fx(function* () {
@@ -66,11 +66,11 @@ describe('currentScope', () => {
     const saved = currentScope
 
     const result = run(scoped(fx(function* () {
-      yield* andFinally(saved, fx(function* () {
+      yield* andFinallyIn(saved, fx(function* () {
         events.push('outer cleanup')
       }))
       yield* scoped(fx(function* () {
-        yield* andFinally(saved, fx(function* () {
+        yield* andFinallyIn(saved, fx(function* () {
           events.push('inner cleanup')
         }))
       }))
@@ -103,7 +103,7 @@ describe('scoped', () => {
     const exits: string[] = []
 
     const result = run(scoped(fx(function* () {
-      yield* andFinallyExit(currentScope, exit => ok(void exits.push(exit.type)))
+      yield* andFinally(exit => ok(void exits.push(exit.type)))
       return 'done' as const
     })).pipe(assertNoFail))
 
@@ -116,7 +116,7 @@ describe('scoped', () => {
     const exits: string[] = []
 
     const result = run(scoped(fx(function* () {
-      yield* andFinallyExit(currentScope, exit => ok(void exits.push(exit.type)))
+      yield* andFinally(exit => ok(void exits.push(exit.type)))
       return yield* fail(failure)
     })).pipe(returnFail))
 
@@ -129,7 +129,7 @@ describe('scoped', () => {
     const reason = new Error('stop')
     const exits: string[] = []
     const program = scoped(fx(function* () {
-      yield* andFinallyExit(currentScope, exit => ok(void exits.push(exit.type)))
+      yield* andFinally(exit => ok(void exits.push(exit.type)))
       return yield* interruptFrom(currentScope, reason)
     }))
 
@@ -146,7 +146,7 @@ describe('scoped', () => {
     const result = await scoped(fx(function* () {
       yield* forkIn(currentScope, fx(function* () {
         events.push('child ran')
-        yield* andFinally(currentScope, ok(void events.push('child cleanup')))
+        yield* andFinally(ok(void events.push('child cleanup')))
         return 'child' as const
       }))
       events.push('parent done')
@@ -165,7 +165,7 @@ describe('scoped', () => {
     const exits: string[] = []
 
     const result = run(scoped(fx(function* () {
-      yield* andFinallyExit(currentScope, exit => ok(void exits.push(exit.type)))
+      yield* andFinally(exit => ok(void exits.push(exit.type)))
       return 'done' as const
     })).pipe(assertNoFail))
 

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { Fail, fail, returnFail } from './Fail.js'
-import { andFinally } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import { fx, ok, run, type Fx } from './Fx.js'
 import { scope, withScope } from './Scope.js'
 import { GetState, getState, modifyState, type ModifyState, type Stateful, withState, withStateInit } from './State.js'
@@ -117,7 +117,7 @@ describe('State', () => {
     let finalizerState = 0
     const program = fx(function* () {
       yield* modifyState(CounterState, count => [count + 1, undefined])
-      yield* andFinally(CounterState, fx(function* () {
+      yield* andFinallyIn(CounterState, fx(function* () {
         finalizerState = yield* modifyState(CounterState, count => [count + 1, count])
       }))
 
@@ -130,7 +130,7 @@ describe('State', () => {
 
   it('leaves cleanup state effects typed when withState is inside the scope boundary', () => {
     const program = fx(function* () {
-      yield* andFinally(CounterState, modifyState(CounterState, count => [count + 1, undefined]))
+      yield* andFinallyIn(CounterState, modifyState(CounterState, count => [count + 1, undefined]))
       return 'done'
     })
     const wrongOrder = program.pipe(withState(CounterState, 1), withScope(CounterState))

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { Fail, fail, returnFail } from './Fail.js'
 import { forkIn, withBoundedConcurrency, withCoopConcurrency, withUnboundedConcurrency } from './Concurrent.js'
 import { fx, ok, run, runPromise } from './Fx.js'
-import { andFinallyExit } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import type { Fx } from './Fx.js'
 import { control } from './Handler.js'
 import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
@@ -108,7 +108,7 @@ describe('Timeout', () => {
     let completed = false
 
     const p = fx(function* () {
-      yield* andFinallyExit(TestScope, exit => fx(function* () {
+      yield* andFinallyIn(TestScope, exit => fx(function* () {
         exits.push(exit)
       }))
       yield* sleep(100)
@@ -136,7 +136,7 @@ describe('Timeout', () => {
     let exit!: Exit
 
     const p = fx(function* () {
-      yield* andFinallyExit(TestScope, e => fx(function* () {
+      yield* andFinallyIn(TestScope, e => fx(function* () {
         exit = e
       }))
       yield* sleep(100)
@@ -212,7 +212,7 @@ describe('Timeout', () => {
     let settled = false
 
     const p = fx(function* () {
-      yield* andFinallyExit(TestScope, () => fx(function* () {
+      yield* andFinallyIn(TestScope, () => fx(function* () {
         events.push('cleanup:start')
         yield* sleep(25)
         events.push('cleanup:end')
@@ -275,7 +275,7 @@ describe('Timeout', () => {
     const p = fx(function* () {
       yield* timeoutIn(TestScope, { ms: 50, reason: () => reason })
       yield* forkIn(TestScope, fx(function* () {
-        yield* andFinallyExit(TestScope, exit => fx(function* () {
+        yield* andFinallyIn(TestScope, exit => fx(function* () {
           exits.push(exit)
         }))
         yield* sleep(100)
@@ -413,7 +413,7 @@ describe('Timeout', () => {
     const p = fx(function* () {
       yield* forkIn(TestScope, fx(function* () {
         events.push('child:start')
-        yield* andFinallyExit(TestScope, exit => fx(function* () {
+        yield* andFinallyIn(TestScope, exit => fx(function* () {
           events.push(`child:finalize:${exit.type}`)
         }))
         yield* sleep(100)

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -2,7 +2,7 @@ import { Async, assertPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
 import { Fork, forkIn } from './Concurrent.js'
 import { Fail, catchAll, fail } from './Fail.js'
-import { Finally, andFinallyExit } from './Finalization.js'
+import { Finally, andFinallyIn } from './Finalization.js'
 import { Fx, flatMap, fx, map, ok } from './Fx.js'
 import { withCapturedHandlers, type HandlerCapture } from './HandlerCapture.js'
 import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
@@ -78,7 +78,7 @@ function timeoutInWithTrace<const Scope extends AnyLifetimeScope, const Options 
     )).pipe(
       flatMap(fx => new ScopedFork(scope, { fx, ...traceOrigin, daemon: true, scheduling: 'unmetered' }))
     )
-    yield* andFinallyExit(scope, exit => assertPromise(() => task.interrupt(exitReason(exit))))
+    yield* andFinallyIn(scope, exit => assertPromise(() => task.interrupt(exitReason(exit))))
   })
 }
 

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -4,7 +4,7 @@ import { assertPromise, tryPromise } from './Async.js'
 import { at } from './Breadcrumb.js'
 import { RaceAllFailed, all, withCoopConcurrency, firstSuccess, fork, forkIn, mapAll, race, withUnboundedConcurrency } from './Concurrent.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { andFinally } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import { fx, runPromise } from './Fx.js'
 import { control } from './Handler.js'
 import { InterruptFrom } from './InterruptFrom.js'
@@ -613,7 +613,7 @@ describe('Trace', () => {
   it('captures active scopes for cleanup failures', async () => {
     const DbTransaction = scope('db/transaction')
     const f = fx(function* () {
-      yield* andFinally(DbTransaction, fail(new Error('cleanup scoped')))
+      yield* andFinallyIn(DbTransaction, fail(new Error('cleanup scoped')))
     }).pipe(withScope(DbTransaction))
 
     await assert.rejects(


### PR DESCRIPTION
## Summary
- make unsuffixed finalization/resource helpers target `currentScope`
- add explicit-scope `andFinallyIn`, `usingIn`, and `usingManagedIn` forms
- remove public use of `andFinallyExit` and update examples/tests/import inference

## Validation
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- `git diff --check`