### PR TITLE
[codex] Add exit-aware lexical cleanup

### DIFF
--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -11,7 +11,7 @@ import { isEffect } from './Effect.js'
 import * as generator from './internal/generator.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './internal/interrupt.js'
 import { Pipeable } from './internal/pipe.js'
-import { effectiveExit, returnExit, resumeExit, type ExitEffect, type ResumableExit } from './internal/returnExit.js'
+import { effectiveExit, returnExit, resumeExit, withCleanupExit, type ExitEffect, type ResumableExit } from './internal/returnExit.js'
 import { interruptionReason } from './internal/runtimeContext.js'
 import { RunForkOptions, runFork } from './internal/runFork.js'
 import { ScopedHandlerCapture } from './internal/scopedHandlerCapture.js'
@@ -236,8 +236,8 @@ export function bracket<const IE, const FE, const E, const R, const A>(
       exit = yield* returnExit(restore(f(r)))
       if (exit === undefined) return undefined as A
       released = true
-      yield* andFinally(r, toRegionExit(exit))
-      return yield* restore(resumeExit(exit))
+      const cleanup = yield* returnExit(andFinally(r, toRegionExit(exit)))
+      return yield* restore(resumeExit(withCleanupExit(exit, cleanup)))
     } finally {
       if (!released) yield* andFinally(r, exit === undefined ? interruptedExit() : toRegionExit(exit))
     }
