### PR TITLE
[codex] Prototype shared exit region for Scope

### DIFF
--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -2821,10 +2821,12 @@ describe('Task interruption finalization', () => {
     const TestScope = scope('test/Fork/InterruptedMultipleInnerCleanupFailures')
     const firstFailure = new Error('first release failed')
     const secondFailure = new Error('second release failed')
+    const thirdFailure = new Error('third release failed')
 
     const slow = awaitAbort().pipe(
       finalizing(fail(firstFailure)),
-      finalizing(fail(secondFailure))
+      finalizing(fail(secondFailure)),
+      finalizing(fail(thirdFailure))
     )
 
     const result = await race([ok('winner'), slow]).pipe(
@@ -2837,7 +2839,7 @@ describe('Task interruption finalization', () => {
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
     assert.equal(result.arg.message, 'Resource release failed')
-    assert.deepEqual(result.arg.errors, [firstFailure, secondFailure])
+    assert.deepEqual(result.arg.errors, [firstFailure, secondFailure, thirdFailure])
   })
 
   it('aggregates interrupted scoped cleanup failure with synchronous iterator return throw', async () => {

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -2709,6 +2709,33 @@ describe('Task interruption finalization', () => {
     assert.deepEqual(released, ['inner'])
   })
 
+  it('interprets scope effects yielded from wrapped iterator return during interruption', async () => {
+    const TestScope = scope<Control>()('test/Fork/InterruptedInnerReturnScopeEffect')
+    const released = [] as string[]
+
+    const result = await fx(function* () {
+      return yield* fork(fx(function* () {
+        try {
+          yield* awaitAbort()
+        } finally {
+          released.push('inner')
+          yield* returnFrom(TestScope, 'cleanup')
+        }
+      }))
+    }).pipe(
+      withScope(TestScope),
+      withUnboundedConcurrency,
+      returnFail,
+      runPromise
+    )
+    assert.ok(result instanceof Task)
+    const task = result
+
+    await task.interrupt()
+
+    assert.deepEqual(released, ['inner'])
+  })
+
   it('drains wrapped iterator return after interrupted scoped finalizer yields', async () => {
     const TestScope = scope('test/Fork/InterruptedScopeThenInnerReturn')
     const released = [] as string[]

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -5,7 +5,7 @@ import { Effect } from './Effect.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { RaceAllFailed, all, withBoundedConcurrency, withCoopConcurrency, firstSuccess, fork, forkEach, forkIn, mapAll, race, withUnboundedConcurrency } from './Concurrent.js'
 import { andFinallyIn } from './Finalization.js'
-import { bracket, flatMap, fx, ok, runPromise, runTask, type Fx } from './Fx.js'
+import { bracket, finalizing, flatMap, fx, ok, runPromise, runTask, type Fx } from './Fx.js'
 import { handle } from './Handler.js'
 import { type HandlerCapture } from './HandlerCapture.js'
 import { interruptFrom, recoverInterrupt } from './InterruptFrom.js'
@@ -2815,6 +2815,29 @@ describe('Task interruption finalization', () => {
     assert.ok(result.arg instanceof AggregateError)
     assert.equal(result.arg.message, 'Resource release failed')
     assert.deepEqual(result.arg.errors, [innerFailure, scopeFailure])
+  })
+
+  it('aggregates multiple interrupted wrapped iterator cleanup failures', async () => {
+    const TestScope = scope('test/Fork/InterruptedMultipleInnerCleanupFailures')
+    const firstFailure = new Error('first release failed')
+    const secondFailure = new Error('second release failed')
+
+    const slow = awaitAbort().pipe(
+      finalizing(fail(firstFailure)),
+      finalizing(fail(secondFailure))
+    )
+
+    const result = await race([ok('winner'), slow]).pipe(
+      withScope(TestScope),
+      withUnboundedConcurrency,
+      returnFail,
+      runPromise
+    )
+
+    assert.ok(Fail.is(result))
+    assert.ok(result.arg instanceof AggregateError)
+    assert.equal(result.arg.message, 'Resource release failed')
+    assert.deepEqual(result.arg.errors, [firstFailure, secondFailure])
   })
 
   it('aggregates interrupted scoped cleanup failure with synchronous iterator return throw', async () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -10,7 +10,7 @@ import { InterruptFrom } from './InterruptFrom.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { Fork } from './internal/concurrent/effects.js'
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
-import { drainExitRegionReturn, type ExitRegionExit, type ExitRegionWithCleanupExit } from './internal/exitRegion.js'
+import { drainExitRegionReturn, isExitRegionSuccess, type ExitRegionExit, type ExitRegionStep, type ExitRegionWithCleanupExit } from './internal/exitRegion.js'
 import { isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
@@ -252,85 +252,90 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
       }
       return finalExit.value as A
     }
-    const step = function* (ir: IteratorResult<unknown, A>): Generator<unknown, A, unknown> {
-      while (!ir.done) {
-        if (isEffect(ir.value)) {
-          const effect = ir.value
-          const effectScope = (effect as { readonly scope?: AnyScope }).scope
-          const matchesScope = effectScope !== undefined && sameScope(effectScope, scope)
-          const matchesLifetimeScope = matchesScope || (effectScope !== undefined && sameScope(effectScope, currentScope))
+    const continueWith = (value: unknown): ExitRegionStep<A> => ({ type: 'continue', value })
+    const doneWith = (value: A): ExitRegionStep<A> => ({ type: 'done', value })
+    const step = function* (effect: unknown): Generator<unknown, ExitRegionStep<A>, unknown> {
+      if (!isEffect(effect)) {
+        throw new Error(`Unexpected non-Effect value yielded ${String(effect)}`)
+      }
 
-          if (matchesLifetimeScope && Finally.is(effect)) {
-            controller.addFinalizer(effect.arg)
-            ir = i.next(undefined)
-          } else if (matchesLifetimeScope && ScopedFork.is(effect)) {
-            const context = yield* new ScopedHandlerCapture(rootHandlerCaptureTarget)
-            const task = yield* controller.fork({
-              ...effect.arg,
-              fx: withHandlerContext([capturedShared, ...(context as readonly CapturedHandler[])], effect.arg.fx)
-            })
-            ir = i.next(task)
-          } else if (matchesScope && ReturnFrom.is(effect)) {
-            const exit = { type: 'returnFrom', scope, value: effect.arg } satisfies Exit<Scope>
-            if (!root) {
-              controller.requestExit(exit)
-              return effect.arg as A
-            }
-            return yield* finishRoot(exit)
-          } else if (matchesScope && Abort.is(effect)) {
-            const exit = { type: 'abort', scope } satisfies Exit<Scope>
-            if (!root) {
-              controller.requestExit(exit)
-              return undefined as A
-            }
-            return yield* finishRoot(exit, effect)
-          } else if (matchesLifetimeScope && InterruptFrom.is(effect)) {
-            const exit = interruptedExit(scope, effect.arg)
-            const interrupt = matchesScope ? effect : new InterruptFrom(scope, effect.arg)
-            if (!root) {
-              controller.requestExit(exit)
-              return undefined as A
-            }
-            return yield* finishRoot(exit, interrupt)
-          } else if (Fail.is(effect)) {
-            const exit = { type: 'failure', failure: effect } satisfies Exit
-            if (!root) {
-              return (yield effect) as A
-            }
-            return yield* finishRoot(exit)
-          } else if (ScopedHandlerCapture.is(effect)) {
-            const target = effect.arg
-            if (target.type === 'root') {
-              ir = i.next([capturedShared, ...(yield effect) as any])
-            } else if (target.type === 'nearestScope' || sameScope(target.scope, scope)) {
-              ir = i.next([capturedShared, ...(yield new ScopedHandlerCapture(rootHandlerCaptureTarget)) as any])
-            } else {
-              ir = i.next(yield effect as any)
-            }
-          } else if (HandlerCapture.is(effect)) {
-            const local = effect.arg === 'fx/Concurrent/ForkIn' ? capturedShared : captured
-            ir = i.next([local, ...(yield effect) as any])
-          } else {
-            const result = yield effect
-            if (result instanceof RuntimeScopeExit) {
-              if (sameScope(result.scope, scope)) {
-                const exit = result.exit as Exit<Scope>
-                const cleanup = exit.type === 'failure' ? undefined : yield* returnFail(fx(function* () {
-                  return yield* drainScopeInterruptedReturn(i, step)
-                }))
-                const failures = cleanup !== undefined && Fail.is(cleanup) ? cleanupFailuresOf(cleanup.arg) : []
-                return yield* finishRoot(exit, undefined, failures)
-              }
-              const { failures } = yield* release(interruptedExit(scope, result.reason))
-              const cleanupFailures = failures.flatMap(cleanupFailuresOf)
-              if (cleanupFailures.length > 0) return (yield* withMaybeActiveScope(failCleanup(cleanupFailures))) as A
-              return yield* propagateRuntimeScopeExit(result)
-            }
-            ir = i.next(result)
-          }
-        } else {
-          throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
+      const effectScope = (effect as { readonly scope?: AnyScope }).scope
+      const matchesScope = effectScope !== undefined && sameScope(effectScope, scope)
+      const matchesLifetimeScope = matchesScope || (effectScope !== undefined && sameScope(effectScope, currentScope))
+
+      if (matchesLifetimeScope && Finally.is(effect)) {
+        controller.addFinalizer(effect.arg)
+        return continueWith(undefined)
+      } else if (matchesLifetimeScope && ScopedFork.is(effect)) {
+        const context = yield* new ScopedHandlerCapture(rootHandlerCaptureTarget)
+        const task = yield* controller.fork({
+          ...effect.arg,
+          fx: withHandlerContext([capturedShared, ...(context as readonly CapturedHandler[])], effect.arg.fx)
+        })
+        return continueWith(task)
+      } else if (matchesScope && ReturnFrom.is(effect)) {
+        const exit = { type: 'returnFrom', scope, value: effect.arg } satisfies Exit<Scope>
+        if (!root) {
+          controller.requestExit(exit)
+          return doneWith(effect.arg as A)
         }
+        return doneWith(yield* finishRoot(exit))
+      } else if (matchesScope && Abort.is(effect)) {
+        const exit = { type: 'abort', scope } satisfies Exit<Scope>
+        if (!root) {
+          controller.requestExit(exit)
+          return doneWith(undefined as A)
+        }
+        return doneWith(yield* finishRoot(exit, effect))
+      } else if (matchesLifetimeScope && InterruptFrom.is(effect)) {
+        const exit = interruptedExit(scope, effect.arg)
+        const interrupt = matchesScope ? effect : new InterruptFrom(scope, effect.arg)
+        if (!root) {
+          controller.requestExit(exit)
+          return doneWith(undefined as A)
+        }
+        return doneWith(yield* finishRoot(exit, interrupt))
+      } else if (Fail.is(effect)) {
+        const exit = { type: 'failure', failure: effect } satisfies Exit
+        if (!root) {
+          return doneWith((yield effect) as A)
+        }
+        return doneWith(yield* finishRoot(exit))
+      } else if (ScopedHandlerCapture.is(effect)) {
+        const target = effect.arg
+        if (target.type === 'root') {
+          return continueWith([capturedShared, ...(yield effect) as any])
+        } else if (target.type === 'nearestScope' || sameScope(target.scope, scope)) {
+          return continueWith([capturedShared, ...(yield new ScopedHandlerCapture(rootHandlerCaptureTarget)) as any])
+        }
+        return continueWith(yield effect as any)
+      } else if (HandlerCapture.is(effect)) {
+        const local = effect.arg === 'fx/Concurrent/ForkIn' ? capturedShared : captured
+        return continueWith([local, ...(yield effect) as any])
+      }
+
+      const result = yield effect
+      if (result instanceof RuntimeScopeExit) {
+        if (sameScope(result.scope, scope)) {
+          const exit = result.exit as Exit<Scope>
+          const cleanup = exit.type === 'failure' ? undefined : yield* returnFail(fx(function* () {
+            return yield* drainScopeInterruptedReturn(i, step)
+          }))
+          const failures = cleanup !== undefined && Fail.is(cleanup) ? cleanupFailuresOf(cleanup.arg) : []
+          return doneWith(yield* finishRoot(exit, undefined, failures))
+        }
+        const { failures } = yield* release(interruptedExit(scope, result.reason))
+        const cleanupFailures = failures.flatMap(cleanupFailuresOf)
+        if (cleanupFailures.length > 0) return doneWith((yield* withMaybeActiveScope(failCleanup(cleanupFailures))) as A)
+        return doneWith(yield* propagateRuntimeScopeExit(result))
+      }
+      return continueWith(result)
+    }
+    const run = function* (ir: IteratorResult<unknown, A>): Generator<unknown, A, unknown> {
+      while (!ir.done) {
+        const result = yield* step(ir.value)
+        if (result.type === 'done') return result.value
+        ir = i.next(result.value)
       }
 
       const exit = { type: 'success', value: ir.value } satisfies Exit<Scope, A>
@@ -340,7 +345,7 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
 
     let completed = false
     try {
-      const value = yield* step(i.next())
+      const value = yield* run(i.next())
       completed = true
       return value
     } finally {
@@ -509,7 +514,7 @@ const collectInterruptedCleanupFailures = function* <A, Scope extends AnyScope>(
   completed: boolean,
   shouldDrainReturn: boolean,
   iterator: Iterator<unknown, A, unknown>,
-  step: (ir: IteratorResult<unknown, A>) => Generator<unknown, A, unknown>
+  step: (effect: unknown) => Generator<unknown, ExitRegionStep<A>, unknown>
 ): Generator<unknown, readonly unknown[], unknown> {
   const failures = [] as unknown[]
   const exit = interruptedExit(scope, interruptionReason())
@@ -534,7 +539,7 @@ const collectInterruptedChildCleanupFailures = function* <A>(
   completed: boolean,
   shouldDrainReturn: boolean,
   iterator: Iterator<unknown, A, unknown>,
-  step: (ir: IteratorResult<unknown, A>) => Generator<unknown, A, unknown>
+  step: (effect: unknown) => Generator<unknown, ExitRegionStep<A>, unknown>
 ): Generator<unknown, readonly unknown[], unknown> {
   const failures = [] as unknown[]
 
@@ -557,20 +562,23 @@ const interruptedExit = <Scope extends AnyScope>(scope: Scope, reason: unknown):
 
 const drainScopeInterruptedReturn = function* <A>(
   iterator: Iterator<unknown, A, unknown>,
-  step: (ir: IteratorResult<unknown, A>) => Generator<unknown, A, unknown>
+  step: (effect: unknown) => Generator<unknown, ExitRegionStep<A>, unknown>
 ): Generator<unknown, A | Fail<unknown> | undefined, unknown> {
-  const result = yield* drainExitRegionReturn(iterator, step, {
-    classify: effect => Fail.is(effect) ? effect : undefined
+  const result = yield* drainExitRegionReturn(iterator, {
+    classify: effect => Fail.is(effect) ? effect : undefined,
+    step
   })
   return cleanupFailureOf(result)
 }
 
 const cleanupFailureOf = <A>(
-  result: A | ExitRegionExit<Fail<unknown>> | undefined
+  result: ExitRegionExit<Fail<unknown>> | { readonly type: 'success', readonly value: A } | undefined
 ): A | Fail<unknown> | undefined =>
-    Fail.is(result)
-      ? result
-      : isExitRegionWithCleanupExit(result) ? result.primary : result
+    result === undefined
+      ? undefined
+      : isExitRegionSuccess(result) ? result.value
+      : Fail.is(result) ? result
+        : isExitRegionWithCleanupExit(result) ? result.primary : result
 
 const isExitRegionWithCleanupExit = (
   result: unknown

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -10,7 +10,8 @@ import { InterruptFrom } from './InterruptFrom.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { Fork } from './internal/concurrent/effects.js'
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
-import { drainIteratorReturn, isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
+import { drainExitRegionReturn } from './internal/exitRegion.js'
+import { isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
 import { ScopeTypeId, sameScope, scopeId, type ScopeIdentity } from './internal/scopeIdentity.js'
@@ -315,7 +316,7 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
               if (sameScope(result.scope, scope)) {
                 const exit = result.exit as Exit<Scope>
                 const cleanup = exit.type === 'failure' ? undefined : yield* returnFail(fx(function* () {
-                  return yield* drainIteratorReturn(i, step)
+                  return yield* drainScopeInterruptedReturn(i, step)
                 }))
                 const failures = cleanup !== undefined && Fail.is(cleanup) ? cleanupFailuresOf(cleanup.arg) : []
                 return yield* finishRoot(exit, undefined, failures)
@@ -520,7 +521,7 @@ const collectInterruptedCleanupFailures = function* <A, Scope extends AnyScope>(
   if (!completed && shouldDrainReturn) {
     yield* collectCleanupFailures(failures, function* () {
       const result = yield* returnFail(fx(function* () {
-        return yield* drainIteratorReturn(iterator, step)
+        return yield* drainScopeInterruptedReturn(iterator, step)
       }))
       if (Fail.is(result)) failures.push(result.arg)
     })
@@ -540,7 +541,7 @@ const collectInterruptedChildCleanupFailures = function* <A>(
   if (!completed && shouldDrainReturn) {
     yield* collectCleanupFailures(failures, function* () {
       const result = yield* returnFail(fx(function* () {
-        return yield* drainIteratorReturn(iterator, step)
+        return yield* drainScopeInterruptedReturn(iterator, step)
       }))
       if (Fail.is(result)) failures.push(result.arg)
     })
@@ -553,6 +554,16 @@ const interruptedExit = <Scope extends AnyScope>(scope: Scope, reason: unknown):
   reason === undefined
     ? { type: 'interrupted', scope }
     : { type: 'interrupted', scope, reason }
+
+const drainScopeInterruptedReturn = function* <A>(
+  iterator: Iterator<unknown, A, unknown>,
+  step: (ir: IteratorResult<unknown, A>) => Generator<unknown, A, unknown>
+): Generator<unknown, A | Fail<unknown> | undefined, unknown> {
+  return yield* drainExitRegionReturn(iterator, step, {
+    classify: effect => Fail.is(effect) ? effect : undefined,
+    keepExit: (current, next) => current ?? next
+  })
+}
 
 const propagateRuntimeScopeExit = function* <A>(result: RuntimeScopeExit): Generator<unknown, A> {
   const exit = result.exit as Exit<AnyScope>

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -10,7 +10,7 @@ import { InterruptFrom } from './InterruptFrom.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { Fork } from './internal/concurrent/effects.js'
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
-import { drainExitRegionReturn, isExitRegionSuccess, type ExitRegionExit, type ExitRegionStep } from './internal/exitRegion.js'
+import { drainExitRegionReturn, isExitRegionSuccess, type CapturedExit, type ExitRegionStep } from './internal/exitRegion.js'
 import { isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
@@ -576,7 +576,7 @@ const drainScopeInterruptedReturn = function* <A>(
 }
 
 const cleanupFailuresOfExitRegion = <A>(
-  result: ExitRegionExit<Fail<unknown>> | { readonly type: 'success', readonly value: A } | undefined
+  result: CapturedExit<Fail<unknown>> | { readonly type: 'success', readonly value: A } | undefined
 ): readonly unknown[] =>
     result === undefined
       ? []

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -10,7 +10,7 @@ import { InterruptFrom } from './InterruptFrom.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { Fork } from './internal/concurrent/effects.js'
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
-import { drainExitRegionReturn, isExitRegionSuccess, type ExitRegionExit, type ExitRegionStep, type ExitRegionWithCleanupExit } from './internal/exitRegion.js'
+import { drainExitRegionReturn, isExitRegionSuccess, type ExitRegionExit, type ExitRegionStep } from './internal/exitRegion.js'
 import { isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
@@ -321,7 +321,9 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
           const cleanup = exit.type === 'failure' ? undefined : yield* returnFail(fx(function* () {
             return yield* drainScopeInterruptedReturn(i, step)
           }))
-          const failures = cleanup !== undefined && Fail.is(cleanup) ? cleanupFailuresOf(cleanup.arg) : []
+          const failures = cleanup === undefined
+            ? []
+            : Fail.is(cleanup) ? cleanupFailuresOf(cleanup.arg) : cleanup
           return doneWith(yield* finishRoot(exit, undefined, failures))
         }
         const { failures } = yield* release(interruptedExit(scope, result.reason))
@@ -529,6 +531,7 @@ const collectInterruptedCleanupFailures = function* <A, Scope extends AnyScope>(
         return yield* drainScopeInterruptedReturn(iterator, step)
       }))
       if (Fail.is(result)) failures.push(result.arg)
+      else failures.push(...result)
     })
   }
 
@@ -549,6 +552,7 @@ const collectInterruptedChildCleanupFailures = function* <A>(
         return yield* drainScopeInterruptedReturn(iterator, step)
       }))
       if (Fail.is(result)) failures.push(result.arg)
+      else failures.push(...result)
     })
   }
 
@@ -563,30 +567,22 @@ const interruptedExit = <Scope extends AnyScope>(scope: Scope, reason: unknown):
 const drainScopeInterruptedReturn = function* <A>(
   iterator: Iterator<unknown, A, unknown>,
   step: (effect: unknown) => Generator<unknown, ExitRegionStep<A>, unknown>
-): Generator<unknown, A | Fail<unknown> | undefined, unknown> {
+): Generator<unknown, readonly unknown[], unknown> {
   const result = yield* drainExitRegionReturn(iterator, {
     classify: effect => Fail.is(effect) ? effect : undefined,
     step
   })
-  return cleanupFailureOf(result)
+  return cleanupFailuresOfExitRegion(result)
 }
 
-const cleanupFailureOf = <A>(
+const cleanupFailuresOfExitRegion = <A>(
   result: ExitRegionExit<Fail<unknown>> | { readonly type: 'success', readonly value: A } | undefined
-): A | Fail<unknown> | undefined =>
+): readonly unknown[] =>
     result === undefined
-      ? undefined
-      : isExitRegionSuccess(result) ? result.value
-      : Fail.is(result) ? result
-        : isExitRegionWithCleanupExit(result) ? result.primary : result
-
-const isExitRegionWithCleanupExit = (
-  result: unknown
-): result is ExitRegionWithCleanupExit<Fail<unknown>> =>
-  typeof result === 'object'
-  && result !== null
-  && 'type' in result
-  && result.type === 'withCleanupExit'
+      ? []
+      : isExitRegionSuccess(result) ? []
+      : Fail.is(result) ? [result.arg]
+        : [...cleanupFailuresOfExitRegion(result.primary), ...cleanupFailuresOfExitRegion(result.cleanup)]
 
 const propagateRuntimeScopeExit = function* <A>(result: RuntimeScopeExit): Generator<unknown, A> {
   const exit = result.exit as Exit<AnyScope>

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -10,7 +10,7 @@ import { InterruptFrom } from './InterruptFrom.js'
 import { ReturnFrom } from './ReturnFrom.js'
 import { Fork } from './internal/concurrent/effects.js'
 import { cooperativeAssertPromise } from './internal/concurrent/cooperativeAsync.js'
-import { drainExitRegionReturn } from './internal/exitRegion.js'
+import { drainExitRegionReturn, type ExitRegionExit, type ExitRegionWithCleanupExit } from './internal/exitRegion.js'
 import { isInterpretingReturn, isInterruptedReturn } from './internal/iteratorClose.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
@@ -559,11 +559,26 @@ const drainScopeInterruptedReturn = function* <A>(
   iterator: Iterator<unknown, A, unknown>,
   step: (ir: IteratorResult<unknown, A>) => Generator<unknown, A, unknown>
 ): Generator<unknown, A | Fail<unknown> | undefined, unknown> {
-  return yield* drainExitRegionReturn(iterator, step, {
-    classify: effect => Fail.is(effect) ? effect : undefined,
-    keepExit: (current, next) => current ?? next
+  const result = yield* drainExitRegionReturn(iterator, step, {
+    classify: effect => Fail.is(effect) ? effect : undefined
   })
+  return cleanupFailureOf(result)
 }
+
+const cleanupFailureOf = <A>(
+  result: A | ExitRegionExit<Fail<unknown>> | undefined
+): A | Fail<unknown> | undefined =>
+    Fail.is(result)
+      ? result
+      : isExitRegionWithCleanupExit(result) ? result.primary : result
+
+const isExitRegionWithCleanupExit = (
+  result: unknown
+): result is ExitRegionWithCleanupExit<Fail<unknown>> =>
+  typeof result === 'object'
+  && result !== null
+  && 'type' in result
+  && result.type === 'withCleanupExit'
 
 const propagateRuntimeScopeExit = function* <A>(result: RuntimeScopeExit): Generator<unknown, A> {
   const exit = result.exit as Exit<AnyScope>

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -493,6 +493,24 @@ describe('State', () => {
       assert.equal(state, 0)
     })
 
+    it('commits state for effective cleanup returnFrom after body returnFrom', () => {
+      const result = fx(function* () {
+        const returned = yield* fx(function* () {
+          yield* modifyState(CounterState, count => [count + 1, undefined])
+          return yield* returnFrom(ForkScope, 'body')
+        }).pipe(
+          finalizing(returnFrom(ForkScope, 'cleanup')),
+          transactionalState(CounterState),
+          withScope(ForkScope),
+          returnFail
+        )
+
+        return [returned, yield* getState(CounterState)] as const
+      }).pipe(withState(CounterState, 0), run)
+
+      assert.deepEqual(result, ['cleanup', 1])
+    })
+
     it('does not become the nearest current scope', () => {
       const events: string[] = []
 

--- a/src/State.ts
+++ b/src/State.ts
@@ -2,7 +2,7 @@ import { ScopedEffect } from './Effect.js'
 import { Fx, flatMap, fx, ok } from './Fx.js'
 import { handleScoped, type HandleScoped } from './Handler.js'
 import { AnyScope } from './Scope.js'
-import { returnExit, resumeExit } from './internal/returnExit.js'
+import { effectiveExit, returnExit, resumeExit } from './internal/returnExit.js'
 
 declare const StatefulTypeId: unique symbol
 
@@ -103,7 +103,8 @@ export const transactionalState = <const Scope extends AnyScope & Stateful<unkno
         })
       )
 
-      if (dirty && (exit.type === 'success' || exit.type === 'returnFrom')) {
+      const effective = effectiveExit(exit)
+      if (dirty && (effective.type === 'success' || effective.type === 'returnFrom')) {
         yield* modifyState(scope, () => [state, undefined])
       }
 

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -11,7 +11,7 @@ export type ExitRegionSuccess<A> = {
 export type ExitRegionWithCleanupExit<Exit> = {
   readonly type: 'withCleanupExit'
   readonly primary: Exit
-  readonly cleanup: Exit
+  readonly cleanup: ExitRegionExit<Exit>
 }
 
 export type ExitRegionExit<Exit> =
@@ -148,11 +148,10 @@ const mergeCleanupExit = <Exit>(
   next: ExitRegionExit<Exit>
 ): ExitRegionExit<Exit> => {
   if (current === undefined) return next
-  if (isExitRegionWithCleanupExit(current)) return current
-  if (isExitRegionWithCleanupExit(next)) return {
+  if (isExitRegionWithCleanupExit(current)) return {
     type: 'withCleanupExit',
-    primary: current,
-    cleanup: next.cleanup
+    primary: current.primary,
+    cleanup: mergeCleanupExit(current.cleanup, next)
   }
   return {
     type: 'withCleanupExit',

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -83,7 +83,7 @@ export function* drainExitRegionReturn<Y, A, Exit>(
     }
 
     const result = yield* options.step(ir.value)
-    if (result.type === 'done') return { type: 'success', value: result.value }
+    if (result.type === 'done') return exit ?? { type: 'success', value: result.value }
     ir = safeNext(result.value)
   }
 

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -8,26 +8,34 @@ export type ExitRegionSuccess<A> = {
   readonly value: A
 }
 
+export type ExitRegionWithCleanupExit<Exit> = {
+  readonly type: 'withCleanupExit'
+  readonly primary: Exit
+  readonly cleanup: Exit
+}
+
+export type ExitRegionExit<Exit> =
+  | Exit
+  | ExitRegionWithCleanupExit<Exit>
+
 export interface ExitRegionOptions<E, Exit> {
   classify(effect: E): Exit | undefined
-  resume(exit: Exit): Fx<E, never>
-  keepExit?(current: Exit | undefined, next: Exit): Exit
+  resume(exit: ExitRegionExit<Exit>): Fx<E, never>
   unavailableExitMessage?: string
 }
 
 export const exitRegion = <const E, const A, const Exit>(
   fx: Fx<E, A>,
   options: ExitRegionOptions<E, Exit>
-): Fx<E, ExitRegionSuccess<A> | Exit> =>
+): Fx<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> =>
   new ExitRegion(fx, options)
 
 export function* drainExitRegionReturn<Y, A, R, Exit>(
   iterator: Iterator<Y, A, unknown>,
   step: (ir: IteratorResult<Y, A>) => Generator<Y, R, unknown>,
-  options: Pick<ExitRegionOptions<Y, Exit>, 'classify' | 'keepExit'>
-): Generator<Y, R | Exit | undefined, unknown> {
+  options: Pick<ExitRegionOptions<Y, Exit>, 'classify'>
+): Generator<Y, R | ExitRegionExit<Exit> | undefined, unknown> {
   let exit: Exit | undefined
-  const keepExit = options.keepExit ?? ((_current: Exit | undefined, next: Exit) => next)
 
   const safeNext = (a: unknown): IteratorResult<Y, A> | undefined => {
     try {
@@ -62,7 +70,7 @@ export function* drainExitRegionReturn<Y, A, R, Exit>(
 
     const cleanupExit = options.classify(ir.value)
     if (cleanupExit !== undefined) {
-      exit = keepExit(exit, cleanupExit)
+      exit ??= cleanupExit
       ir = safeInterruptReturn()
       continue
     }
@@ -73,7 +81,7 @@ export function* drainExitRegionReturn<Y, A, R, Exit>(
   return exit ?? (ir === undefined ? undefined : yield* step(ir))
 }
 
-class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | Exit>, Pipeable {
+class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>>, Pipeable {
   public readonly pipe = pipeThis as Pipeable['pipe']
 
   constructor(
@@ -81,22 +89,19 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | Exit>, Pipe
     public readonly options: ExitRegionOptions<E, Exit>
   ) { }
 
-  *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | Exit> {
+  *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> {
     const i = this.fx[Symbol.iterator]()
     const classify = (effect: E): Exit | undefined => this.options.classify(effect)
-    const resume = (exit: Exit): Fx<E, never> => this.options.resume(exit)
-    const keepExit = (current: Exit | undefined, next: Exit): Exit =>
-      this.options.keepExit?.(current, next) ?? next
-    let exit: Exit | undefined
+    const resume = (exit: ExitRegionExit<Exit>): Fx<E, never> => this.options.resume(exit)
+    let exit: ExitRegionExit<Exit> | undefined
 
     const close = function* (): Generator<E, void, unknown> {
       const closeExit = yield* drainExitRegionReturn<E, A, undefined, Exit>(i, function* () {
         return undefined
       }, {
-        classify,
-        keepExit
+        classify
       })
-      if (closeExit !== undefined) exit = keepExit(exit, closeExit)
+      if (closeExit !== undefined) exit = mergeCleanupExit(exit, closeExit)
     }
 
     let completed = false
@@ -109,7 +114,7 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | Exit>, Pipe
 
         const nextExit = classify(ir.value)
         if (nextExit !== undefined) {
-          exit = keepExit(exit, nextExit)
+          exit = mergeCleanupExit(exit, nextExit)
           yield* close()
           if (exit === undefined) {
             throw new Error(this.options.unavailableExitMessage ?? 'Exit unavailable after closing interrupted region')
@@ -131,3 +136,29 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | Exit>, Pipe
     }
   }
 }
+
+const mergeCleanupExit = <Exit>(
+  current: ExitRegionExit<Exit> | undefined,
+  next: ExitRegionExit<Exit>
+): ExitRegionExit<Exit> => {
+  if (current === undefined) return next
+  if (isExitRegionWithCleanupExit(current)) return current
+  if (isExitRegionWithCleanupExit(next)) return {
+    type: 'withCleanupExit',
+    primary: current,
+    cleanup: next.cleanup
+  }
+  return {
+    type: 'withCleanupExit',
+    primary: current,
+    cleanup: next
+  }
+}
+
+const isExitRegionWithCleanupExit = <Exit>(
+  exit: ExitRegionExit<Exit>
+): exit is ExitRegionWithCleanupExit<Exit> =>
+  typeof exit === 'object'
+  && exit !== null
+  && 'type' in exit
+  && exit.type === 'withCleanupExit'

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -42,7 +42,7 @@ export function* drainExitRegionReturn<Y, A, Exit>(
   iterator: Iterator<Y, A, unknown>,
   options: Pick<ExitRegionOptions<Y, A, Exit>, 'classify' | 'step'>
 ): Generator<Y, ExitRegionResult<A, Exit> | undefined, unknown> {
-  let exit: Exit | undefined
+  let exit: ExitRegionExit<Exit> | undefined
 
   const safeNext = (a: unknown): IteratorResult<Y, A> | undefined => {
     try {
@@ -77,7 +77,7 @@ export function* drainExitRegionReturn<Y, A, Exit>(
 
     const cleanupExit = options.classify(ir.value)
     if (cleanupExit !== undefined) {
-      exit ??= cleanupExit
+      exit = mergeCleanupExit(exit, cleanupExit)
       ir = safeInterruptReturn()
       continue
     }

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -18,22 +18,30 @@ export type ExitRegionExit<Exit> =
   | Exit
   | ExitRegionWithCleanupExit<Exit>
 
-export interface ExitRegionOptions<E, Exit> {
+export type ExitRegionResult<A, Exit> =
+  | ExitRegionSuccess<A>
+  | ExitRegionExit<Exit>
+
+export type ExitRegionStep<A> =
+  | { readonly type: 'continue', readonly value: unknown }
+  | { readonly type: 'done', readonly value: A }
+
+export interface ExitRegionOptions<E, A, Exit> {
   classify(effect: E): Exit | undefined
+  step(effect: E): Generator<E, ExitRegionStep<A>, unknown>
   resume(exit: ExitRegionExit<Exit>): Fx<E, never>
 }
 
 export const exitRegion = <const E, const A, const Exit>(
   fx: Fx<E, A>,
-  options: ExitRegionOptions<E, Exit>
+  options: ExitRegionOptions<E, A, Exit>
 ): Fx<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> =>
   new ExitRegion(fx, options)
 
-export function* drainExitRegionReturn<Y, A, R, Exit>(
+export function* drainExitRegionReturn<Y, A, Exit>(
   iterator: Iterator<Y, A, unknown>,
-  step: (ir: IteratorResult<Y, A>) => Generator<Y, R, unknown>,
-  options: Pick<ExitRegionOptions<Y, Exit>, 'classify'>
-): Generator<Y, R | ExitRegionExit<Exit> | undefined, unknown> {
+  options: Pick<ExitRegionOptions<Y, A, Exit>, 'classify' | 'step'>
+): Generator<Y, ExitRegionResult<A, Exit> | undefined, unknown> {
   let exit: Exit | undefined
 
   const safeNext = (a: unknown): IteratorResult<Y, A> | undefined => {
@@ -74,10 +82,12 @@ export function* drainExitRegionReturn<Y, A, R, Exit>(
       continue
     }
 
-    ir = safeNext(yield ir.value as Y)
+    const result = yield* options.step(ir.value)
+    if (result.type === 'done') return { type: 'success', value: result.value }
+    ir = safeNext(result.value)
   }
 
-  return exit ?? (ir === undefined ? undefined : yield* step(ir))
+  return exit ?? (ir === undefined ? undefined : { type: 'success', value: ir.value })
 }
 
 class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>>, Pipeable {
@@ -85,7 +95,7 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
 
   constructor(
     public readonly fx: Fx<E, A>,
-    public readonly options: ExitRegionOptions<E, Exit>
+    public readonly options: ExitRegionOptions<E, A, Exit>
   ) { }
 
   *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> {
@@ -94,10 +104,8 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
     let exit: ExitRegionExit<Exit> | undefined
 
     const close = function* (): Generator<E, void, unknown> {
-      const closeExit = yield* drainExitRegionReturn<E, A, undefined, Exit>(i, function* () {
-        return undefined
-      }, options)
-      if (closeExit !== undefined) exit = mergeCleanupExit(exit, closeExit)
+      const closeExit = yield* drainExitRegionReturn<E, A, Exit>(i, options)
+      if (closeExit !== undefined && !isExitRegionSuccess(closeExit)) exit = mergeCleanupExit(exit, closeExit)
     }
 
     let completed = false
@@ -113,10 +121,15 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
           exit = mergeCleanupExit(exit, nextExit)
           yield* close()
           completed = true
-          return exit
+          return exit ?? nextExit
         }
 
-        ir = i.next(yield ir.value as E)
+        const result = yield* options.step(ir.value)
+        if (result.type === 'done') {
+          completed = true
+          return { type: 'success', value: result.value }
+        }
+        ir = i.next(result.value)
       }
 
       completed = true
@@ -155,3 +168,11 @@ const isExitRegionWithCleanupExit = <Exit>(
   && exit !== null
   && 'type' in exit
   && exit.type === 'withCleanupExit'
+
+export const isExitRegionSuccess = <A, Exit>(
+  result: ExitRegionResult<A, Exit>
+): result is ExitRegionSuccess<A> =>
+  typeof result === 'object'
+  && result !== null
+  && 'type' in result
+  && result.type === 'success'

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -163,15 +163,9 @@ const mergeCleanupExit = <Exit>(
 const isCapturedCleanupExit = <Exit>(
   exit: CapturedExit<Exit>
 ): exit is CapturedCleanupExit<Exit> =>
-  typeof exit === 'object'
-  && exit !== null
-  && 'type' in exit
-  && exit.type === 'withCleanupExit'
+  (exit as { readonly type?: unknown } | null | undefined)?.type === 'withCleanupExit'
 
 export const isExitRegionSuccess = <A, Exit>(
   result: ExitRegionResult<A, Exit>
 ): result is ExitRegionSuccess<A> =>
-  typeof result === 'object'
-  && result !== null
-  && 'type' in result
-  && result.type === 'success'
+  (result as { readonly type?: unknown } | null | undefined)?.type === 'success'

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -21,7 +21,6 @@ export type ExitRegionExit<Exit> =
 export interface ExitRegionOptions<E, Exit> {
   classify(effect: E): Exit | undefined
   resume(exit: ExitRegionExit<Exit>): Fx<E, never>
-  unavailableExitMessage?: string
 }
 
 export const exitRegion = <const E, const A, const Exit>(
@@ -116,9 +115,6 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
         if (nextExit !== undefined) {
           exit = mergeCleanupExit(exit, nextExit)
           yield* close()
-          if (exit === undefined) {
-            throw new Error(this.options.unavailableExitMessage ?? 'Exit unavailable after closing interrupted region')
-          }
           completed = true
           return exit
         }

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -90,16 +90,13 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
 
   *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> {
     const i = this.fx[Symbol.iterator]()
-    const classify = (effect: E): Exit | undefined => this.options.classify(effect)
-    const resume = (exit: ExitRegionExit<Exit>): Fx<E, never> => this.options.resume(exit)
+    const options = this.options
     let exit: ExitRegionExit<Exit> | undefined
 
     const close = function* (): Generator<E, void, unknown> {
       const closeExit = yield* drainExitRegionReturn<E, A, undefined, Exit>(i, function* () {
         return undefined
-      }, {
-        classify
-      })
+      }, options)
       if (closeExit !== undefined) exit = mergeCleanupExit(exit, closeExit)
     }
 
@@ -111,7 +108,7 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
           throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
         }
 
-        const nextExit = classify(ir.value)
+        const nextExit = options.classify(ir.value)
         if (nextExit !== undefined) {
           exit = mergeCleanupExit(exit, nextExit)
           yield* close()
@@ -127,7 +124,7 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
     } finally {
       if (!completed) {
         yield* close()
-        if (exit !== undefined) yield* resume(exit)
+        if (exit !== undefined) yield* options.resume(exit)
       }
     }
   }

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -8,19 +8,19 @@ export type ExitRegionSuccess<A> = {
   readonly value: A
 }
 
-export type ExitRegionWithCleanupExit<Exit> = {
+export type CapturedCleanupExit<Exit> = {
   readonly type: 'withCleanupExit'
   readonly primary: Exit
-  readonly cleanup: ExitRegionExit<Exit>
+  readonly cleanup: CapturedExit<Exit>
 }
 
-export type ExitRegionExit<Exit> =
+export type CapturedExit<Exit> =
   | Exit
-  | ExitRegionWithCleanupExit<Exit>
+  | CapturedCleanupExit<Exit>
 
 export type ExitRegionResult<A, Exit> =
   | ExitRegionSuccess<A>
-  | ExitRegionExit<Exit>
+  | CapturedExit<Exit>
 
 export type ExitRegionStep<A> =
   | { readonly type: 'continue', readonly value: unknown }
@@ -29,20 +29,20 @@ export type ExitRegionStep<A> =
 export interface ExitRegionOptions<E, A, Exit> {
   classify(effect: E): Exit | undefined
   step(effect: E): Generator<E, ExitRegionStep<A>, unknown>
-  resume(exit: ExitRegionExit<Exit>): Fx<E, never>
+  resume(exit: CapturedExit<Exit>): Fx<E, never>
 }
 
 export const exitRegion = <const E, const A, const Exit>(
   fx: Fx<E, A>,
   options: ExitRegionOptions<E, A, Exit>
-): Fx<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> =>
+): Fx<E, ExitRegionSuccess<A> | CapturedExit<Exit>> =>
   new ExitRegion(fx, options)
 
 export function* drainExitRegionReturn<Y, A, Exit>(
   iterator: Iterator<Y, A, unknown>,
   options: Pick<ExitRegionOptions<Y, A, Exit>, 'classify' | 'step'>
 ): Generator<Y, ExitRegionResult<A, Exit> | undefined, unknown> {
-  let exit: ExitRegionExit<Exit> | undefined
+  let exit: CapturedExit<Exit> | undefined
 
   const safeNext = (a: unknown): IteratorResult<Y, A> | undefined => {
     try {
@@ -90,7 +90,7 @@ export function* drainExitRegionReturn<Y, A, Exit>(
   return exit ?? (ir === undefined ? undefined : { type: 'success', value: ir.value })
 }
 
-class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>>, Pipeable {
+class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | CapturedExit<Exit>>, Pipeable {
   public readonly pipe = pipeThis as Pipeable['pipe']
 
   constructor(
@@ -98,10 +98,10 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
     public readonly options: ExitRegionOptions<E, A, Exit>
   ) { }
 
-  *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | ExitRegionExit<Exit>> {
+  *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | CapturedExit<Exit>> {
     const i = this.fx[Symbol.iterator]()
     const options = this.options
-    let exit: ExitRegionExit<Exit> | undefined
+    let exit: CapturedExit<Exit> | undefined
 
     const close = function* (): Generator<E, void, unknown> {
       const closeExit = yield* drainExitRegionReturn<E, A, Exit>(i, options)
@@ -144,11 +144,11 @@ class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | ExitRegionE
 }
 
 const mergeCleanupExit = <Exit>(
-  current: ExitRegionExit<Exit> | undefined,
-  next: ExitRegionExit<Exit>
-): ExitRegionExit<Exit> => {
+  current: CapturedExit<Exit> | undefined,
+  next: CapturedExit<Exit>
+): CapturedExit<Exit> => {
   if (current === undefined) return next
-  if (isExitRegionWithCleanupExit(current)) return {
+  if (isCapturedCleanupExit(current)) return {
     type: 'withCleanupExit',
     primary: current.primary,
     cleanup: mergeCleanupExit(current.cleanup, next)
@@ -160,9 +160,9 @@ const mergeCleanupExit = <Exit>(
   }
 }
 
-const isExitRegionWithCleanupExit = <Exit>(
-  exit: ExitRegionExit<Exit>
-): exit is ExitRegionWithCleanupExit<Exit> =>
+const isCapturedCleanupExit = <Exit>(
+  exit: CapturedExit<Exit>
+): exit is CapturedCleanupExit<Exit> =>
   typeof exit === 'object'
   && exit !== null
   && 'type' in exit

--- a/src/internal/exitRegion.ts
+++ b/src/internal/exitRegion.ts
@@ -1,0 +1,133 @@
+import { isEffect } from '../Effect.js'
+import { Fx } from '../Fx.js'
+import { InterruptedReturn, isInterruptedReturn } from './iteratorClose.js'
+import { Pipeable, pipeThis } from './pipe.js'
+
+export type ExitRegionSuccess<A> = {
+  readonly type: 'success'
+  readonly value: A
+}
+
+export interface ExitRegionOptions<E, Exit> {
+  classify(effect: E): Exit | undefined
+  resume(exit: Exit): Fx<E, never>
+  keepExit?(current: Exit | undefined, next: Exit): Exit
+  unavailableExitMessage?: string
+}
+
+export const exitRegion = <const E, const A, const Exit>(
+  fx: Fx<E, A>,
+  options: ExitRegionOptions<E, Exit>
+): Fx<E, ExitRegionSuccess<A> | Exit> =>
+  new ExitRegion(fx, options)
+
+export function* drainExitRegionReturn<Y, A, R, Exit>(
+  iterator: Iterator<Y, A, unknown>,
+  step: (ir: IteratorResult<Y, A>) => Generator<Y, R, unknown>,
+  options: Pick<ExitRegionOptions<Y, Exit>, 'classify' | 'keepExit'>
+): Generator<Y, R | Exit | undefined, unknown> {
+  let exit: Exit | undefined
+  const keepExit = options.keepExit ?? ((_current: Exit | undefined, next: Exit) => next)
+
+  const safeNext = (a: unknown): IteratorResult<Y, A> | undefined => {
+    try {
+      return iterator.next(a)
+    } catch (e) {
+      if (isInterruptedReturn(e)) return undefined
+      throw e
+    }
+  }
+  const safeReturn = (): IteratorResult<Y, A> | undefined => {
+    try {
+      return iterator.return?.()
+    } catch (e) {
+      if (isInterruptedReturn(e)) return undefined
+      throw e
+    }
+  }
+  const safeInterruptReturn = (): IteratorResult<Y, A> | undefined => {
+    try {
+      return iterator.throw?.(new InterruptedReturn()) ?? iterator.return?.()
+    } catch (e) {
+      if (isInterruptedReturn(e)) return undefined
+      throw e
+    }
+  }
+
+  let ir = safeReturn()
+  while (ir !== undefined && !ir.done) {
+    if (!isEffect(ir.value)) {
+      throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
+    }
+
+    const cleanupExit = options.classify(ir.value)
+    if (cleanupExit !== undefined) {
+      exit = keepExit(exit, cleanupExit)
+      ir = safeInterruptReturn()
+      continue
+    }
+
+    ir = safeNext(yield ir.value as Y)
+  }
+
+  return exit ?? (ir === undefined ? undefined : yield* step(ir))
+}
+
+class ExitRegion<E, A, Exit> implements Fx<E, ExitRegionSuccess<A> | Exit>, Pipeable {
+  public readonly pipe = pipeThis as Pipeable['pipe']
+
+  constructor(
+    public readonly fx: Fx<E, A>,
+    public readonly options: ExitRegionOptions<E, Exit>
+  ) { }
+
+  *[Symbol.iterator](): Iterator<E, ExitRegionSuccess<A> | Exit> {
+    const i = this.fx[Symbol.iterator]()
+    const classify = (effect: E): Exit | undefined => this.options.classify(effect)
+    const resume = (exit: Exit): Fx<E, never> => this.options.resume(exit)
+    const keepExit = (current: Exit | undefined, next: Exit): Exit =>
+      this.options.keepExit?.(current, next) ?? next
+    let exit: Exit | undefined
+
+    const close = function* (): Generator<E, void, unknown> {
+      const closeExit = yield* drainExitRegionReturn<E, A, undefined, Exit>(i, function* () {
+        return undefined
+      }, {
+        classify,
+        keepExit
+      })
+      if (closeExit !== undefined) exit = keepExit(exit, closeExit)
+    }
+
+    let completed = false
+    try {
+      let ir = i.next()
+      while (!ir.done) {
+        if (!isEffect(ir.value)) {
+          throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
+        }
+
+        const nextExit = classify(ir.value)
+        if (nextExit !== undefined) {
+          exit = keepExit(exit, nextExit)
+          yield* close()
+          if (exit === undefined) {
+            throw new Error(this.options.unavailableExitMessage ?? 'Exit unavailable after closing interrupted region')
+          }
+          completed = true
+          return exit
+        }
+
+        ir = i.next(yield ir.value as E)
+      }
+
+      completed = true
+      return { type: 'success', value: ir.value }
+    } finally {
+      if (!completed) {
+        yield* close()
+        if (exit !== undefined) yield* resume(exit)
+      }
+    }
+  }
+}

--- a/src/internal/returnExit.test.ts
+++ b/src/internal/returnExit.test.ts
@@ -8,9 +8,10 @@ import { fail, Fail } from '../Fail.js'
 import { finalizing, fx, ok, run, runTask } from '../Fx.js'
 import { handle } from '../Handler.js'
 import { interruptFrom } from '../InterruptFrom.js'
-import { returnFrom } from '../ReturnFrom.js'
+import { ReturnFrom, returnFrom } from '../ReturnFrom.js'
 import { scope, type Control } from '../Scope.js'
 import { getState, modifyState, withState, type Stateful } from '../State.js'
+import { drainExitRegionReturn } from './exitRegion.js'
 import { returnExit, resumeExit } from './returnExit.js'
 
 describe('returnExit', () => {
@@ -156,6 +157,31 @@ describe('returnExit', () => {
     assert.equal(exit.cleanup.effect.arg, cleanupFailure)
     assert.deepEqual(events, ['failing cleanup', 'state cleanup'])
     assert.equal(state, 1)
+  })
+
+  it('preserves a recorded cleanup exit when cleanup interpretation completes', () => {
+    const cleanupFailure = new Fail(new Error('cleanup failed'))
+    const cleanupReturn = returnFrom(ControlScope, 'cleanup')
+    let interrupted = false
+    const iterator: Iterator<Fail<Error> | typeof cleanupReturn, void, unknown> = {
+      next: () => ({ done: true, value: undefined }),
+      return: () => ({ done: false, value: cleanupFailure }),
+      throw: () => {
+        interrupted = true
+        return { done: false, value: cleanupReturn }
+      }
+    }
+
+    const result = drainExitRegionReturn(iterator, {
+      classify: effect => Fail.is(effect) ? effect : undefined,
+      step: function* (effect) {
+        assert.equal(ReturnFrom.is(effect), true)
+        return { type: 'done', value: undefined }
+      }
+    }).next()
+
+    assert.deepEqual(result, { done: true, value: cleanupFailure })
+    assert.equal(interrupted, true)
   })
 
   it('closes the wrapped iterator when interrupted on a forwarded effect', () => {

--- a/src/internal/returnExit.test.ts
+++ b/src/internal/returnExit.test.ts
@@ -128,6 +128,27 @@ describe('returnExit', () => {
     assert.equal(exit.cleanup.effect.arg, cleanupFailure)
   })
 
+  it('returns later cleanup failure after cleanup returnFrom', () => {
+    const cleanupFailure = new Error('cleanup failed')
+    const exit = returnFrom(ControlScope, 'body').pipe(
+      finalizing(returnFrom(ControlScope, 'cleanup')),
+      finalizing(fail(cleanupFailure)),
+      returnExit,
+      run
+    )
+
+    assert.equal(exit.type, 'withCleanupExit')
+    assert.equal(exit.primary.type, 'returnFrom')
+    assert.equal(exit.primary.effect.arg, 'body')
+    assert.equal(exit.cleanup.type, 'failure')
+    assert.equal(exit.cleanup.effect.arg, cleanupFailure)
+
+    const next = resumeExit(exit)[Symbol.iterator]().next()
+    assert.equal(next.done, false)
+    assert.ok(Fail.is(next.value))
+    assert.equal(next.value.arg, cleanupFailure)
+  })
+
   it('preserves body failure and keeps closing after cleanup failure', () => {
     const bodyFailure = new Error('body failed')
     const cleanupFailure = new Error('cleanup failed')

--- a/src/internal/returnExit.test.ts
+++ b/src/internal/returnExit.test.ts
@@ -112,7 +112,7 @@ describe('returnExit', () => {
     assert.equal(exit.effect.arg, cleanupFailure)
   })
 
-  it('returns cleanup failure after body returnFrom', () => {
+  it('returns body returnFrom with cleanup failure after body returnFrom', () => {
     const cleanupFailure = new Error('cleanup failed')
     const exit = returnFrom(ControlScope, 'returned').pipe(
       finalizing(fail(cleanupFailure)),
@@ -120,8 +120,11 @@ describe('returnExit', () => {
       run
     )
 
-    assert.equal(exit.type, 'failure')
-    assert.equal(exit.effect.arg, cleanupFailure)
+    assert.equal(exit.type, 'withCleanupExit')
+    assert.equal(exit.primary.type, 'returnFrom')
+    assert.equal(exit.primary.effect.arg, 'returned')
+    assert.equal(exit.cleanup.type, 'failure')
+    assert.equal(exit.cleanup.effect.arg, cleanupFailure)
   })
 
   it('preserves body failure and keeps closing after cleanup failure', () => {
@@ -146,8 +149,11 @@ describe('returnExit', () => {
       return [exit, yield* getState(StateScope)] as const
     }).pipe(withState(StateScope, 0), run)
 
-    assert.equal(exit.type, 'failure')
-    assert.equal(exit.effect.arg, bodyFailure)
+    assert.equal(exit.type, 'withCleanupExit')
+    assert.equal(exit.primary.type, 'failure')
+    assert.equal(exit.primary.effect.arg, bodyFailure)
+    assert.equal(exit.cleanup.type, 'failure')
+    assert.equal(exit.cleanup.effect.arg, cleanupFailure)
     assert.deepEqual(events, ['failing cleanup', 'state cleanup'])
     assert.equal(state, 1)
   })

--- a/src/internal/returnExit.test.ts
+++ b/src/internal/returnExit.test.ts
@@ -140,8 +140,11 @@ describe('returnExit', () => {
     assert.equal(exit.type, 'withCleanupExit')
     assert.equal(exit.primary.type, 'returnFrom')
     assert.equal(exit.primary.effect.arg, 'body')
-    assert.equal(exit.cleanup.type, 'failure')
-    assert.equal(exit.cleanup.effect.arg, cleanupFailure)
+    assert.equal(exit.cleanup.type, 'withCleanupExit')
+    assert.equal(exit.cleanup.primary.type, 'returnFrom')
+    assert.equal(exit.cleanup.primary.effect.arg, 'cleanup')
+    assert.equal(exit.cleanup.cleanup.type, 'failure')
+    assert.equal(exit.cleanup.cleanup.effect.arg, cleanupFailure)
 
     const next = resumeExit(exit)[Symbol.iterator]().next()
     assert.equal(next.done, false)

--- a/src/internal/returnExit.test.ts
+++ b/src/internal/returnExit.test.ts
@@ -5,7 +5,7 @@ import { assertPromise } from '../Async.js'
 import { abort } from '../Abort.js'
 import { Effect } from '../Effect.js'
 import { fail, Fail } from '../Fail.js'
-import { finalizing, fx, ok, run, runTask } from '../Fx.js'
+import { finalizing, fx, ok, run, runTask, type Fx } from '../Fx.js'
 import { handle } from '../Handler.js'
 import { interruptFrom } from '../InterruptFrom.js'
 import { ReturnFrom, returnFrom } from '../ReturnFrom.js'
@@ -35,6 +35,9 @@ describe('returnExit', () => {
     const next = resumeExit(exit)[Symbol.iterator]().next()
     assert.equal(next.done, false)
     assert.equal(next.value, failure)
+
+    const resumed: Fx<typeof failure, never> = resumeExit(exit)
+    void resumed
   })
 
   it('preserves and resumes the original ReturnFrom effect', () => {
@@ -150,6 +153,9 @@ describe('returnExit', () => {
     assert.equal(next.done, false)
     assert.ok(Fail.is(next.value))
     assert.equal(next.value.arg, cleanupFailure)
+
+    const resumed: Fx<Fail<Error> | ReturnFrom<typeof ControlScope, string>, never> = resumeExit(exit)
+    void resumed
   })
 
   it('preserves body failure and keeps closing after cleanup failure', () => {

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -69,6 +69,9 @@ export const effectiveExit = <const A, const E extends ExitEffect>(
 export function resumeExit<const A>(
   exit: { readonly type: 'success', readonly value: A }
 ): Fx<never, A>
+export function resumeExit<const E extends ExitEffect>(
+  exit: NonSuccessExit<E> | WithCleanupExit<E>
+): Fx<E, never>
 export function resumeExit<const A, const E extends ExitEffect>(
   exit: ResumableExit<A, E>
 ): Fx<E, A>

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -38,27 +38,12 @@ export type AbortExit<E extends Abort<AnyControlScope>> =
 export type InterruptedExit<E extends InterruptFrom<AnyScope, any>> =
   E extends never ? never : { readonly type: 'interrupted', readonly effect: E }
 
-type ResumableExitEffect<Exit> =
-  Exit extends {
-    readonly type: 'withCleanupExit',
-    readonly primary: infer Primary,
-    readonly cleanup: infer Cleanup
-  } ? ResumableExitEffect<Primary> | ResumableExitEffect<Cleanup>
-  : Exit extends { readonly type: 'success' } ? never
-  : Exit extends { readonly effect: infer E extends ExitEffect } ? E
-  : never
-
-type EffectiveExit<Exit> =
-  Exit extends {
-    readonly type: 'withCleanupExit',
-    readonly primary: infer Primary extends NonSuccessExit<any>,
-    readonly cleanup: infer Cleanup extends NonSuccessExit<any>
-  } ? Primary extends { readonly type: 'failure' } ? Primary : EffectiveExit<Cleanup>
-  : Exit
-
 type ExitOf<E, A> = ResumableExit<A, Extract<E, ExitEffect>>
 type NonSuccessExitOf<E> = NonSuccessExit<Extract<E, ExitEffect>>
 type ReturnExitEffects<E> = Exclude<E, ExitEffect>
+type EffectiveExit<A, E extends ExitEffect> =
+  | { readonly type: 'success', readonly value: A }
+  | NonSuccessExit<E>
 
 export const returnExit = <const E, const A>(
   f: Fx<E, A>
@@ -71,24 +56,31 @@ export const returnExit = <const E, const A>(
     resume: exit => resumeExit(exit) as Fx<E, never>
   }) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
 
-export const effectiveExit = <const Exit extends ResumableExit<any, any>>(
-  exit: Exit
-): EffectiveExit<Exit> => {
-  let current: ResumableExit<any, any> = exit
+export const effectiveExit = <const A, const E extends ExitEffect>(
+  exit: ResumableExit<A, E>
+): EffectiveExit<A, E> => {
+  let current: ResumableExit<A, E> = exit
   while (current.type === 'withCleanupExit') {
     current = current.primary.type === 'failure' ? current.primary : current.cleanup
   }
-  return current as EffectiveExit<Exit>
+  return current as EffectiveExit<A, E>
 }
 
-export const resumeExit = <const Exit extends ResumableExit<any, any>>(
-  exit: Exit
-): Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never> =>
-  fx(function* () {
+export function resumeExit<const A>(
+  exit: { readonly type: 'success', readonly value: A }
+): Fx<never, A>
+export function resumeExit<const A, const E extends ExitEffect>(
+  exit: ResumableExit<A, E>
+): Fx<E, A>
+export function resumeExit(
+  exit: ResumableExit<any, ExitEffect>
+): Fx<ExitEffect, any> {
+  return fx(function* () {
     const effective = effectiveExit(exit)
     if (effective.type === 'success') return effective.value
-    return (yield effective.effect) as never
-  }) as Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never>
+    return yield effective.effect
+  })
+}
 
 const toExit = <E>(effect: E): NonSuccessExitOf<E> | undefined => {
   if (Fail.is(effect)) return { type: 'failure', effect } as NonSuccessExitOf<E>

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -57,8 +57,7 @@ export const returnExit = <const E, const A>(
 ): Fx<ReturnExitEffects<E>, ExitOf<E, A>> =>
   exitRegion(f, {
     classify: toExit<E>,
-    resume: exit => resumeExit(exit) as Fx<E, never>,
-    unavailableExitMessage: 'Exit unavailable after closing interrupted region'
+    resume: exit => resumeExit(exit) as Fx<E, never>
   }) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
 
 export const resumeExit = <const Exit extends ResumableExit<any, any>>(

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -57,6 +57,9 @@ export const returnExit = <const E, const A>(
 ): Fx<ReturnExitEffects<E>, ExitOf<E, A>> =>
   exitRegion(f, {
     classify: toExit<E>,
+    step: function* (effect) {
+      return { type: 'continue', value: yield effect }
+    },
     resume: exit => resumeExit(exit) as Fx<E, never>
   }) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
 

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -4,7 +4,7 @@ import { Fx, fx } from '../Fx.js'
 import { InterruptFrom } from '../InterruptFrom.js'
 import { ReturnFrom } from '../ReturnFrom.js'
 import type { AnyControlScope, AnyScope } from '../Scope.js'
-import { exitRegion } from './exitRegion.js'
+import { exitRegion, type ExitRegionWithCleanupExit } from './exitRegion.js'
 
 type ExitEffect =
   | Fail<any>
@@ -14,10 +14,17 @@ type ExitEffect =
 
 export type ResumableExit<A, E extends ExitEffect = ExitEffect> =
   | { readonly type: 'success', readonly value: A }
+  | NonSuccessExit<E>
+  | WithCleanupExit<E>
+
+export type NonSuccessExit<E extends ExitEffect = ExitEffect> =
   | FailureExit<Extract<E, Fail<any>>>
   | ReturnFromExit<Extract<E, ReturnFrom<AnyControlScope, any>>>
   | AbortExit<Extract<E, Abort<AnyControlScope>>>
   | InterruptedExit<Extract<E, InterruptFrom<AnyScope, any>>>
+
+export type WithCleanupExit<E extends ExitEffect = ExitEffect> =
+  ExitRegionWithCleanupExit<NonSuccessExit<E>>
 
 export type FailureExit<E extends Fail<any>> =
   E extends never ? never : { readonly type: 'failure', readonly effect: E }
@@ -32,19 +39,25 @@ export type InterruptedExit<E extends InterruptFrom<AnyScope, any>> =
   E extends never ? never : { readonly type: 'interrupted', readonly effect: E }
 
 type ResumableExitEffect<Exit> =
-  Exit extends { readonly effect: infer E extends ExitEffect } ? E
+  Exit extends {
+    readonly type: 'withCleanupExit',
+    readonly primary: infer Primary,
+    readonly cleanup: infer Cleanup
+  } ? ResumableExitEffect<Primary> | ResumableExitEffect<Cleanup>
+  : Exit extends { readonly type: 'success' } ? never
+  : Exit extends { readonly effect: infer E extends ExitEffect } ? E
   : never
 
 type ExitOf<E, A> = ResumableExit<A, Extract<E, ExitEffect>>
+type NonSuccessExitOf<E> = NonSuccessExit<Extract<E, ExitEffect>>
 type ReturnExitEffects<E> = Exclude<E, ExitEffect>
 
 export const returnExit = <const E, const A>(
   f: Fx<E, A>
 ): Fx<ReturnExitEffects<E>, ExitOf<E, A>> =>
   exitRegion(f, {
-    classify: toExit<E, A>,
+    classify: toExit<E>,
     resume: exit => resumeExit(exit) as Fx<E, never>,
-    keepExit: (current, next) => current?.type === 'failure' ? current : next,
     unavailableExitMessage: 'Exit unavailable after closing interrupted region'
   }) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
 
@@ -53,13 +66,16 @@ export const resumeExit = <const Exit extends ResumableExit<any, any>>(
 ): Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never> =>
   fx(function* () {
     if (exit.type === 'success') return exit.value
+    if (exit.type === 'withCleanupExit') {
+      return yield* resumeExit(exit.primary.type === 'failure' ? exit.primary : exit.cleanup)
+    }
     return (yield exit.effect) as never
   }) as Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never>
 
-const toExit = <E, A>(effect: E): ExitOf<E, A> | undefined => {
-  if (Fail.is(effect)) return { type: 'failure', effect } as ExitOf<E, A>
-  if (ReturnFrom.is(effect)) return { type: 'returnFrom', effect } as ExitOf<E, A>
-  if (Abort.is(effect)) return { type: 'abort', effect } as ExitOf<E, A>
-  if (InterruptFrom.is(effect)) return { type: 'interrupted', effect } as ExitOf<E, A>
+const toExit = <E>(effect: E): NonSuccessExitOf<E> | undefined => {
+  if (Fail.is(effect)) return { type: 'failure', effect } as NonSuccessExitOf<E>
+  if (ReturnFrom.is(effect)) return { type: 'returnFrom', effect } as NonSuccessExitOf<E>
+  if (Abort.is(effect)) return { type: 'abort', effect } as NonSuccessExitOf<E>
+  if (InterruptFrom.is(effect)) return { type: 'interrupted', effect } as NonSuccessExitOf<E>
   return undefined
 }

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -1,12 +1,10 @@
 import { Abort } from '../Abort.js'
-import { isEffect } from '../Effect.js'
 import { Fail } from '../Fail.js'
 import { Fx, fx } from '../Fx.js'
 import { InterruptFrom } from '../InterruptFrom.js'
 import { ReturnFrom } from '../ReturnFrom.js'
 import type { AnyControlScope, AnyScope } from '../Scope.js'
-import { InterruptedReturn, isInterruptedReturn } from './iteratorClose.js'
-import { Pipeable, pipeThis } from './pipe.js'
+import { exitRegion } from './exitRegion.js'
 
 type ExitEffect =
   | Fail<any>
@@ -43,7 +41,12 @@ type ReturnExitEffects<E> = Exclude<E, ExitEffect>
 export const returnExit = <const E, const A>(
   f: Fx<E, A>
 ): Fx<ReturnExitEffects<E>, ExitOf<E, A>> =>
-  new ReturnExit(f) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
+  exitRegion(f, {
+    classify: toExit<E, A>,
+    resume: exit => resumeExit(exit) as Fx<E, never>,
+    keepExit: (current, next) => current?.type === 'failure' ? current : next,
+    unavailableExitMessage: 'Exit unavailable after closing interrupted region'
+  }) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
 
 export const resumeExit = <const Exit extends ResumableExit<any, any>>(
   exit: Exit
@@ -52,92 +55,6 @@ export const resumeExit = <const Exit extends ResumableExit<any, any>>(
     if (exit.type === 'success') return exit.value
     return (yield exit.effect) as never
   }) as Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never>
-
-class ReturnExit<E, A> implements Fx<E, ResumableExit<A>>, Pipeable {
-  public readonly pipe = pipeThis as Pipeable['pipe']
-
-  constructor(public readonly fx: Fx<E, A>) { }
-
-  *[Symbol.iterator](): Iterator<E, ResumableExit<A>> {
-    const i = this.fx[Symbol.iterator]()
-    let exit: ExitOf<E, A> | undefined
-
-    const safeNext = (a: unknown): IteratorResult<E, A> | undefined => {
-      try {
-        return i.next(a)
-      } catch (e) {
-        if (isInterruptedReturn(e)) return undefined
-        throw e
-      }
-    }
-    const safeReturn = (): IteratorResult<E, A> | undefined => {
-      try {
-        return i.return?.()
-      } catch (e) {
-        if (isInterruptedReturn(e)) return undefined
-        throw e
-      }
-    }
-    const safeInterruptReturn = (): IteratorResult<E, A> | undefined => {
-      try {
-        return i.throw?.(new InterruptedReturn()) ?? i.return?.()
-      } catch (e) {
-        if (isInterruptedReturn(e)) return undefined
-        throw e
-      }
-    }
-
-    const close = function* (): Generator<E, void, unknown> {
-      let ir = safeReturn()
-      while (ir !== undefined && !ir.done) {
-
-        if (!isEffect(ir.value)) {
-          throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
-        }
-
-        const cleanupExit = toExit<E, A>(ir.value)
-        if (cleanupExit !== undefined) {
-          if (exit?.type !== 'failure') exit = cleanupExit
-          ir = safeInterruptReturn()
-          continue
-        }
-
-        ir = safeNext(yield ir.value as E)
-      }
-    }
-
-    let completed = false
-    try {
-      let ir = i.next()
-      while (!ir.done) {
-        if (!isEffect(ir.value)) {
-          throw new Error(`Unexpected non-Effect value yielded ${String(ir.value)}`)
-        }
-
-        const nextExit = toExit<E, A>(ir.value)
-        if (nextExit !== undefined) {
-          exit = nextExit
-          yield* close()
-          if (exit === undefined) throw new Error('Exit unavailable after closing interrupted region')
-          completed = true
-          return exit
-        }
-
-        ir = i.next(yield ir.value as E)
-      }
-
-      completed = true
-      return { type: 'success', value: ir.value }
-    } finally {
-      if (!completed) {
-        yield* close()
-        // The captured exit effect was yielded by this iterator or its cleanup,
-        // but TypeScript cannot prove that through ResumableExitEffect.
-        if (exit !== undefined) yield* (resumeExit(exit) as Fx<E, never>)
-      }
-    }
-  }
-}
 
 const toExit = <E, A>(effect: E): ExitOf<E, A> | undefined => {
   if (Fail.is(effect)) return { type: 'failure', effect } as ExitOf<E, A>

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -48,6 +48,14 @@ type ResumableExitEffect<Exit> =
   : Exit extends { readonly effect: infer E extends ExitEffect } ? E
   : never
 
+type EffectiveExit<Exit> =
+  Exit extends {
+    readonly type: 'withCleanupExit',
+    readonly primary: infer Primary extends NonSuccessExit<any>,
+    readonly cleanup: infer Cleanup extends NonSuccessExit<any>
+  } ? Primary extends { readonly type: 'failure' } ? Primary : EffectiveExit<Cleanup>
+  : Exit
+
 type ExitOf<E, A> = ResumableExit<A, Extract<E, ExitEffect>>
 type NonSuccessExitOf<E> = NonSuccessExit<Extract<E, ExitEffect>>
 type ReturnExitEffects<E> = Exclude<E, ExitEffect>
@@ -63,15 +71,23 @@ export const returnExit = <const E, const A>(
     resume: exit => resumeExit(exit) as Fx<E, never>
   }) as Fx<ReturnExitEffects<E>, ExitOf<E, A>>
 
+export const effectiveExit = <const Exit extends ResumableExit<any, any>>(
+  exit: Exit
+): EffectiveExit<Exit> => {
+  let current: ResumableExit<any, any> = exit
+  while (current.type === 'withCleanupExit') {
+    current = current.primary.type === 'failure' ? current.primary : current.cleanup
+  }
+  return current as EffectiveExit<Exit>
+}
+
 export const resumeExit = <const Exit extends ResumableExit<any, any>>(
   exit: Exit
 ): Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never> =>
   fx(function* () {
-    if (exit.type === 'success') return exit.value
-    if (exit.type === 'withCleanupExit') {
-      return yield* resumeExit(exit.primary.type === 'failure' ? exit.primary : exit.cleanup)
-    }
-    return (yield exit.effect) as never
+    const effective = effectiveExit(exit)
+    if (effective.type === 'success') return effective.value
+    return (yield effective.effect) as never
   }) as Fx<ResumableExitEffect<Exit>, Exit extends { readonly type: 'success', readonly value: infer A } ? A : never>
 
 const toExit = <E>(effect: E): NonSuccessExitOf<E> | undefined => {

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -4,7 +4,7 @@ import { Fx, fx } from '../Fx.js'
 import { InterruptFrom } from '../InterruptFrom.js'
 import { ReturnFrom } from '../ReturnFrom.js'
 import type { AnyControlScope, AnyScope } from '../Scope.js'
-import { exitRegion, type ExitRegionWithCleanupExit } from './exitRegion.js'
+import { exitRegion, type CapturedCleanupExit } from './exitRegion.js'
 
 type ExitEffect =
   | Fail<any>
@@ -24,7 +24,7 @@ export type NonSuccessExit<E extends ExitEffect = ExitEffect> =
   | InterruptedExit<Extract<E, InterruptFrom<AnyScope, any>>>
 
 export type WithCleanupExit<E extends ExitEffect = ExitEffect> =
-  ExitRegionWithCleanupExit<NonSuccessExit<E>>
+  CapturedCleanupExit<NonSuccessExit<E>>
 
 export type FailureExit<E extends Fail<any>> =
   E extends never ? never : { readonly type: 'failure', readonly effect: E }


### PR DESCRIPTION
## Summary

- extracts the iterator close/drain machinery behind `returnExit` into a reusable internal `exitRegion` helper
- keeps `returnExit` / `resumeExit` as the public internal entrypoints while adding an internal `withCleanupExit` variant to represent primary-plus-cleanup exits explicitly
- removes the callback-style exit merge policy from the shared region helper
- routes Scope interrupted-return cleanup draining through the shared helper while keeping Scope ownership policy, controller behavior, runtime scope exits, handler capture, task joining, and cleanup aggregation in `Scope.ts`

## Notes

This is intended as a behavior-preserving prototype for effective resumption semantics. `returnExit` remains the generic exit-region use that classifies all `Fail`, `ReturnFrom`, `Abort`, and `InterruptFrom` exits. When cleanup exits after a primary exit, the region now preserves both as `withCleanupExit` instead of collapsing them through a `keepExit` option. `resumeExit` still resumes the effective exit so transactional state rollback behavior remains unchanged.

Scope keeps its own boundary-specific behavior and only shares the low-level iterator close/drain path.

## Validation

- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `node --import tsx --test src/internal/returnExit.test.ts`
- `node --import tsx --test src/Finalization.test.ts`
- `node --import tsx --test src/State.test.ts`
- `node --import tsx --test src/Concurrent.test.ts`
- `corepack pnpm test`
