### PR TITLE
[codex] HTTP request scope interruption

### DIFF
--- a/src/HttpServer.test.ts
+++ b/src/HttpServer.test.ts
@@ -1,10 +1,12 @@
 import * as assert from 'node:assert/strict'
 import { createServer, request as nodeRequest, type IncomingHttpHeaders } from 'node:http'
 import { describe, it } from 'node:test'
-import { Async } from './Async.js'
+import { Async, assertPromise } from './Async.js'
+import { forkIn } from './Concurrent.js'
 import { Get, provideFrom } from './Env.js'
 import { Effect } from './Effect.js'
 import { Fail, assert as assertNoFail, fail } from './Fail.js'
+import { andFinally } from './Finalization.js'
 import { ok, fx, run, runPromise, runTask, type Fx } from './Fx.js'
 import { handle } from './Handler.js'
 import {
@@ -27,7 +29,7 @@ import {
 import { NodeHttpError, nodeHttp, type NodeHttpServerFactory } from './HttpServerNode.js'
 import { HandlerCapture } from './HandlerCapture.js'
 import type { Interrupt } from './Interrupt.js'
-import { scope } from './Scope.js'
+import { currentScope, scope } from './Scope.js'
 import { YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 const HttpServerEvents = scope<Yielding<ServerEvent>>()('test/HttpServer/events')
@@ -507,6 +509,113 @@ describe('HttpServer', () => {
       })
     })
 
+    it('interrupts route handlers when the response closes before finishing', async () => {
+      let interrupted = false
+      const events: ServerEvent[] = []
+      const app = route('GET', '/slow', fx(function* () {
+        yield* waitForInterrupt(() => {
+          interrupted = true
+        })
+        return text('late')
+      }))
+
+      await withServer(createServer => serve(app, {
+        port: 0,
+        host: '127.0.0.1',
+        observe: event => ok(void events.push(event))
+      }).pipe(
+        nodeHttp({ createServer })
+      ), async port => {
+        await httpAbortGet(port, '/slow')
+        await eventually(() => interrupted)
+        const event = await waitForEvent(events, isRequestFailed)
+
+        assert.equal(event.path, '/slow')
+        assert.equal(event.status, undefined)
+      })
+    })
+
+    it('runs current-scope finalizers when the response closes before finishing', async () => {
+      const exits: string[] = []
+      const app = route('GET', '/slow', fx(function* () {
+        yield* andFinally(exit => ok(void exits.push(exit.type)))
+        yield* waitForInterrupt()
+        return text('late')
+      }))
+
+      const runnable = serve(app, { port: 0, host: '127.0.0.1' }).pipe(
+        nodeHttp()
+      )
+      const _: Fx<Async | Interrupt | HandlerCapture<string> | Fail<NodeHttpError>, void> = runnable
+      void _
+
+      await withServer(createServer => serve(app, { port: 0, host: '127.0.0.1' }).pipe(
+        nodeHttp({ createServer })
+      ), async port => {
+        await httpAbortGet(port, '/slow')
+        await eventually(() => exits.includes('interrupted'))
+      })
+    })
+
+    it('does not treat normal response close after finish as a failed request', async () => {
+      const app = route('GET', '/health', ok(text('ok')))
+      const events: ServerEvent[] = []
+
+      await withServer(createServer => serve(app, {
+        port: 0,
+        host: '127.0.0.1',
+        observe: event => ok(void events.push(event))
+      }).pipe(
+        nodeHttp({ createServer })
+      ), async port => {
+        const response = await httpGet(port, '/health')
+        const event = await waitForEvent(events, isRequest)
+
+        assert.equal(response.status, 200)
+        assert.equal(event.status, 200)
+        assert.equal(events.some(isRequestFailed), false)
+      })
+    })
+
+    it('interrupts route handlers when the request body closes before completion', async () => {
+      let interrupted = false
+      const events: ServerEvent[] = []
+      const app = route('POST', '/upload', fx(function* () {
+        yield* waitForInterrupt(() => {
+          interrupted = true
+        })
+        return text('late')
+      }))
+
+      await withServer(createServer => serve(app, {
+        port: 0,
+        host: '127.0.0.1',
+        observe: event => ok(void events.push(event))
+      }).pipe(
+        nodeHttp({ createServer })
+      ), async port => {
+        await httpAbortUpload(port, '/upload')
+        await eventually(() => interrupted)
+        const event = await waitForEvent(events, isRequestFailed)
+
+        assert.equal(event.path, '/upload')
+        assert.equal(event.status, undefined)
+      })
+    })
+
+    it('does not expose request-owned current-scope forks from server program types', () => {
+      const app = route('GET', '/fork', fx(function* () {
+        yield* forkIn(currentScope, ok('child'))
+        return text('ok')
+      }))
+
+      const runnable = serve(app, { port: 0, host: '127.0.0.1' }).pipe(
+        nodeHttp()
+      )
+      const _: Fx<Async | Interrupt | HandlerCapture<string> | Fail<NodeHttpError>, void> = runnable
+      void _
+    })
+
     it('keeps observer yield effects visible until handled', () => {
       const app = route('GET', '/health', ok(text('ok')))
 
@@ -666,6 +775,14 @@ const assertTimestamp = (timestamp: number, before: number, after: number): void
   assert.equal(timestamp <= after, true)
 }
 
+const waitForInterrupt = (onInterrupt: () => void = () => { }): Fx<Async, void> =>
+  assertPromise(signal => new Promise<void>(resolve => {
+    signal.addEventListener('abort', () => {
+      onInterrupt()
+      resolve()
+    }, { once: true })
+  }))
+
 const httpGet = (
   port: number,
   path: string
@@ -683,6 +800,50 @@ const httpGet = (
     request.on('error', reject)
     request.end()
   })
+
+const httpAbortGet = (
+  port: number,
+  path: string
+): Promise<void> =>
+  new Promise(resolve => {
+    const request = nodeRequest({ host: '127.0.0.1', port, path }, response => {
+      response.resume()
+    })
+    request.on('error', () => resolve())
+    request.end()
+    setTimeout(() => {
+      request.destroy()
+      resolve()
+    }, 5)
+  })
+
+const httpAbortUpload = (
+  port: number,
+  path: string
+): Promise<void> =>
+  new Promise(resolve => {
+    const request = nodeRequest({
+      host: '127.0.0.1',
+      port,
+      path,
+      method: 'POST',
+      headers: { 'content-length': '1048576' }
+    })
+    request.on('error', () => resolve())
+    request.write(new Uint8Array(1024))
+    setTimeout(() => {
+      request.destroy()
+      resolve()
+    }, 5)
+  })
+
+const eventually = async (predicate: () => boolean): Promise<void> => {
+  for (let i = 0; i < 100; i++) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 1))
+  }
+  throw new Error('Timed out waiting for condition')
+}
 
 const toHeaderRecord = (headers: IncomingHttpHeaders): Record<string, string> =>
   Object.fromEntries(Object.entries(headers).flatMap(([name, value]) =>

--- a/src/HttpServer.ts
+++ b/src/HttpServer.ts
@@ -2,9 +2,13 @@ import { Async } from './Async.js'
 import { Effect } from './Effect.js'
 import { Get, provide, provideFrom, type ExcludeEnv } from './Env.js'
 import { Fail } from './Fail.js'
+import { Finally } from './Finalization.js'
 import { Fx, flatMap, ok } from './Fx.js'
 import { HandlerCapture, captureHandlers, type CapturedHandler } from './HandlerCapture.js'
 import { type Headers, type Method } from './HttpClient.js'
+import { Fork } from './internal/concurrent/effects.js'
+import { ScopedFork } from './internal/scopedFork.js'
+import { currentScope } from './Scope.js'
 
 /**
  * A transport-neutral HTTP server request.
@@ -59,7 +63,7 @@ export type ServerRequestFailed = {
   readonly timestamp: number
   readonly method: Method
   readonly path: string
-  readonly status: number
+  readonly status?: number
   readonly durationMs: number
   readonly error: unknown
 }
@@ -226,7 +230,32 @@ export const provideRoutesFrom =
     transformRoutes(provideFrom(context)) as
       <const E>(routes: Routes<E>) => Routes<RouteEffects<PE | ExcludeEnv<E, C>>>
 
-export type ServerRouteEffects = Async | Fail<any> | HandlerCapture<string>
+export type ServerRouteEffects = Async | Fail<any> | Fork | HandlerCapture<string>
+
+export type ServerRequestScopeEffects<E> =
+  HandleServerRequestScopeEffect<E> | ServerRequestScopedForkEffects<E> | ServerRequestCleanupEffects<E> | ServerRequestCleanupFailure<E>
+
+type HandleServerRequestScopeEffect<E> =
+  E extends Finally<typeof currentScope, any> ? never
+  : E extends ScopedFork<typeof currentScope> ? never
+  : E
+
+type ServerRequestScopedForkEffects<E> =
+  E extends ScopedFork<typeof currentScope> ? Fork | Async | Fail<unknown> : never
+
+type MatchingServerRequestFinally<E> =
+  Extract<E, Finally<typeof currentScope, any>>
+
+type ServerRequestFinalizerEffects<E> =
+  MatchingServerRequestFinally<E> extends never
+    ? never
+    : MatchingServerRequestFinally<E> extends Finally<typeof currentScope, infer FE> ? FE : never
+
+type ServerRequestCleanupEffects<E> =
+  Exclude<ServerRequestFinalizerEffects<E>, Fail<any>>
+
+type ServerRequestCleanupFailure<E> =
+  MatchingServerRequestFinally<E> extends never ? never : Fail<AggregateError>
 
 export const ServeScope = 'fx/HttpServer/Serve'
 
@@ -251,12 +280,14 @@ export type ServeOptions<OE = never> = {
  * Request that an HTTP server run the provided routes.
  *
  * `serve` captures the surrounding handler context so route handlers can use
- * application handlers installed at the server boundary.
+ * application handlers installed at the server boundary. Server interpreters
+ * run each matched route handler in a request lifetime scope, so current-scope
+ * finalizers and scoped forks are owned by the request.
  */
 export const serve = <E, OE = never>(
   routes: Routes<E>,
   options: ServeOptions<OE>
-): Fx<Exclude<E, ServerRouteEffects> | OE | Serve<E, OE> | HandlerCapture<typeof ServeScope>, void> =>
+): Fx<Exclude<ServerRequestScopeEffects<E>, ServerRouteEffects> | OE | Serve<E, OE> | HandlerCapture<typeof ServeScope>, void> =>
   captureHandlers(ServeScope).pipe(
     flatMap(context => new Serve<E, OE>({ routes, options, context }))
   )

--- a/src/HttpServerNode.ts
+++ b/src/HttpServerNode.ts
@@ -3,7 +3,7 @@ import { Readable } from 'node:stream'
 import { finished, pipeline } from 'node:stream/promises'
 import { Async, tryPromise } from './Async.js'
 import { Fail, catchAll, fail, returnFail, returnAll } from './Fail.js'
-import { Fx, assertSync, bracket, flatMap, flatten, fx, ok, runPromise, trySync, unit } from './Fx.js'
+import { Fx, assertSync, bracket, flatMap, flatten, fx, ok, runTask, trySync, unit } from './Fx.js'
 import { Handle } from './Handler.js'
 import { type Headers, type Method } from './HttpClient.js'
 import {
@@ -22,6 +22,7 @@ import {
 import { HandlerCapture, handleCaptured, withCapturedHandlers, withHandlerContext } from './HandlerCapture.js'
 import type { Interrupt } from './Interrupt.js'
 import * as Queue from './internal/Queue.js'
+import { scope, withScope } from './Scope.js'
 
 export type NodeHttpOptions = {
   readonly createServer?: NodeHttpServerFactory
@@ -219,6 +220,8 @@ const runNodeRequest = async <E>(
   const start = performance.now()
   let status = 500
   let failure: { readonly error: unknown } | undefined
+  const requestScope = scope(Symbol('fx/HttpServer/Request'), { label: 'http request' })
+  const clientDisconnect = watchClientDisconnect(incoming, outgoing)
 
   const program = fx(function* () {
     const response = yield* dispatch(compiled, request)
@@ -226,19 +229,33 @@ const runNodeRequest = async <E>(
     yield* writeNodeResponse(outgoing, response)
   })
 
+  const task = withHandlerContext(context, program as Fx<unknown, void>).pipe(
+    withScope(requestScope),
+    catchAll(cause => {
+      failure = { error: cause }
+      return outgoing.destroyed
+        ? unit
+        : writeInternalServerError(outgoing)
+    }),
+    returnAll,
+    f => runTask(f as Fx<Async | HandlerCapture<string>, void>)
+  )
+
   try {
-    await withHandlerContext(context, program as Fx<unknown, void>).pipe(
-      catchAll(cause => {
-        failure = { error: cause }
-        return writeInternalServerError(outgoing)
-      }),
-      returnAll,
-      f => runPromise(f as Fx<Async | HandlerCapture<string>, void>)
-    )
+    const result = await Promise.race([
+      task.promise.then(() => undefined),
+      clientDisconnect.promise
+    ])
+
+    if (result !== undefined) {
+      failure = { error: result }
+      await task.interrupt(result)
+    }
   } catch (cause) {
     failure ??= { error: cause }
     outgoing.destroy()
   } finally {
+    clientDisconnect[Symbol.dispose]()
     const durationMs = performance.now() - start
     const finalStatus = outgoing.headersSent ? outgoing.statusCode : status
     const event = failure ? {
@@ -246,7 +263,7 @@ const runNodeRequest = async <E>(
       timestamp: eventTimestamp(),
       method: request.method,
       path: request.path,
-      status: finalStatus,
+      ...(outgoing.headersSent ? { status: finalStatus } : {}),
       durationMs,
       error: failure.error
     } : {
@@ -259,6 +276,60 @@ const runNodeRequest = async <E>(
     }
 
     events.enqueue(event)
+  }
+}
+
+type ClientClosedRequest = {
+  readonly type: 'clientClosedRequest'
+  readonly phase: 'request' | 'response'
+}
+
+type ClientDisconnectWatcher = {
+  readonly promise: Promise<ClientClosedRequest>
+  readonly [Symbol.dispose]: () => void
+}
+
+const watchClientDisconnect = (
+  request: IncomingMessage,
+  response: NodeServerResponse
+): ClientDisconnectWatcher => {
+  const disconnected = Promise.withResolvers<ClientClosedRequest>()
+  let responseFinished = false
+  let settled = false
+  const disconnect = (reason: ClientClosedRequest) => {
+    if (settled) return
+    settled = true
+    cleanup()
+    disconnected.resolve(reason)
+  }
+  const onFinish = () => {
+    responseFinished = true
+  }
+  const onResponseClose = () => {
+    if (!responseFinished) disconnect({ type: 'clientClosedRequest', phase: 'response' })
+  }
+  const onRequestClose = () => {
+    if (!request.complete) disconnect({ type: 'clientClosedRequest', phase: 'request' })
+  }
+  const cleanup = () => {
+    response.off('finish', onFinish)
+    response.off('close', onResponseClose)
+    request.off('close', onRequestClose)
+  }
+
+  // Node emits response "close" after normal completion too. Treat it as a
+  // client disconnect only if response "finish" has not happened. For request
+  // bodies, request.complete distinguishes aborted uploads from complete reads.
+  response.on('finish', onFinish)
+  response.on('close', onResponseClose)
+  request.on('close', onRequestClose)
+
+  return {
+    promise: disconnected.promise,
+    [Symbol.dispose]() {
+      settled = true
+      cleanup()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Run each Node HTTP request handler as an interruptible task inside a private request scope.
- Interrupt request work when the response closes before `finish`, or when the request body closes before completion.
- Add regression coverage for early response close, aborted uploads, current-scope finalization, and normal close-after-finish behavior.

## Impact

This is an internal Node HTTP adapter prototype. It does not add public route APIs or expose a request-scope token, but it lets request-local cleanup and request-owned work observe interruption when the client goes away early.

## Validation

- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- `git diff --check`