@@ -279,8 +279,8 @@ export function finalizing<const FE>(
         exit = yield* returnExit(restore(program))
         if (exit === undefined) return undefined as A
         finalized = true
-        yield* finalize(finally_, toRegionExit(exit))
-        return yield* restore(resumeExit(exit))
+        const cleanup = yield* returnExit(finalize(finally_, toRegionExit(exit)))
+        return yield* restore(resumeExit(withCleanupExit(exit, cleanup)))
       } finally {
         if (!finalized) yield* finalize(finally_, exit === undefined ? interruptedExit() : toRegionExit(exit))
       }

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -217,17 +217,6 @@ export function bracket<const IE, const FE, const E, const R, const A>(
   andFinally: (a: R, exit: RegionExit) => Fx<FE, void>,
   f: (a: R) => Fx<E, A>
 ): Fx<IE | FE | E | Interrupt, A> {
-  if (andFinally.length < 2) {
-    return uninterruptibleMask(restore => fx(function* () {
-      const r = yield* initially
-      try {
-        return yield* restore(f(r))
-      } finally {
-        yield* (andFinally as (a: R) => Fx<FE, void>)(r)
-      }
-    }))
-  }
-
   return uninterruptibleMask(restore => fx(function* () {
     const r = yield* initially
     let exit: ResumableExit<A, Extract<E, ExitEffect>> | undefined

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -5,7 +5,7 @@ import { Fail, assert } from './Fail.js'
 import { HandlerCapture } from './HandlerCapture.js'
 import { uninterruptibleMask } from './Interrupt.js'
 import type { Interrupt } from './Interrupt.js'
-import { currentScope, type Exit } from './Scope.js'
+import type { RegionExit } from './Scope.js'
 import { Task } from './Task.js'
 import { isEffect } from './Effect.js'
 import * as generator from './internal/generator.js'
@@ -209,12 +209,12 @@ export function bracket<const IE, const FE, const E, const R, const A>(
  */
 export function bracket<const IE, const FE, const E, const R, const A>(
   initially: Fx<IE, R>,
-  andFinally: (a: R, exit: Exit) => Fx<FE, void>,
+  andFinally: (a: R, exit: RegionExit) => Fx<FE, void>,
   f: (a: R) => Fx<E, A>
 ): Fx<IE | FE | E | Interrupt, A>
 export function bracket<const IE, const FE, const E, const R, const A>(
   initially: Fx<IE, R>,
-  andFinally: (a: R, exit: Exit) => Fx<FE, void>,
+  andFinally: (a: R, exit: RegionExit) => Fx<FE, void>,
   f: (a: R) => Fx<E, A>
 ): Fx<IE | FE | E | Interrupt, A> {
   if (andFinally.length < 2) {
@@ -236,10 +236,10 @@ export function bracket<const IE, const FE, const E, const R, const A>(
       exit = yield* returnExit(restore(f(r)))
       if (exit === undefined) return undefined as A
       released = true
-      yield* andFinally(r, toExit(exit))
+      yield* andFinally(r, toRegionExit(exit))
       return yield* restore(resumeExit(exit))
     } finally {
-      if (!released) yield* andFinally(r, exit === undefined ? interruptedExit() : toExit(exit))
+      if (!released) yield* andFinally(r, exit === undefined ? interruptedExit() : toRegionExit(exit))
     }
   }))
 }
@@ -255,10 +255,10 @@ export function finalizing<const FE>(
  * The cleanup operation may inspect the lexical region's exit.
  */
 export function finalizing<const FE>(
-  finally_: (exit: Exit) => Fx<FE, void>
+  finally_: (exit: RegionExit) => Fx<FE, void>
 ): <const E, const A>(program: Fx<E, A>) => Fx<E | FE | Interrupt, A>
 export function finalizing<const FE>(
-  finally_: Fx<FE, void> | ((exit: Exit) => Fx<FE, void>)
+  finally_: Fx<FE, void> | ((exit: RegionExit) => Fx<FE, void>)
 ): <const E, const A>(program: Fx<E, A>) => Fx<E | FE | Interrupt, A> {
   if (typeof finally_ !== 'function') {
     return <const E, const A>(program: Fx<E, A>): Fx<E | FE | Interrupt, A> =>
@@ -279,21 +279,21 @@ export function finalizing<const FE>(
         exit = yield* returnExit(restore(program))
         if (exit === undefined) return undefined as A
         finalized = true
-        yield* finalize(finally_, toExit(exit))
+        yield* finalize(finally_, toRegionExit(exit))
         return yield* restore(resumeExit(exit))
       } finally {
-        if (!finalized) yield* finalize(finally_, exit === undefined ? interruptedExit() : toExit(exit))
+        if (!finalized) yield* finalize(finally_, exit === undefined ? interruptedExit() : toRegionExit(exit))
       }
     }))
 }
 
 const finalize = <const FE>(
-  finally_: Fx<FE, void> | ((exit: Exit) => Fx<FE, void>),
-  exit: Exit
+  finally_: Fx<FE, void> | ((exit: RegionExit) => Fx<FE, void>),
+  exit: RegionExit
 ): Fx<FE, void> =>
   typeof finally_ === 'function' ? finally_(exit) : finally_
 
-const toExit = <const A>(exit: ResumableExit<A>): Exit => {
+const toRegionExit = <const A>(exit: ResumableExit<A>): RegionExit => {
   const effective = effectiveExit(exit)
   switch (effective.type) {
     case 'success':
@@ -301,19 +301,19 @@ const toExit = <const A>(exit: ResumableExit<A>): Exit => {
     case 'failure':
       return { type: 'failure', failure: effective.effect }
     case 'returnFrom':
-      return { type: 'returnFrom', scope: effective.effect.scope, value: effective.effect.arg }
+      return { type: 'returnFrom', value: effective.effect.arg }
     case 'abort':
-      return { type: 'abort', scope: effective.effect.scope }
+      return { type: 'abort' }
     case 'interrupted':
       return effective.effect.arg === undefined
-        ? { type: 'interrupted', scope: effective.effect.scope }
-        : { type: 'interrupted', scope: effective.effect.scope, reason: effective.effect.arg }
+        ? { type: 'interrupted' }
+        : { type: 'interrupted', reason: effective.effect.arg }
   }
 }
 
-const interruptedExit = (): Exit => {
+const interruptedExit = (): RegionExit => {
   const reason = interruptionReason()
   return reason === undefined
-    ? { type: 'interrupted', scope: currentScope }
-    : { type: 'interrupted', scope: currentScope, reason }
+    ? { type: 'interrupted' }
+    : { type: 'interrupted', reason }
 }

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -274,23 +274,17 @@ export function finalizing<const FE>(
         if (exit === undefined) return undefined as A
         finalized = true
         if (isSuccessExit(exit)) {
-          yield* finalize(finally_, toRegionExit(exit))
+          yield* finally_(toRegionExit(exit))
           return exit.value
         }
-        const cleanup = yield* returnExit(finalize(finally_, toRegionExit(exit)))
+        const cleanup = yield* returnExit(finally_(toRegionExit(exit)))
         const combined: ResumableExit<A, Extract<E | FE, ExitEffect>> = withCleanupExit(exit, cleanup)
         return yield* restore(resumeExit(combined))
       } finally {
-        if (!finalized) yield* finalize(finally_, exit === undefined ? interruptedExit() : toRegionExit(exit))
+        if (!finalized) yield* finally_(exit === undefined ? interruptedExit() : toRegionExit(exit))
       }
     }))
 }
-
-const finalize = <const FE>(
-  finally_: Fx<FE, void> | ((exit: RegionExit) => Fx<FE, void>),
-  exit: RegionExit
-): Fx<FE, void> =>
-  typeof finally_ === 'function' ? finally_(exit) : finally_
 
 const isSuccessExit = <const A>(
   exit: ResumableExit<A>

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -5,11 +5,14 @@ import { Fail, assert } from './Fail.js'
 import { HandlerCapture } from './HandlerCapture.js'
 import { uninterruptibleMask } from './Interrupt.js'
 import type { Interrupt } from './Interrupt.js'
+import { currentScope, type Exit } from './Scope.js'
 import { Task } from './Task.js'
 import { isEffect } from './Effect.js'
 import * as generator from './internal/generator.js'
 import { InterruptMaskBegin, InterruptMaskEnd, InterruptMaskState } from './internal/interrupt.js'
 import { Pipeable } from './internal/pipe.js'
+import { effectiveExit, returnExit, resumeExit, type ExitEffect, type ResumableExit } from './internal/returnExit.js'
+import { interruptionReason } from './internal/runtimeContext.js'
 import { RunForkOptions, runFork } from './internal/runFork.js'
 import { ScopedHandlerCapture } from './internal/scopedHandlerCapture.js'
 import { TrySync } from './internal/sync.js'
@@ -190,33 +193,75 @@ export const run = <const R>(f: Fx<Interrupt, R>): R =>
     return ir.value as R
   })
 
