### PR TITLE
Add lexical finalizing helper

### DIFF
--- a/examples/advanced/bookmarks/browser/dom-presentation.ts
+++ b/examples/advanced/bookmarks/browser/dom-presentation.ts
@@ -1,4 +1,4 @@
-import { assertSync, finalizing, fx, ok, type Fx } from '../../../../src/Fx.js'
+import { andThen, assertSync, finalizing, ok, type Fx } from '../../../../src/Fx.js'
 import { handle } from '../../../../src/Handler.js'
 import { handleCaptured } from '../../../../src/HandlerCapture.js'
 import type { Interrupt } from '../../../../src/Interrupt.js'
@@ -40,12 +40,10 @@ export const domPresentation = (elements: BookmarkElements) => {
 
   const interpret = <E, A>(program: Fx<E, A>): Fx<Exclude<E, Presentation> | Interrupt, A> => program.pipe(
       handleCaptured(BusyScope, Busy, effect =>
-        fx(function* () {
-          yield* assertSync(() => setBusy(true))
-          return yield* interpret(effect.arg).pipe(
-            finalizing(assertSync(() => setBusy(false)))
-          )
-        })
+        assertSync(() => setBusy(true)).pipe(
+          andThen(interpret(effect.arg)),
+          finalizing(assertSync(() => setBusy(false)))
+        )
       ),
       handle(ReadAddBookmarkInput, () => ok(addBookmarkInput(elements))),
       handle(ReadBookmarkQuery, () => ok(currentQuery(elements))),

--- a/examples/advanced/bookmarks/browser/dom-presentation.ts
+++ b/examples/advanced/bookmarks/browser/dom-presentation.ts
@@ -1,4 +1,4 @@
-import { assertSync, bracket, ok, type Fx } from '../../../../src/Fx.js'
+import { assertSync, finalizing, fx, ok, type Fx } from '../../../../src/Fx.js'
 import { handle } from '../../../../src/Handler.js'
 import { handleCaptured } from '../../../../src/HandlerCapture.js'
 import type { Interrupt } from '../../../../src/Interrupt.js'
@@ -40,11 +40,12 @@ export const domPresentation = (elements: BookmarkElements) => {
 
   const interpret = <E, A>(program: Fx<E, A>): Fx<Exclude<E, Presentation> | Interrupt, A> => program.pipe(
       handleCaptured(BusyScope, Busy, effect =>
-        bracket(
-          assertSync(() => setBusy(true)),
-          () => assertSync(() => setBusy(false)),
-          () => interpret(effect.arg)
-        )
+        fx(function* () {
+          yield* assertSync(() => setBusy(true))
+          return yield* interpret(effect.arg).pipe(
+            finalizing(assertSync(() => setBusy(false)))
+          )
+        })
       ),
       handle(ReadAddBookmarkInput, () => ok(addBookmarkInput(elements))),
       handle(ReadBookmarkQuery, () => ok(currentQuery(elements))),

--- a/examples/package-import-inference.test.ts
+++ b/examples/package-import-inference.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { Effect, fx, ScopedEffect, type Fx } from '@briancavalier/fx'
+import { Effect, finalizing, fx, ScopedEffect, type Fx } from '@briancavalier/fx'
 import * as concurrentApi from '@briancavalier/fx/concurrent'
 import * as scopeApi from '@briancavalier/fx/scope'
 import * as timeoutApi from '@briancavalier/fx/timeout'
@@ -49,6 +49,7 @@ describe('package import inference', () => {
     assert.equal(typeof usingIn, 'function')
     assert.equal(typeof usingManaged, 'function')
     assert.equal(typeof usingManagedIn, 'function')
+    assert.equal(typeof finalizing, 'function')
 
     assert.equal(typeof timeout, 'function')
     assert.equal(typeof timeoutIn, 'function')
@@ -61,6 +62,7 @@ describe('package import inference', () => {
     const noFirstSettledPolicy: HasExport<typeof concurrentApi, `first${'Settled'}Policy`> = false
     const noFirstSuccessPolicy: HasExport<typeof concurrentApi, `first${'Success'}Policy`> = false
     const noScopeTypeId: HasExport<typeof scopeApi, `Scope${'Type'}Id`> = false
+    const noScopeFinalizing: HasExport<typeof scopeApi, `final${'izing'}`> = false
     const noTimeoutInScope: HasExport<typeof timeoutApi, `timeout${'In'}Scope`> = false
     assert.equal(noConcurrentEffect, false)
     assert.equal(noConcurrentConstructor, false)
@@ -69,6 +71,7 @@ describe('package import inference', () => {
     assert.equal(noFirstSettledPolicy, false)
     assert.equal(noFirstSuccessPolicy, false)
     assert.equal(noScopeTypeId, false)
+    assert.equal(noScopeFinalizing, false)
     assert.equal(noTimeoutInScope, false)
   })
 

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -209,3 +209,18 @@ export const bracket = <const IE, const FE, const E, const R, const A>(
     yield* andFinally(r)
   }
 }))
+
+/**
+ * Run cleanup when a lexical computation exits, without registering it with a
+ * scope.
+ */
+export const finalizing =
+  <const FE>(finally_: Fx<FE, void>) =>
+    <const E, const A>(program: Fx<E, A>): Fx<E | FE | Interrupt, A> =>
+      uninterruptibleMask(restore => fx(function* () {
+        try {
+          return yield* restore(program)
+        } finally {
+          yield* finally_
+        }
+      }))

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -5,7 +5,7 @@ import { Effect } from './Effect.js'
 import { fail, Fail, returnFail } from './Fail.js'
 import { race, withUnboundedConcurrency } from './Concurrent.js'
 import { andFinallyIn, managed, usingIn, usingManagedIn } from './Finalization.js'
-import { bracket, fx, ok, run, runPromise, runTask, type Fx } from './Fx.js'
+import { bracket, finalizing, fx, ok, run, runPromise, runTask, type Fx } from './Fx.js'
 import { control, handle } from './Handler.js'
 import { InterruptFrom, interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
@@ -316,6 +316,123 @@ describe('Interrupt masking', () => {
     await interrupted
 
     assert.deepEqual(released, ['resource'])
+  })
+
+  it('finalizing runs cleanup after success and preserves the result', () => {
+    const released = [] as string[]
+
+    const program = ok('value').pipe(finalizing(fx(function* () {
+      released.push('cleanup')
+    })))
+
+    const _: Fx<Interrupt, 'value'> = program
+    void _
+
+    assert.equal(run(program), 'value')
+    assert.deepEqual(released, ['cleanup'])
+  })
+
+  it('finalizing runs cleanup after failure', () => {
+    class Cleanup extends Effect('test/Interrupt/finalizing/Cleanup')<string, void> { }
+    const failure = new Error('failed')
+    const released = [] as string[]
+
+    const program = fail(failure).pipe(finalizing(new Cleanup('cleanup')))
+
+    const _: Fx<Fail<Error> | Cleanup | Interrupt, never> = program
+    void _
+
+    const result = program.pipe(
+      handle(Cleanup, effect => ok(void released.push(effect.arg))),
+      returnFail,
+      run
+    )
+
+    assert.equal(result.arg, failure)
+    assert.deepEqual(released, ['cleanup'])
+  })
+
+  it('finalizing runs cleanup exactly once', () => {
+    let released = 0
+
+    ok('value').pipe(
+      finalizing(fx(function* () {
+        released += 1
+      })),
+      run
+    )
+
+    assert.equal(released, 1)
+  })
+
+  it('finalizing runs cleanup when interrupted', async () => {
+    const released = [] as string[]
+    let started = false
+
+    const task = assertPromise<void>(() => new Promise(() => {
+      started = true
+    })).pipe(
+      finalizing(fx(function* () {
+        released.push('cleanup')
+      })),
+      runTask
+    )
+
+    await eventually(() => started)
+    await task.interrupt()
+
+    assert.deepEqual(released, ['cleanup'])
+  })
+
+  it('finalizing drains async cleanup effects during interruption', async () => {
+    const released = [] as string[]
+    let started = false
+
+    const task = assertPromise<void>(() => new Promise(() => {
+      started = true
+    })).pipe(
+      finalizing(fx(function* () {
+        yield* assertPromise(() => Promise.resolve())
+        released.push('cleanup')
+      })),
+      runTask
+    )
+
+    await eventually(() => started)
+    await task.interrupt()
+
+    assert.deepEqual(released, ['cleanup'])
+  })
+
+  it('finalizing cleanup effects are handled by handlers around the lexical region', () => {
+    class Request extends Effect('test/Interrupt/finalizing/Request')<string, void> { }
+    const handled = [] as string[]
+
+    fx(function* () {
+      yield* new Request('program')
+      return 'value'
+    }).pipe(
+      finalizing(new Request('cleanup')),
+      handle(Request, effect => ok(void handled.push(effect.arg))),
+      run
+    )
+
+    assert.deepEqual(handled, ['program', 'cleanup'])
+  })
+
+  it('finalizing cleanup is not handled by handlers inside the protected program', () => {
+    class Request<A> extends Effect('test/Interrupt/finalizing/InnerRequest')<string, A> { }
+    const handled = [] as string[]
+
+    const result = new Request<string>('program').pipe(
+      handle(Request, effect => ok(`inner:${effect.arg}`)),
+      finalizing(new Request<void>('cleanup')),
+      handle(Request, effect => ok(void handled.push(`outer:${effect.arg}`))),
+      run
+    )
+
+    assert.equal(result, 'inner:program')
+    assert.deepEqual(handled, ['outer:cleanup'])
   })
 
   it('restore re-enables interruption inside uninterruptibleMask', async () => {

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -17,6 +17,7 @@ export {
   andThen,
   assertSync,
   bracket,
+  finalizing,
   flatMap,
   flatten,
   fx,


### PR DESCRIPTION
## Summary
- add root `finalizing(cleanup)` as a lexical cleanup companion to `bracket`
- export `finalizing` from the root package API, not the scope subpath
- cover success, failure, interruption, async cleanup, handler extent, and package import behavior

## Validation
- `corepack pnpm build`
- `corepack pnpm typecheck`
- `node --import tsx --test src/Interrupt.test.ts examples/package-import-inference.test.ts`
- `corepack pnpm test`
- `corepack pnpm lint`
- `git diff --check`