### PR TITLE
[codex] Show HTTP request scope finalization

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ Use the smallest example that demonstrates the task:
 | --- | --- | --- |
 | Minimal runnable program | `basic/hello.ts` | Shows one effect, one handler, and `run` without extra structure. |
 | Custom domain effects and pure tests | `basic/guessing-game` | Shows business logic written against effects and interpreted by handlers. |
-| HTTP boundary code | `basic/http-server-client` | Shows routes, request context, client/server boundaries, and in-memory handlers. |
+| HTTP boundary code | `basic/http-server-client` | Shows routes, request context, request-scope cleanup, client/server boundaries, and in-memory handlers. |
 | Concurrency operators and schedulers | `intermediate/concurrency-handlers.ts` | Shows race operators and scheduler handlers. |
 | Scope-owned fork lifetime | `intermediate/scope-owned-forks.ts` | Shows scoped fork lifetime, a scope deadline, and scheduler handler ordering. |
 | Interruption and cleanup | `intermediate/interrupt-safe-finalization.ts` | Shows cancellation, named scopes, and async finalizers. |
@@ -32,7 +32,7 @@ already matches the requested pattern.
 | --- | --- | --- | --- |
 | `basic/hello.ts` | A minimal `Fx` program, console effect, handler, and `run`. | First-time readers who want the smallest runnable example. | `node --import tsx examples/basic/hello.ts` |
 | `basic/guessing-game` | Custom effects, handler composition, environment input, pure handlers, and tests. | Readers learning how business logic stays independent from interpreters. | `node --import tsx examples/basic/guessing-game/index.ts` |
-| `basic/http-server-client` | Small HTTP API routes, server/client boundaries, route context, and in-memory handlers. | Readers who want a compact platform-boundary example. | `node --import tsx examples/basic/http-server-client/server.ts` |
+| `basic/http-server-client` | Small HTTP API routes, server/client boundaries, route context, request-scope cleanup, and in-memory handlers. | Readers who want a compact platform-boundary example. | `node --import tsx examples/basic/http-server-client/server.ts` |
 
 ## Intermediate
 

--- a/examples/basic/http-server-client/api.ts
+++ b/examples/basic/http-server-client/api.ts
@@ -101,9 +101,7 @@ function readText(request: ServerRequest) {
   )
 }
 
-const requestAudit = (user: User) => fx(function* () {
-  const { request } = yield* get<RouteContext>()
-
+const requestAudit = (user: User) => fx(function* ({ request }: RouteContext) {
   return yield* using(
     openRequestAudit(request, user),
     closeRequestAudit

--- a/examples/basic/http-server-client/api.ts
+++ b/examples/basic/http-server-client/api.ts
@@ -2,6 +2,8 @@ import { Effect, fx, type Fx, get, handle, map, ok } from '@briancavalier/fx'
 
 import { bytes as readBytes } from '@briancavalier/fx/http-client'
 import { mount, provideRoutesFrom, route, routes, type RouteContext, type ServerRequest, type ServerResponse } from '@briancavalier/fx/http-server'
+import { info } from '@briancavalier/fx/log'
+import { using, type Exit } from '@briancavalier/fx/scope'
 
 export type Note = {
   readonly id: string
@@ -23,6 +25,12 @@ type UserContext = {
   readonly user: User
 }
 
+type RequestAudit = {
+  readonly method: string
+  readonly path: string
+  readonly userId: string
+}
+
 const userContext = fx(function* ({ request }: RouteContext) {
   return {
     user: fakeAuthenticate(request)
@@ -33,6 +41,8 @@ const healthRoutes = route('GET', '/health', ok(text('ok')))
 
 const noteRoutes = provideRoutesFrom(userContext)(routes(
   route('GET', '/notes', fx(function* ({ user }: UserContext) {
+    yield* requestAudit(user)
+
     return json({
       user,
       notes: yield* listNotes
@@ -40,6 +50,8 @@ const noteRoutes = provideRoutesFrom(userContext)(routes(
   })),
 
   route('POST', '/notes', fx(function* ({ user }: UserContext) {
+    yield* requestAudit(user)
+
     const { request: req } = yield* get<RouteContext>()
     const note = yield* createNote(`${user.name}: ${(yield* readText(req)).trim()}`)
     return json({ user, note }, 201)
@@ -88,6 +100,32 @@ function readText(request: ServerRequest) {
     map((bytes: Uint8Array) => new TextDecoder().decode(bytes))
   )
 }
+
+const requestAudit = (user: User) => fx(function* () {
+  const { request } = yield* get<RouteContext>()
+
+  return yield* using(
+    openRequestAudit(request, user),
+    closeRequestAudit
+  )
+})
+
+const openRequestAudit = (request: ServerRequest, user: User) => fx(function* () {
+  const audit = {
+    method: request.method,
+    path: request.path,
+    userId: user.id
+  }
+
+  yield* info('Request scope opened', audit)
+  return audit
+})
+
+const closeRequestAudit = (audit: RequestAudit, exit: Exit) =>
+  info('Request scope finalized', {
+    ...audit,
+    exit: exit.type
+  })
 
 function fakeAuthenticate(request: ServerRequest): User {
   const id = request.headers.find(([name]) => name.toLowerCase() === 'x-user-id')?.[1] ?? 'demo-user'

--- a/src/HttpServerNode.ts
+++ b/src/HttpServerNode.ts
@@ -229,8 +229,9 @@ const runNodeRequest = async <E>(
     yield* writeNodeResponse(outgoing, response)
   })
 
-  const task = withHandlerContext(context, program as Fx<unknown, void>).pipe(
+  const task = program.pipe(
     withScope(requestScope),
+    f => withHandlerContext(context, f as Fx<unknown, void>),
     catchAll(cause => {
       failure = { error: cause }
       return outgoing.destroyed


### PR DESCRIPTION
## Summary

- Run HTTP route handlers with captured server-boundary handlers outside the private request scope so request finalizers can use the same handled effects as the route body.
- Expand the basic HTTP server/client example with a request audit resource that logs acquisition and current-scope finalization for note routes.
- Update the examples README to mention request-scope cleanup in the HTTP example.

## Why

The example uncovered that `nodeHttp` applied captured route handlers only to the route body. Current-scope finalizers ran after that wrapper had completed, so effectful cleanup such as `Log` could escape and turn a completed request into a failed request event. Request finalization is part of request handling and should run under the same captured application handlers.

## Validation

- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `node --import tsx --test src/HttpServer.test.ts`
- `corepack pnpm test`
- Manual `PORT=3107 node --import tsx examples/basic/http-server-client/server.ts` plus client run confirmed `Request scope finalized` logs through `withConsoleLog` with successful request events.