+export function bracket<const IE, const FE, const E, const R, const A>(
+  initially: Fx<IE, R>,
+  andFinally: (a: R) => Fx<FE, void>,
+  f: (a: R) => Fx<E, A>
+): Fx<IE | FE | E | Interrupt, A>
 /**
  * Acquire a resource, use it, and release it even if use fails or is
  * interrupted.
  *
  * `bracket` is useful for local acquire/use/release flows. For named resource
  * scopes, prefer the helpers in `Finalization`.
+ *
+ * The release operation may inspect the lexical region's exit.
  */
-export const bracket = <const IE, const FE, const E, const R, const A>(
+export function bracket<const IE, const FE, const E, const R, const A>(
   initially: Fx<IE, R>,
-  andFinally: (a: R) => Fx<FE, void>,
+  andFinally: (a: R, exit: Exit) => Fx<FE, void>,
   f: (a: R) => Fx<E, A>
-) => uninterruptibleMask(restore => fx(function* () {
-  const r = yield* initially
-  try {
-    return yield* restore(f(r))
-  } finally {
-    yield* andFinally(r)
+): Fx<IE | FE | E | Interrupt, A>
+export function bracket<const IE, const FE, const E, const R, const A>(
+  initially: Fx<IE, R>,
+  andFinally: (a: R, exit: Exit) => Fx<FE, void>,
+  f: (a: R) => Fx<E, A>
+): Fx<IE | FE | E | Interrupt, A> {
+  if (andFinally.length < 2) {
+    return uninterruptibleMask(restore => fx(function* () {
+      const r = yield* initially
+      try {
+        return yield* restore(f(r))
+      } finally {
+        yield* (andFinally as (a: R) => Fx<FE, void>)(r)
+      }
+    }))
   }
-}))
+
+  return uninterruptibleMask(restore => fx(function* () {
+    const r = yield* initially
+    let exit: ResumableExit<A, Extract<E, ExitEffect>> | undefined
+    let released = false
+    try {
+      exit = yield* returnExit(restore(f(r)))
+      if (exit === undefined) return undefined as A
+      released = true
+      yield* andFinally(r, toExit(exit))
+      return yield* restore(resumeExit(exit))
+    } finally {
+      if (!released) yield* andFinally(r, exit === undefined ? interruptedExit() : toExit(exit))
+    }
+  }))
+}
+
+export function finalizing<const FE>(
+  finally_: Fx<FE, void>
+): <const E, const A>(program: Fx<E, A>) => Fx<E | FE | Interrupt, A>
 
 /**
  * Run cleanup when a lexical computation exits, without registering it with a
  * scope.
+ *
+ * The cleanup operation may inspect the lexical region's exit.
  */
-export const finalizing =
-  <const FE>(finally_: Fx<FE, void>) =>
-    <const E, const A>(program: Fx<E, A>): Fx<E | FE | Interrupt, A> =>
+export function finalizing<const FE>(
+  finally_: (exit: Exit) => Fx<FE, void>
+): <const E, const A>(program: Fx<E, A>) => Fx<E | FE | Interrupt, A>
+export function finalizing<const FE>(
+  finally_: Fx<FE, void> | ((exit: Exit) => Fx<FE, void>)
+): <const E, const A>(program: Fx<E, A>) => Fx<E | FE | Interrupt, A> {
+  if (typeof finally_ !== 'function') {
+    return <const E, const A>(program: Fx<E, A>): Fx<E | FE | Interrupt, A> =>
       uninterruptibleMask(restore => fx(function* () {
         try {
           return yield* restore(program)
@@ -224,3 +269,51 @@ export const finalizing =
           yield* finally_
         }
       }))
+  }
+
+  return <const E, const A>(program: Fx<E, A>): Fx<E | FE | Interrupt, A> =>
+    uninterruptibleMask(restore => fx(function* () {
+      let exit: ResumableExit<A, Extract<E, ExitEffect>> | undefined
+      let finalized = false
+      try {
+        exit = yield* returnExit(restore(program))
+        if (exit === undefined) return undefined as A
+        finalized = true
+        yield* finalize(finally_, toExit(exit))
+        return yield* restore(resumeExit(exit))
+      } finally {
+        if (!finalized) yield* finalize(finally_, exit === undefined ? interruptedExit() : toExit(exit))
+      }
+    }))
+}
+
+const finalize = <const FE>(
+  finally_: Fx<FE, void> | ((exit: Exit) => Fx<FE, void>),
+  exit: Exit
+): Fx<FE, void> =>
+  typeof finally_ === 'function' ? finally_(exit) : finally_
+
+const toExit = <const A>(exit: ResumableExit<A>): Exit => {
+  const effective = effectiveExit(exit)
+  switch (effective.type) {
+    case 'success':
+      return { type: 'success', value: effective.value }
+    case 'failure':
+      return { type: 'failure', failure: effective.effect }
+    case 'returnFrom':
+      return { type: 'returnFrom', scope: effective.effect.scope, value: effective.effect.arg }
+    case 'abort':
+      return { type: 'abort', scope: effective.effect.scope }
+    case 'interrupted':
+      return effective.effect.arg === undefined
+        ? { type: 'interrupted', scope: effective.effect.scope }
+        : { type: 'interrupted', scope: effective.effect.scope, reason: effective.effect.arg }
+  }
+}
+
+const interruptedExit = (): Exit => {
+  const reason = interruptionReason()
+  return reason === undefined
+    ? { type: 'interrupted', scope: currentScope }
+    : { type: 'interrupted', scope: currentScope, reason }
+}

--- a/src/Fx.ts
+++ b/src/Fx.ts
@@ -217,7 +217,7 @@ export function bracket<const IE, const FE, const E, const R, const A>(
   andFinally: (a: R, exit: RegionExit) => Fx<FE, void>,
   f: (a: R) => Fx<E, A>
 ): Fx<IE | FE | E | Interrupt, A> {
-  return uninterruptibleMask(restore => fx(function* () {
+  return uninterruptibleMask(restore => fx(function* (): Generator<IE | FE | E | Interrupt, A, unknown> {
     const r = yield* initially
     let exit: ResumableExit<A, Extract<E, ExitEffect>> | undefined
     let released = false
@@ -225,8 +225,13 @@ export function bracket<const IE, const FE, const E, const R, const A>(
       exit = yield* returnExit(restore(f(r)))
       if (exit === undefined) return undefined as A
       released = true
+      if (isSuccessExit(exit)) {
+        yield* andFinally(r, toRegionExit(exit))
+        return exit.value
+      }
       const cleanup = yield* returnExit(andFinally(r, toRegionExit(exit)))
-      return yield* restore(resumeExit(withCleanupExit(exit, cleanup)))
+      const combined: ResumableExit<A, Extract<E | FE, ExitEffect>> = withCleanupExit(exit, cleanup)
+      return yield* restore(resumeExit(combined))
     } finally {
       if (!released) yield* andFinally(r, exit === undefined ? interruptedExit() : toRegionExit(exit))
     }
@@ -261,15 +266,20 @@ export function finalizing<const FE>(
   }
 
   return <const E, const A>(program: Fx<E, A>): Fx<E | FE | Interrupt, A> =>
-    uninterruptibleMask(restore => fx(function* () {
+    uninterruptibleMask(restore => fx(function* (): Generator<E | FE | Interrupt, A, unknown> {
       let exit: ResumableExit<A, Extract<E, ExitEffect>> | undefined
       let finalized = false
       try {
         exit = yield* returnExit(restore(program))
         if (exit === undefined) return undefined as A
         finalized = true
+        if (isSuccessExit(exit)) {
+          yield* finalize(finally_, toRegionExit(exit))
+          return exit.value
+        }
         const cleanup = yield* returnExit(finalize(finally_, toRegionExit(exit)))
-        return yield* restore(resumeExit(withCleanupExit(exit, cleanup)))
+        const combined: ResumableExit<A, Extract<E | FE, ExitEffect>> = withCleanupExit(exit, cleanup)
+        return yield* restore(resumeExit(combined))
       } finally {
         if (!finalized) yield* finalize(finally_, exit === undefined ? interruptedExit() : toRegionExit(exit))
       }
@@ -281,6 +291,11 @@ const finalize = <const FE>(
   exit: RegionExit
 ): Fx<FE, void> =>
   typeof finally_ === 'function' ? finally_(exit) : finally_
+
+const isSuccessExit = <const A>(
+  exit: ResumableExit<A>
+): exit is { readonly type: 'success', readonly value: A } =>
+  exit.type === 'success'
 
 const toRegionExit = <const A>(exit: ResumableExit<A>): RegionExit => {
   const effective = effectiveExit(exit)

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -336,6 +336,26 @@ describe('Interrupt masking', () => {
     assert.deepEqual(exits, [{ type: 'success', value: 'resource:value' }])
   })
 
+  it('bracket provides an exit to release callbacks with defaulted exit parameters', () => {
+    const fallback = { type: 'abort' } as const
+    const exits = [] as RegionExit[]
+
+    const release = (resource: string, exit: RegionExit = fallback) => fx(function* () {
+      assert.equal(resource, 'resource')
+      exits.push(exit)
+    })
+
+    const result = bracket(
+      ok('resource'),
+      release,
+      resource => ok(`${resource}:value` as const)
+    ).pipe(run)
+
+    assert.equal(release.length, 1)
+    assert.equal(result, 'resource:value')
+    assert.deepEqual(exits, [{ type: 'success', value: 'resource:value' }])
+  })
+
   it('bracket provides a failure exit to release', () => {
     const failure = new Error('failed')
     const exits = [] as RegionExit[]

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -11,7 +11,7 @@ import { control, handle } from './Handler.js'
 import { InterruptFrom, interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
 import { returnFrom } from './ReturnFrom.js'
-import { currentScope, scope, withScope, type Control, type Exit } from './Scope.js'
+import { currentScope, scope, withScope, type Control, type Exit, type RegionExit } from './Scope.js'
 
 describe('Typed interruption', () => {
   const TestScope = scope('test/InterruptFrom')
@@ -321,11 +321,11 @@ describe('Interrupt masking', () => {
   })
 
   it('bracket provides a success exit to release', () => {
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = bracket(
       ok('resource'),
-      (resource: string, exit: Exit) => fx(function* () {
+      (resource: string, exit: RegionExit) => fx(function* () {
         assert.equal(resource, 'resource')
         exits.push(exit)
       }),
@@ -338,11 +338,11 @@ describe('Interrupt masking', () => {
 
   it('bracket provides a failure exit to release', () => {
     const failure = new Error('failed')
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = bracket(
       ok('resource'),
-      (resource: string, exit: Exit) => fx(function* () {
+      (resource: string, exit: RegionExit) => fx(function* () {
         assert.equal(resource, 'resource')
         exits.push(exit)
       }),
@@ -392,7 +392,7 @@ describe('Interrupt masking', () => {
   })
 
   it('finalizing provides a success exit to cleanup', () => {
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = ok('value').pipe(
       finalizing(exit => fx(function* () {
@@ -407,7 +407,7 @@ describe('Interrupt masking', () => {
 
   it('finalizing provides a failure exit to cleanup', () => {
     const failure = new Error('failed')
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = fail(failure).pipe(
       finalizing(exit => fx(function* () {
@@ -427,7 +427,7 @@ describe('Interrupt masking', () => {
 
   it('finalizing provides a returnFrom exit to cleanup', () => {
     const ControlScope = scope<Control>()('test/Interrupt/finalizing/ReturnFromExit')
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = returnFrom(ControlScope, 'returned').pipe(
       finalizing(exit => fx(function* () {
@@ -438,12 +438,12 @@ describe('Interrupt masking', () => {
     )
 
     assert.equal(result, 'returned')
-    assert.deepEqual(exits, [{ type: 'returnFrom', scope: ControlScope, value: 'returned' }])
+    assert.deepEqual(exits, [{ type: 'returnFrom', value: 'returned' }])
   })
 
   it('finalizing provides an abort exit to cleanup', () => {
     const ControlScope = scope<Control>()('test/Interrupt/finalizing/AbortExit')
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = abort(ControlScope).pipe(
       finalizing(exit => fx(function* () {
@@ -455,13 +455,13 @@ describe('Interrupt masking', () => {
     )
 
     assert.equal(result, 'aborted')
-    assert.deepEqual(exits, [{ type: 'abort', scope: ControlScope }])
+    assert.deepEqual(exits, [{ type: 'abort' }])
   })
 
   it('finalizing provides an interruptFrom exit to cleanup', () => {
     const InterruptScope = scope('test/Interrupt/finalizing/InterruptFromExit')
     const reason = { type: 'lexical-interrupt' }
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = interruptFrom(InterruptScope, reason).pipe(
       finalizing(exit => fx(function* () {
@@ -472,13 +472,31 @@ describe('Interrupt masking', () => {
     )
 
     assert.equal(result, 'interrupted')
-    assert.deepEqual(exits, [{ type: 'interrupted', scope: InterruptScope, reason }])
+    assert.deepEqual(exits, [{ type: 'interrupted', reason }])
+  })
+
+  it('finalizing does not expose unresolved currentScope as a lexical exit scope', () => {
+    const LexicalScope = scope('test/Interrupt/finalizing/CurrentScopeLexicalExit')
+    const reason = { type: 'current-scope-lexical-interrupt' }
+    const exits = [] as RegionExit[]
+
+    const result = interruptFrom(currentScope, reason).pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      withScope(LexicalScope),
+      recoverInterrupt(LexicalScope, () => ok('interrupted')),
+      run
+    )
+
+    assert.equal(result, 'interrupted')
+    assert.deepEqual(exits, [{ type: 'interrupted', reason }])
   })
 
   it('finalizing surfaces cleanup failure after observing the primary failure', () => {
     const programFailure = new Error('program failed')
     const cleanupFailure = new Error('cleanup failed')
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
 
     const result = fail(programFailure).pipe(
       finalizing(exit => fx(function* () {
@@ -530,7 +548,7 @@ describe('Interrupt masking', () => {
   })
 
   it('finalizing provides an interrupted exit when task interruption closes the region', async () => {
-    const exits = [] as Exit[]
+    const exits = [] as RegionExit[]
     let started = false
 
     const task = assertPromise<void>(() => new Promise(() => {
@@ -545,7 +563,7 @@ describe('Interrupt masking', () => {
     await eventually(() => started)
     await task.interrupt()
 
-    assert.deepEqual(exits, [{ type: 'interrupted', scope: currentScope }])
+    assert.deepEqual(exits, [{ type: 'interrupted' }])
   })
 
   it('finalizing drains async cleanup effects during interruption', async () => {

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
+import { abort, orReturn } from './Abort.js'
 import { assertPromise } from './Async.js'
 import { Effect } from './Effect.js'
 import { fail, Fail, returnFail } from './Fail.js'
@@ -9,7 +10,8 @@ import { bracket, finalizing, fx, ok, run, runPromise, runTask, type Fx } from '
 import { control, handle } from './Handler.js'
 import { InterruptFrom, interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
-import { scope, withScope, type Exit } from './Scope.js'
+import { returnFrom } from './ReturnFrom.js'
+import { currentScope, scope, withScope, type Control, type Exit } from './Scope.js'
 
 describe('Typed interruption', () => {
   const TestScope = scope('test/InterruptFrom')
@@ -318,6 +320,43 @@ describe('Interrupt masking', () => {
     assert.deepEqual(released, ['resource'])
   })
 
+  it('bracket provides a success exit to release', () => {
+    const exits = [] as Exit[]
+
+    const result = bracket(
+      ok('resource'),
+      (resource: string, exit: Exit) => fx(function* () {
+        assert.equal(resource, 'resource')
+        exits.push(exit)
+      }),
+      resource => ok(`${resource}:value` as const)
+    ).pipe(run)
+
+    assert.equal(result, 'resource:value')
+    assert.deepEqual(exits, [{ type: 'success', value: 'resource:value' }])
+  })
+
+  it('bracket provides a failure exit to release', () => {
+    const failure = new Error('failed')
+    const exits = [] as Exit[]
+
+    const result = bracket(
+      ok('resource'),
+      (resource: string, exit: Exit) => fx(function* () {
+        assert.equal(resource, 'resource')
+        exits.push(exit)
+      }),
+      () => fail(failure)
+    ).pipe(returnFail, run)
+
+    assert.ok(Fail.is(result))
+    assert.equal(result.arg, failure)
+    assert.equal(exits.length, 1)
+    const [exit] = exits
+    assert.equal(exit.type, 'failure')
+    if (exit.type === 'failure') assert.equal(exit.failure.arg, failure)
+  })
+
   it('finalizing runs cleanup after success and preserves the result', () => {
     const released = [] as string[]
 
@@ -352,6 +391,112 @@ describe('Interrupt masking', () => {
     assert.deepEqual(released, ['cleanup'])
   })
 
+  it('finalizing provides a success exit to cleanup', () => {
+    const exits = [] as Exit[]
+
+    const result = ok('value').pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      run
+    )
+
+    assert.equal(result, 'value')
+    assert.deepEqual(exits, [{ type: 'success', value: 'value' }])
+  })
+
+  it('finalizing provides a failure exit to cleanup', () => {
+    const failure = new Error('failed')
+    const exits = [] as Exit[]
+
+    const result = fail(failure).pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      returnFail,
+      run
+    )
+
+    assert.ok(Fail.is(result))
+    assert.equal(result.arg, failure)
+    assert.equal(exits.length, 1)
+    const [exit] = exits
+    assert.equal(exit.type, 'failure')
+    if (exit.type === 'failure') assert.equal(exit.failure.arg, failure)
+  })
+
+  it('finalizing provides a returnFrom exit to cleanup', () => {
+    const ControlScope = scope<Control>()('test/Interrupt/finalizing/ReturnFromExit')
+    const exits = [] as Exit[]
+
+    const result = returnFrom(ControlScope, 'returned').pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      withScope(ControlScope),
+      run
+    )
+
+    assert.equal(result, 'returned')
+    assert.deepEqual(exits, [{ type: 'returnFrom', scope: ControlScope, value: 'returned' }])
+  })
+
+  it('finalizing provides an abort exit to cleanup', () => {
+    const ControlScope = scope<Control>()('test/Interrupt/finalizing/AbortExit')
+    const exits = [] as Exit[]
+
+    const result = abort(ControlScope).pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      withScope(ControlScope),
+      orReturn(ControlScope, 'aborted'),
+      run
+    )
+
+    assert.equal(result, 'aborted')
+    assert.deepEqual(exits, [{ type: 'abort', scope: ControlScope }])
+  })
+
+  it('finalizing provides an interruptFrom exit to cleanup', () => {
+    const InterruptScope = scope('test/Interrupt/finalizing/InterruptFromExit')
+    const reason = { type: 'lexical-interrupt' }
+    const exits = [] as Exit[]
+
+    const result = interruptFrom(InterruptScope, reason).pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      recoverInterrupt(InterruptScope, () => ok('interrupted')),
+      run
+    )
+
+    assert.equal(result, 'interrupted')
+    assert.deepEqual(exits, [{ type: 'interrupted', scope: InterruptScope, reason }])
+  })
+
+  it('finalizing surfaces cleanup failure after observing the primary failure', () => {
+    const programFailure = new Error('program failed')
+    const cleanupFailure = new Error('cleanup failed')
+    const exits = [] as Exit[]
+
+    const result = fail(programFailure).pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+        yield* fail(cleanupFailure)
+      })),
+      returnFail,
+      run
+    )
+
+    assert.ok(Fail.is(result))
+    assert.equal(result.arg, cleanupFailure)
+    assert.equal(exits.length, 1)
+    const [exit] = exits
+    assert.equal(exit.type, 'failure')
+    if (exit.type === 'failure') assert.equal(exit.failure.arg, programFailure)
+  })
+
   it('finalizing runs cleanup exactly once', () => {
     let released = 0
 
@@ -382,6 +527,25 @@ describe('Interrupt masking', () => {
     await task.interrupt()
 
     assert.deepEqual(released, ['cleanup'])
+  })
+
+  it('finalizing provides an interrupted exit when task interruption closes the region', async () => {
+    const exits = [] as Exit[]
+    let started = false
+
+    const task = assertPromise<void>(() => new Promise(() => {
+      started = true
+    })).pipe(
+      finalizing(exit => fx(function* () {
+        exits.push(exit)
+      })),
+      runTask
+    )
+
+    await eventually(() => started)
+    await task.interrupt()
+
+    assert.deepEqual(exits, [{ type: 'interrupted', scope: currentScope }])
   })
 
   it('finalizing drains async cleanup effects during interruption', async () => {

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -493,7 +493,7 @@ describe('Interrupt masking', () => {
     assert.deepEqual(exits, [{ type: 'interrupted', reason }])
   })
 
-  it('finalizing surfaces cleanup failure after observing the primary failure', () => {
+  it('finalizing preserves primary failure when cleanup fails after observing it', () => {
     const programFailure = new Error('program failed')
     const cleanupFailure = new Error('cleanup failed')
     const exits = [] as RegionExit[]
@@ -508,11 +508,12 @@ describe('Interrupt masking', () => {
     )
 
     assert.ok(Fail.is(result))
-    assert.equal(result.arg, cleanupFailure)
+    assert.equal(result.arg, programFailure)
     assert.equal(exits.length, 1)
     const [exit] = exits
     assert.equal(exit.type, 'failure')
     if (exit.type === 'failure') assert.equal(exit.failure.arg, programFailure)
+    assert.equal(cleanupFailure.message, 'cleanup failed')
   })
 
   it('finalizing runs cleanup exactly once', () => {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -91,6 +91,17 @@ export type Exit<
   | Aborted<Scope>
   | Interrupted<Scope>
 
+export type RegionExit<
+  A = unknown,
+  F extends Fail<unknown> = Fail<unknown>,
+  R = unknown
+> =
+  | Success<A>
+  | Failure<F>
+  | RegionReturned<R>
+  | RegionAborted
+  | RegionInterrupted
+
 export interface Success<A> {
   readonly type: 'success'
   readonly value: A
@@ -101,22 +112,28 @@ export interface Failure<F extends Fail<unknown>> {
   readonly failure: F
 }
 
-export interface ReturnedFrom<Scope extends AnyScope, A> {
+export interface RegionReturned<A> {
   readonly type: 'returnFrom'
-  readonly scope: Scope
   readonly value: A
 }
 
-export interface Aborted<Scope extends AnyScope> {
+export type ReturnedFrom<Scope extends AnyScope, A> =
+  RegionReturned<A> & { readonly scope: Scope }
+
+export interface RegionAborted {
   readonly type: 'abort'
-  readonly scope: Scope
 }
 
-export interface Interrupted<Scope extends AnyScope> {
+export type Aborted<Scope extends AnyScope> =
+  RegionAborted & { readonly scope: Scope }
+
+export interface RegionInterrupted {
   readonly type: 'interrupted'
-  readonly scope: Scope
   readonly reason?: unknown
 }
+
+export type Interrupted<Scope extends AnyScope> =
+  RegionInterrupted & { readonly scope: Scope }
 
 /**
  * Logical nearest lifetime scope token.

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -4,9 +4,9 @@ import { describe, it } from 'node:test'
 import { fork, forkIn, withUnboundedConcurrency } from './Concurrent.js'
 import { Fail, catchAll, catchIf, fail, returnFail, runCatch } from './Fail.js'
 import { andFinally, andFinallyIn } from './Finalization.js'
-import { finalizing, fx, ok, run, runPromise, type Fx } from './Fx.js'
+import { bracket, finalizing, fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control } from './Scope.js'
+import { scope, withScope, type Control, type RegionExit } from './Scope.js'
 import {
   GetState,
   getState,
@@ -256,6 +256,53 @@ describe('State', () => {
       }).pipe(withState(CounterState, 0), run)
 
       assert.deepEqual(program, ['body:0', 10])
+    })
+
+    it('preserves the original failure when exit-aware finalizing returns', () => {
+      const program = fx(function* () {
+        const recovered = yield* fx(function* () {
+          yield* modifyState(CounterState, count => [count + 1, undefined])
+          yield* fail('body')
+        }).pipe(
+          finalizing((_exit) => returnFrom(ForkScope, 'cleanup')),
+          transactionalState(CounterState),
+          withScope(ForkScope),
+          catchAll(error => fx(function* () {
+            const recoveredFrom = yield* getState(CounterState)
+            return `${error}:${recoveredFrom}`
+          })),
+          runCatch
+        )
+
+        return [recovered, yield* getState(CounterState)] as const
+      }).pipe(withState(CounterState, 0), run)
+
+      assert.deepEqual(program, ['body:0', 0])
+    })
+
+    it('preserves the original failure when exit-aware bracket cleanup returns', () => {
+      const program = fx(function* () {
+        const recovered = yield* bracket(
+          ok(undefined),
+          (_resource: void, _exit: RegionExit) => returnFrom(ForkScope, 'cleanup'),
+          () => fx(function* () {
+            yield* modifyState(CounterState, count => [count + 1, undefined])
+            yield* fail('body')
+          })
+        ).pipe(
+          transactionalState(CounterState),
+          withScope(ForkScope),
+          catchAll(error => fx(function* () {
+            const recoveredFrom = yield* getState(CounterState)
+            return `${error}:${recoveredFrom}`
+          })),
+          runCatch
+        )
+
+        return [recovered, yield* getState(CounterState)] as const
+      }).pipe(withState(CounterState, 0), run)
+
+      assert.deepEqual(program, ['body:0', 0])
     })
 
     it('preserves the original failure when transactional cleanup fails', () => {

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -66,6 +66,31 @@ export const effectiveExit = <const A, const E extends ExitEffect>(
   return current as EffectiveExit<A, E>
 }
 
+export const withCleanupExit = <const A, const E extends ExitEffect, const CE extends ExitEffect>(
+  primary: ResumableExit<A, E>,
+  cleanup: ResumableExit<void, CE>
+): ResumableExit<A, E | CE> => {
+  if (cleanup.type === 'success') return primary
+  if (primary.type === 'success') return cleanup
+  return mergeCleanupExit(primary, cleanup)
+}
+
+const mergeCleanupExit = <const E extends ExitEffect, const CE extends ExitEffect>(
+  primary: NonSuccessExit<E> | WithCleanupExit<E>,
+  cleanup: NonSuccessExit<CE> | WithCleanupExit<CE>
+): WithCleanupExit<E | CE> =>
+  primary.type === 'withCleanupExit'
+    ? {
+        type: 'withCleanupExit',
+        primary: primary.primary,
+        cleanup: mergeCleanupExit(primary.cleanup, cleanup)
+      } as WithCleanupExit<E | CE>
+    : {
+        type: 'withCleanupExit',
+        primary,
+        cleanup
+      } as WithCleanupExit<E | CE>
+
 export function resumeExit<const A>(
   exit: { readonly type: 'success', readonly value: A }
 ): Fx<never, A>

--- a/src/internal/returnExit.ts
+++ b/src/internal/returnExit.ts
@@ -6,7 +6,7 @@ import { ReturnFrom } from '../ReturnFrom.js'
 import type { AnyControlScope, AnyScope } from '../Scope.js'
 import { exitRegion, type CapturedCleanupExit } from './exitRegion.js'
 
-type ExitEffect =
+export type ExitEffect =
   | Fail<any>
   | ReturnFrom<AnyControlScope, any>
   | Abort<AnyControlScope>


### PR DESCRIPTION
## Summary

- Extend `bracket` and `finalizing` so cleanup can inspect lexical region exits.
- Add a public `RegionExit` type for scope-less lexical exits, while preserving existing scoped `Exit` for `Finally`-related APIs.
- Preserve the existing one-argument `bracket` release and `finalizing(Fx)` code paths for compatibility.

## Notes

This is a prototype PR. Scope-owned finalizers still receive `Exit`, where scoped control exits have a resolved concrete scope. Exit-aware lexical cleanup now receives `RegionExit`, so pre-boundary observations of `returnFrom`, `abort`, and `interruptFrom` do not expose raw or unresolved scope tokens.

For external task interruption before a typed exit is available, lexical cleanup receives `{ type: 'interrupted' }` or `{ type: 'interrupted', reason }`.

Callback cleanup exits are captured and combined with the primary lexical exit before resuming, matching the existing `finalizing(Fx)` cleanup-exit behavior. That preserves primary failures across cleanup `returnFrom`/`abort`/`interruptFrom` exits and transactional rollback decisions.

## Validation

- `corepack pnpm build`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm test`