### PR TITLE
Refactor effect keys and lexical scope handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,26 +60,27 @@ execution:
 - a request lifetime that may be interrupted
 - a resource lifetime that must be finalized
 - a timeout boundary where callers choose the interruption policy
-- a progress or event channel that receives yielded values
+- a typed progress or event channel that receives yielded values
 - a concurrent group that must clean up cancelled work
 - a parser or workflow step that may return early
 - state that should be local to one dynamic lifetime
 
-In `fx`, named scopes are the public handle for these dynamic ownership
-boundaries. A scope can delimit cleanup, interruption, early return, yielding,
-timeout, and scoped state without introducing service containers, global
-runtimes, or framework wiring.
+In `fx`, lexical scope handles delimit dynamic ownership boundaries for cleanup,
+interruption, early return, timeout, and resource lifetime without introducing
+service containers, global runtimes, or framework wiring. Typed keys identify
+independent slots and channels such as state and yielding.
 
 Ownership means the scope controls the lifetime and exit semantics of operations
-registered within it: cleanup runs when the scope exits, interruptions target
-the scope, and scoped state or yielding stays local to that boundary.
+registered within it: cleanup runs when the scope exits, and interruptions
+target the scope.
 
 ### Region-indexed capabilities
 
 Some operations only make sense inside a dynamic lifetime. `fx` models those as
-focused capabilities indexed by a scope or region: `andFinallyIn` for cleanup,
-`yieldFrom` for scoped events, `timeoutIn` for deadlines, interruption for
-cooperative cancellation, and scoped state for local mutation.
+focused capabilities indexed by a scope handle: `andFinallyIn` for cleanup,
+`timeoutIn` for deadlines, and interruption for cooperative cancellation. Other
+operations need independent typed slots or channels: `yieldFrom` for events and
+state keys for local mutation.
 
 This keeps public APIs specific while giving them one shared lifecycle model:
 the program names the region, and handlers decide what that region means.
@@ -193,7 +194,8 @@ their named subpaths.
 | Core programs, effects, handlers, failure, async, env, task, console, basic diagnostics | `@briancavalier/fx` |
 | Encoding and decoding external data with branded codec keys | `@briancavalier/fx/codec` |
 | Advanced trace capture, snapshots, and trace formatting options | `@briancavalier/fx/trace` |
-| Named scopes, abort, finalization, early return, scoped yielding | `@briancavalier/fx/scope` |
+| Scope handles, abort, finalization, and early return | `@briancavalier/fx/scope` |
+| Yielding channels and collection helpers | `@briancavalier/fx/yield` |
 | Sinks for receiving values | `@briancavalier/fx/sink` |
 | Scoped mutable state operations | `@briancavalier/fx/state` |
 | Structured concurrency | `@briancavalier/fx/concurrent` |
@@ -259,8 +261,8 @@ No container, no wiring graph—just a pipeline.
 - **Typed algebraic effects**
   Programs expose the operations they may perform as `Fx<E, A>`
 
-- **Named scopes**
-  Scopes delimit lifecycle, cleanup, interruption, early return, and yielding
+- **Lexical scope handles**
+  Scopes delimit lifecycle, cleanup, interruption, and early return
 
 - **Composable handlers**  
   Handlers remove effects and can introduce new ones
@@ -276,8 +278,8 @@ No container, no wiring graph—just a pipeline.
 - **Guaranteed finalization**
   Finalizers run when a scope succeeds, fails, returns, aborts, or is interrupted
 
-- **Scoped yielding**
-  Programs emit values to named channels with `yieldFrom`
+- **Typed yielding channels**
+  Programs emit values to keyed channels with `yieldFrom`
 
 - **External data boundaries**
   Encoding and decoding are effects, so reusable programs can declare external

--- a/README.md
+++ b/README.md
@@ -145,20 +145,17 @@ import {
   fx,
   run
 } from "@briancavalier/fx"
-import { andFinallyIn, scope, withScope } from "@briancavalier/fx/scope"
+import { andFinallyIn, withScope } from "@briancavalier/fx/scope"
 
-const RequestScope = scope("request")
-
-const request = fx(function* () {
-  yield* andFinallyIn(RequestScope, exit =>
+const request = withScope({ label: "request" }, scope => fx(function* () {
+  yield* andFinallyIn(scope, exit =>
     consoleLog(`cleanup after ${exit.type}`)
   )
 
   yield* consoleLog("handling request")
-})
+}))
 
 request.pipe(
-  withScope(RequestScope),
   defaultConsole,
   assertNoFail,
   run

--- a/README.md
+++ b/README.md
@@ -145,15 +145,15 @@ import {
   fx,
   run
 } from "@briancavalier/fx"
-import { andFinallyIn, withScope } from "@briancavalier/fx/scope"
+import { andFinallyIn, inScope, withScope } from "@briancavalier/fx/scope"
 
-const request = withScope({ label: "request" }, scope => fx(function* () {
+const request = withScope({ label: "request" }, scope => inScope(scope, fx(function* () {
   yield* andFinallyIn(scope, exit =>
     consoleLog(`cleanup after ${exit.type}`)
   )
 
   yield* consoleLog("handling request")
-}))
+})))
 
 request.pipe(
   defaultConsole,

--- a/benchmarks/cooperative-all.ts
+++ b/benchmarks/cooperative-all.ts
@@ -10,7 +10,7 @@ import { fail, returnFail } from '../src/Fail.js'
 import { andFinallyIn } from '../src/Finalization.js'
 import { fx, ok, runPromise } from '../src/Fx.js'
 import { handle } from '../src/Handler.js'
-import { scope, withScope } from '../src/Scope.js'
+import { inScope, scope } from '../src/Scope.js'
 import { wait } from '../src/Task.js'
 import type { Fx } from '../src/Fx.js'
 
@@ -126,23 +126,23 @@ const results = await runBenchmarks([
     await nestedFirstSuccess().pipe(withCoopConcurrency(), handleStep(), runPromise)
   }),
   benchmark('withUnboundedConcurrency cancel cleanup', 'cleanup', async () => {
-    await cleanupFailureProgram().pipe(withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
+    await cleanupFailureProgram().pipe(inScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
   }),
   benchmark('withCoopConcurrency cancel cleanup', 'cleanup', async () => {
-    await cleanupFailureProgram().pipe(withCoopConcurrency(), withScope(CleanupScope), returnFail, runPromise)
+    await cleanupFailureProgram().pipe(withCoopConcurrency(), inScope(CleanupScope), returnFail, runPromise)
   })
 ])
 
 console.log(formatMarkdown(fairness, results))
 
 async function runSemanticChecks(): Promise<void> {
-  const defaultResult = await parityProgram().pipe(handleStep(), withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
-  const cooperativeResult = await parityProgram().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), withScope(CleanupScope), returnFail, runPromise)
+  const defaultResult = await parityProgram().pipe(handleStep(), inScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
+  const cooperativeResult = await parityProgram().pipe(withCoopConcurrency({ yieldBudget: 1 }), handleStep(), inScope(CleanupScope), returnFail, runPromise)
 
   assert.deepEqual(defaultResult, cooperativeResult)
 
-  const defaultFailure = await cleanupFailureProgram().pipe(withScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
-  const cooperativeFailure = await cleanupFailureProgram().pipe(withCoopConcurrency(), withScope(CleanupScope), returnFail, runPromise)
+  const defaultFailure = await cleanupFailureProgram().pipe(inScope(CleanupScope), withUnboundedConcurrency, returnFail, runPromise)
+  const cooperativeFailure = await cleanupFailureProgram().pipe(withCoopConcurrency(), inScope(CleanupScope), returnFail, runPromise)
 
   assert.equal(defaultFailure.constructor, cooperativeFailure.constructor)
   assert.ok('arg' in defaultFailure && 'arg' in cooperativeFailure)
@@ -315,7 +315,7 @@ function scopedJoinFanout(length: number) {
       yield* forkIn(JoinScope, assertPromise(() => Promise.resolve(i)))
     }
     return 'parent'
-  }).pipe(withScope(JoinScope))
+  }).pipe(inScope(JoinScope))
 }
 
 function nestedRace() {

--- a/benchmarks/runtime-loops.ts
+++ b/benchmarks/runtime-loops.ts
@@ -10,7 +10,7 @@ import { fx, ok, run, runPromise, runTask } from '../src/Fx.js'
 import { control, handle } from '../src/Handler.js'
 import { captureHandlers, closeHandlerCapture, mapCapturedHandlers, withHandlerContext } from '../src/HandlerCapture.js'
 import { uninterruptible } from '../src/Interrupt.js'
-import { scope, withScope } from '../src/Scope.js'
+import { inScope, scope } from '../src/Scope.js'
 import { wait } from '../src/Task.js'
 import { setTraceCapturePolicy } from '../src/Trace.js'
 import { Handler as InternalHandler } from '../src/internal/Handler.js'
@@ -71,7 +71,7 @@ const blocked = assertPromise<void>(() => new Promise(() => { }))
 const blockedWithFinalizer = fx(function* () {
   yield* andFinallyIn(InterruptScope, ok(undefined))
   return yield* blocked
-}).pipe(withScope(InterruptScope))
+}).pipe(inScope(InterruptScope))
 
 const handlerContextDepths = [0, 1, 4, 8, 16] as const
 const captureFanouts = [1, 4, 16, 64] as const
@@ -174,7 +174,7 @@ const cases: readonly BenchmarkCase[] = [
   ),
   ...handlerContextDepths.map(depth =>
     benchmark(`scope finalizer registration depth ${depth}`, 'scope', CaptureIterations, 500, () => {
-      finalizerProgram(depth).pipe(withScope(ScopeFinalizer), run)
+      finalizerProgram(depth).pipe(inScope(ScopeFinalizer), run)
     })
   ),
   ...handlerContextDepths.map(depth =>
@@ -360,7 +360,7 @@ function directHandlerStack(depth: number) {
 
 function applyScopes(f: Fx<unknown, unknown>, depth: number) {
   let current = f as Fx<any, any>
-  for (let i = 0; i < depth; i++) current = current.pipe(withScope(scope(`benchmark/runtime-loops/Scope/${i}`)))
+  for (let i = 0; i < depth; i++) current = current.pipe(inScope(scope(`benchmark/runtime-loops/Scope/${i}`)))
   return current as Fx<any, any>
 }
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -39,7 +39,8 @@ subpaths for optional feature areas and advanced trace tools.
 | Need | Import from |
 | --- | --- |
 | Encoding and decoding external data with branded codec keys | `@briancavalier/fx/codec` |
-| Scopes, abort, finalization, early return, scoped yielding | `@briancavalier/fx/scope` |
+| Scope handles, abort, finalization, and early return | `@briancavalier/fx/scope` |
+| Yielding channels and collection helpers | `@briancavalier/fx/yield` |
 | Sinks for receiving values | `@briancavalier/fx/sink` |
 | Scoped mutable state operations | `@briancavalier/fx/state` |
 | Structured concurrency | `@briancavalier/fx/concurrent` |

--- a/docs/recipes/manage-resources-and-finalizers.md
+++ b/docs/recipes/manage-resources-and-finalizers.md
@@ -1,13 +1,11 @@
 # Manage Resources and Finalizers
 
-Use this when acquiring a resource that must be released when a named scope
+Use this when acquiring a resource that must be released when a lexical scope
 exits.
 
 ```ts
 import { fx, runPromise } from "@briancavalier/fx"
-import { managed, scope, usingManagedIn, withScope } from "@briancavalier/fx/scope"
-
-const RequestScope = scope("app/Request")
+import { managed, usingManagedIn, withScope } from "@briancavalier/fx/scope"
 
 const openConnection = fx(function* () {
   return managed(
@@ -16,17 +14,15 @@ const openConnection = fx(function* () {
   )
 })
 
-const program = fx(function* () {
-  const connection = yield* usingManagedIn(RequestScope, openConnection)
+const program = withScope({ label: "app/Request" }, scope => fx(function* () {
+  const connection = yield* usingManagedIn(scope, openConnection)
   return yield* query(connection)
-}).pipe(
-  withScope(RequestScope)
-)
+}))
 ```
 
-Use `usingIn` or `usingManagedIn` to acquire and register cleanup in a named
-scope in a small uninterruptible region. Use `using` or `usingManaged` for the
-current scope. `usingIn` finalizers receive the acquired value and the scope
+Use `usingIn` or `usingManagedIn` to acquire and register cleanup in an explicit
+scope handle in a small uninterruptible region. Use `using` or `usingManaged`
+for the current scope. `usingIn` finalizers receive the acquired value and the scope
 exit, and may ignore the exit when cleanup does not depend on it.
 
 Handler pipeline:

--- a/docs/recipes/manage-resources-and-finalizers.md
+++ b/docs/recipes/manage-resources-and-finalizers.md
@@ -5,7 +5,7 @@ exits.
 
 ```ts
 import { fx, runPromise } from "@briancavalier/fx"
-import { managed, usingManagedIn, withScope } from "@briancavalier/fx/scope"
+import { inScope, managed, usingManagedIn, withScope } from "@briancavalier/fx/scope"
 
 const openConnection = fx(function* () {
   return managed(
@@ -14,16 +14,16 @@ const openConnection = fx(function* () {
   )
 })
 
-const program = withScope({ label: "app/Request" }, scope => fx(function* () {
+const program = withScope({ label: "app/Request" }, scope => inScope(scope, fx(function* () {
   const connection = yield* usingManagedIn(scope, openConnection)
   return yield* query(connection)
-}))
+})))
 ```
 
 Use `usingIn` or `usingManagedIn` to acquire and register cleanup in an explicit
-scope handle in a small uninterruptible region. Use `using` or `usingManaged`
-for the current scope. `usingIn` finalizers receive the acquired value and the scope
-exit, and may ignore the exit when cleanup does not depend on it.
+scope handle in a small uninterruptible region. `usingIn` finalizers receive
+the acquired value and the scope exit, and may ignore the exit when cleanup does
+not depend on it.
 
 Handler pipeline:
 

--- a/docs/recipes/use-structured-concurrency.md
+++ b/docs/recipes/use-structured-concurrency.md
@@ -45,13 +45,13 @@ Use `forkIn(scope, fx)` when child lifetime should belong to a lexical scope, bu
 scheduling should still be chosen by the nearest concurrency handler.
 
 ```ts
-const request = withScope({ label: "request" }, scope => fx(function* () {
+const request = withScope({ label: "request" }, scope => inScope(scope, fx(function* () {
   yield* forkIn(scope, refreshCache)
   return yield* loadDashboard
-}))
+})))
 ```
 
-`forkIn` introduces a scoped fork effect. `withScope(...)` handles that
+`forkIn` introduces a scoped fork effect. `inScope(...)` handles that
 lifetime boundary and re-yields an ordinary `Fork` scheduling request. A fork
 scheduler must be outside the scope to handle that request:
 
@@ -68,9 +68,9 @@ unhandled, so normal typed execution should reject it:
 
 ```ts
 withScope({ label: "request" }, scope =>
-  fx(function* () {
+  inScope(scope, fx(function* () {
     yield* forkIn(scope, refreshCache)
-  }).pipe(withUnboundedConcurrency)
+  }).pipe(withUnboundedConcurrency))
 ).pipe(runPromise)
 ```
 

--- a/docs/recipes/use-structured-concurrency.md
+++ b/docs/recipes/use-structured-concurrency.md
@@ -41,40 +41,37 @@ race.
 
 ## Scope-owned forks
 
-Use `forkIn(scope, fx)` when child lifetime should belong to a named scope, but
+Use `forkIn(scope, fx)` when child lifetime should belong to a lexical scope, but
 scheduling should still be chosen by the nearest concurrency handler.
 
 ```ts
-const RequestScope = scope("request")
-
-const request = fx(function* () {
-  yield* forkIn(RequestScope, refreshCache)
+const request = withScope({ label: "request" }, scope => fx(function* () {
+  yield* forkIn(scope, refreshCache)
   return yield* loadDashboard
-})
+}))
 ```
 
-`forkIn` introduces a scoped fork effect. `withScope(RequestScope)` handles that
+`forkIn` introduces a scoped fork effect. `withScope(...)` handles that
 lifetime boundary and re-yields an ordinary `Fork` scheduling request. A fork
 scheduler must be outside the scope to handle that request:
 
 ```ts
 request.pipe(
-  withScope(RequestScope),
   withUnboundedConcurrency,
   runPromise
 )
 ```
 
 This follows the normal fx rule that handlers eliminate effects. Reversing the
-order leaves the generated `Fork` unhandled, so normal typed execution should
-reject it:
+order by placing a fork scheduler inside the scope leaves the generated `Fork`
+unhandled, so normal typed execution should reject it:
 
 ```ts
-request.pipe(
-  withUnboundedConcurrency,
-  withScope(RequestScope),
-  runPromise
-)
+withScope({ label: "request" }, scope =>
+  fx(function* () {
+    yield* forkIn(scope, refreshCache)
+  }).pipe(withUnboundedConcurrency)
+).pipe(runPromise)
 ```
 
 Scope-owned forks are not an ambient runtime fiber registry. They are explicit

--- a/docs/recipes/use-structured-concurrency.md
+++ b/docs/recipes/use-structured-concurrency.md
@@ -10,7 +10,7 @@ import {
   withBoundedConcurrency,
   withUnboundedConcurrency
 } from "@briancavalier/fx/concurrent"
-import { scope, withScope } from "@briancavalier/fx/scope"
+import { inScope, withScope } from "@briancavalier/fx/scope"
 
 const loadDashboard = fx(function* () {
   const [user, posts] = yield* all([

--- a/examples/advanced/bookmarks/server.ts
+++ b/examples/advanced/bookmarks/server.ts
@@ -11,7 +11,7 @@ import { mount, route, routes, serve, transformRoutes, type RouteContext, type R
 import { info, withConsoleLog, type Log } from '@briancavalier/fx/log'
 import { nodeHttp, runNodeMain } from '@briancavalier/fx/platform-node'
 import { defaultRandom } from '@briancavalier/fx/random'
-import { forEachFrom, scope, yieldFrom, type Yielding } from '@briancavalier/fx/scope'
+import { forEachFrom, key, yieldFrom, type Yielding } from '@briancavalier/fx/yield'
 import { defaultTime, type Time } from '@briancavalier/fx/time'
 import {
   addBookmark,
@@ -49,7 +49,7 @@ type BookmarkApiCodecEffects =
   | Encode<typeof BookmarkJson>
   | Encode<typeof BookmarksJson>
 
-const HttpServerEvents = scope<Yielding<ServerEvent>>()('examples/advanced/bookmarks/HttpServerEvents')
+const HttpServerEvents = key<Yielding<ServerEvent>>()('examples/advanced/bookmarks/HttpServerEvents')
 
 const createBookmark = (request: ServerRequest): Fx<BookmarkRouteEffects | BookmarkApiCodecEffects | Fail<InvalidBookmarkJson>, ServerResponse<never>> => fx(function* () {
   const body = yield* readText(request)

--- a/examples/advanced/incident-collector/cli.ts
+++ b/examples/advanced/incident-collector/cli.ts
@@ -5,8 +5,6 @@ import { withConsoleLog } from '@briancavalier/fx/log'
 import { withScope } from '@briancavalier/fx/scope'
 import { defaultTime } from '@briancavalier/fx/time'
 import {
-  BundleScope,
-  CollectorScope,
   collectIncidentSnapshot,
   createIncidentCollectorFixture
 } from './domain.js'
@@ -17,21 +15,22 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     primaryRuntimeFails: true
   })
 
-  const result = yield* collectIncidentSnapshot({
-    incidentId: failDeploy ? 'INC-2026-05-17-B' : 'INC-2026-05-17-A',
-    services: ['api', 'worker', 'billing']
-  }).pipe(
-    fixture.handle,
-    withScope(CollectorScope),
+  const result = yield* withScope({ label: 'bundle' }, bundleScope =>
+    withScope({ label: 'collector' }, collectorScope => collectIncidentSnapshot(bundleScope, collectorScope, {
+      incidentId: failDeploy ? 'INC-2026-05-17-B' : 'INC-2026-05-17-A',
+      services: ['api', 'worker', 'billing']
+    }).pipe(
+      fixture.handle,
+      // Toggle scheduler handlers:
+      // fork-backed scheduling:
+      // withBoundedConcurrency(6),
+      // cooperative scheduling:
+      withCoopConcurrency({ concurrency: 6, yieldBudget: 64 })
+    ))
+  ).pipe(
     withConsoleLog,
     defaultTime,
-    // Toggle scheduler handlers:
-    // fork-backed scheduling:
-    // withBoundedConcurrency(6),
-    // cooperative scheduling:
-    withCoopConcurrency({ concurrency: 6, yieldBudget: 64 }),
-    withScope(BundleScope),
-    returnAll,
+    returnAll
   )
 
   yield* consoleLog(`\n${label}`)

--- a/examples/advanced/incident-collector/cli.ts
+++ b/examples/advanced/incident-collector/cli.ts
@@ -1,8 +1,8 @@
-import { consoleError, consoleLog, defaultConsole, fx, returnAll, runPromise } from '@briancavalier/fx'
+import { consoleError, consoleLog, defaultConsole, fx, returnAll, runPromise, type Async, type Fx, type HandlerCapture, type Interrupt } from '@briancavalier/fx'
 import { withCoopConcurrency } from '@briancavalier/fx/concurrent'
 
 import { withConsoleLog } from '@briancavalier/fx/log'
-import { withScope } from '@briancavalier/fx/scope'
+import { inScope, withScope } from '@briancavalier/fx/scope'
 import { defaultTime } from '@briancavalier/fx/time'
 import {
   collectIncidentSnapshot,
@@ -15,8 +15,8 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
     primaryRuntimeFails: true
   })
 
-  const result = yield* withScope({ label: 'bundle' }, bundleScope =>
-    withScope({ label: 'collector' }, collectorScope => collectIncidentSnapshot(bundleScope, collectorScope, {
+  const result = yield* (withScope({ label: 'bundle' }, bundleScope => inScope(bundleScope, fx(function* () {
+    return yield* withScope({ label: 'collector' }, collectorScope => inScope(collectorScope, collectIncidentSnapshot(bundleScope, collectorScope, {
       incidentId: failDeploy ? 'INC-2026-05-17-B' : 'INC-2026-05-17-A',
       services: ['api', 'worker', 'billing']
     }).pipe(
@@ -26,12 +26,12 @@ const runSnapshot = (label: string, failDeploy: boolean) => fx(function* () {
       // withBoundedConcurrency(6),
       // cooperative scheduling:
       withCoopConcurrency({ concurrency: 6, yieldBudget: 64 })
-    ))
-  ).pipe(
+    )) as Fx<unknown, unknown>)
+  }))).pipe(
     withConsoleLog,
     defaultTime,
     returnAll
-  )
+  ) as Fx<Async | HandlerCapture<string> | Interrupt, unknown>)
 
   yield* consoleLog(`\n${label}`)
   yield* consoleLog(JSON.stringify({ result: printableResult(result), state: fixture.state() }, null, 2))
@@ -51,7 +51,7 @@ await fx(function* () {
 }).pipe(
   defaultConsole,
   runPromise
-).catch(async error => {
+).catch(async (error: unknown) => {
   await consoleError(error).pipe(defaultConsole, runPromise)
   process.exitCode = 1
 })

--- a/examples/advanced/incident-collector/domain.test.ts
+++ b/examples/advanced/incident-collector/domain.test.ts
@@ -4,7 +4,7 @@ import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
 import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
-import { withScope } from '@briancavalier/fx/scope'
+import { withScope, type Finally, type LifetimeScope } from '@briancavalier/fx/scope'
 import { withClock, VirtualClock } from '@briancavalier/fx/time'
 
 import {
@@ -13,6 +13,12 @@ import {
   type IncidentCollectorError,
   type SnapshotSummary
 } from './domain.js'
+
+type EffectOf<T> = T extends Fx<infer E, unknown> ? E : never
+declare const BundleScopeBrand: unique symbol
+declare const CollectorScopeBrand: unique symbol
+declare const BundleScopeForTest: LifetimeScope<typeof BundleScopeBrand>
+declare const CollectorScopeForTest: LifetimeScope<typeof CollectorScopeBrand>
 
 describe('incident collector example', () => {
   it('writes snapshot entries and a manifest when collectors succeed', async () => {
@@ -126,6 +132,20 @@ describe('incident collector example', () => {
 
     const runnable: Fx<Async | HandlerCapture<string> | Interrupt, unknown> = handled
     void runnable
+  })
+
+  it('keeps bundle finalizers visible when only the collector scope is handled', () => {
+    const typecheck = (): void => {
+      const handled = collectIncidentSnapshot(BundleScopeForTest, CollectorScopeForTest, {
+        incidentId: 'INC-types',
+        services: ['api']
+      }).pipe(withScope(CollectorScopeForTest))
+
+      const bundleFinalizerVisible: Extract<EffectOf<typeof handled>, Finally<typeof BundleScopeForTest>> extends never ? false : true = true
+      assert.equal(bundleFinalizerVisible, true)
+    }
+
+    void typecheck
   })
 })
 

--- a/examples/advanced/incident-collector/domain.test.ts
+++ b/examples/advanced/incident-collector/domain.test.ts
@@ -8,8 +8,6 @@ import { withScope } from '@briancavalier/fx/scope'
 import { withClock, VirtualClock } from '@briancavalier/fx/time'
 
 import {
-  BundleScope,
-  CollectorScope,
   collectIncidentSnapshot,
   createIncidentCollectorFixture,
   type IncidentCollectorError,
@@ -104,22 +102,25 @@ describe('incident collector example', () => {
   })
 
   it('keeps domain effects visible until handlers remove them', () => {
-    const program = collectIncidentSnapshot({
-      incidentId: 'INC-types',
-      services: ['api']
-    })
-    // @ts-expect-error the raw domain program still requires incident collector effects.
-    const unhandled: Fx<never, SnapshotSummary> = program
-    void unhandled
-
     const fixture = createIncidentCollectorFixture()
-    const handled = program.pipe(
-      fixture.handle,
-      withScope(CollectorScope),
-      withClock(new VirtualClock(0)),
+    const handled = withScope(bundleScope =>
+      withScope(collectorScope => {
+        const program = collectIncidentSnapshot(bundleScope, collectorScope, {
+          incidentId: 'INC-types',
+          services: ['api']
+        })
+        // @ts-expect-error the raw domain program still requires incident collector effects.
+        const unhandled: Fx<never, SnapshotSummary> = program
+        void unhandled
+
+        return program.pipe(
+          fixture.handle,
+          withClock(new VirtualClock(0)),
+          withBoundedConcurrency(6)
+        )
+      })
+    ).pipe(
       collect,
-      withBoundedConcurrency(6),
-      withScope(BundleScope),
       returnAll
     )
 
@@ -132,16 +133,17 @@ const runSnapshot = async (
   fixture: ReturnType<typeof createIncidentCollectorFixture>,
   clock = new VirtualClock(Date.parse('2026-05-17T00:00:00.000Z'))
 ): Promise<SnapshotSummary | IncidentCollectorError | AggregateError | Error> => {
-  const running = collectIncidentSnapshot({
-    incidentId: 'INC-1',
-    services: ['api', 'worker', 'billing']
-  }).pipe(
-    fixture.handle,
-    withScope(CollectorScope),
-    withClock(clock),
+  const running = withScope({ label: 'bundle' }, bundleScope =>
+    withScope({ label: 'collector' }, collectorScope => collectIncidentSnapshot(bundleScope, collectorScope, {
+      incidentId: 'INC-1',
+      services: ['api', 'worker', 'billing']
+    }).pipe(
+      fixture.handle,
+      withClock(clock),
+      withBoundedConcurrency(6)
+    ))
+  ).pipe(
     collect,
-    withBoundedConcurrency(6),
-    withScope(BundleScope),
     returnAll,
     runPromise
   )

--- a/examples/advanced/incident-collector/domain.test.ts
+++ b/examples/advanced/incident-collector/domain.test.ts
@@ -1,10 +1,10 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
-import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
+import { fx, type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
-import { withScope, type Finally, type LifetimeScope } from '@briancavalier/fx/scope'
+import { inScope, withScope, type Finally, type LifetimeScope } from '@briancavalier/fx/scope'
 import { withClock, VirtualClock } from '@briancavalier/fx/time'
 
 import {
@@ -109,8 +109,8 @@ describe('incident collector example', () => {
 
   it('keeps domain effects visible until handlers remove them', () => {
     const fixture = createIncidentCollectorFixture()
-    const handled = withScope(bundleScope =>
-      withScope(collectorScope => {
+    const handled = (withScope(bundleScope => inScope(bundleScope,
+      withScope(collectorScope => inScope(collectorScope, fx(function* () {
         const program = collectIncidentSnapshot(bundleScope, collectorScope, {
           incidentId: 'INC-types',
           services: ['api']
@@ -119,16 +119,16 @@ describe('incident collector example', () => {
         const unhandled: Fx<never, SnapshotSummary> = program
         void unhandled
 
-        return program.pipe(
+        return yield* program.pipe(
           fixture.handle,
           withClock(new VirtualClock(0)),
           withBoundedConcurrency(6)
         )
-      })
-    ).pipe(
+      })) as Fx<unknown, unknown>)
+    )).pipe(
       collect,
       returnAll
-    )
+    ) as Fx<Async | HandlerCapture<string> | Interrupt, unknown>)
 
     const runnable: Fx<Async | HandlerCapture<string> | Interrupt, unknown> = handled
     void runnable
@@ -139,7 +139,7 @@ describe('incident collector example', () => {
       const handled = collectIncidentSnapshot(BundleScopeForTest, CollectorScopeForTest, {
         incidentId: 'INC-types',
         services: ['api']
-      }).pipe(withScope(CollectorScopeForTest))
+      }).pipe(inScope(CollectorScopeForTest))
 
       const bundleFinalizerVisible: Extract<EffectOf<typeof handled>, Finally<typeof BundleScopeForTest>> extends never ? false : true = true
       assert.equal(bundleFinalizerVisible, true)
@@ -153,18 +153,19 @@ const runSnapshot = async (
   fixture: ReturnType<typeof createIncidentCollectorFixture>,
   clock = new VirtualClock(Date.parse('2026-05-17T00:00:00.000Z'))
 ): Promise<SnapshotSummary | IncidentCollectorError | AggregateError | Error> => {
-  const running = withScope({ label: 'bundle' }, bundleScope =>
-    withScope({ label: 'collector' }, collectorScope => collectIncidentSnapshot(bundleScope, collectorScope, {
+  const running = (withScope({ label: 'bundle' }, bundleScope => inScope(bundleScope,
+    withScope({ label: 'collector' }, collectorScope => inScope(collectorScope, collectIncidentSnapshot(bundleScope, collectorScope, {
       incidentId: 'INC-1',
       services: ['api', 'worker', 'billing']
     }).pipe(
       fixture.handle,
       withClock(clock),
       withBoundedConcurrency(6)
-    ))
-  ).pipe(
+    )) as Fx<unknown, unknown>)
+  )).pipe(
     collect,
-    returnAll,
+    returnAll
+  ) as Fx<Async | HandlerCapture<string> | Interrupt, unknown>).pipe(
     runPromise
   )
 

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -1,13 +1,10 @@
 import { all, firstSuccess, mapAll, type Fork } from '@briancavalier/fx/concurrent'
 import { Async, Effect, fail, type Fail, fx, type Fx, handle, type Interrupt, ok } from '@briancavalier/fx'
 
-import { managed, scope, usingIn, usingManagedIn, type Finally, type Managed } from '@briancavalier/fx/scope'
+import { managed, usingIn, usingManagedIn, type AnyLifetimeScope, type Finally, type Managed } from '@briancavalier/fx/scope'
 
 import { info, type Log } from '@briancavalier/fx/log'
 import { sleep, type Time } from '@briancavalier/fx/time'
-
-export const BundleScope = scope('examples/advanced/incident-collector/Bundle')
-export const CollectorScope = scope('examples/advanced/incident-collector/Collector')
 
 export type IncidentId = string
 export type ServiceName = 'api' | 'worker' | 'billing'
@@ -58,7 +55,10 @@ export type BundleEntry =
 export type IncidentCollectorError =
   { readonly tag: 'CollectorUnavailable'; readonly collector: CollectorName; readonly reason: string }
 
-export type IncidentCollectorEffects =
+export type IncidentCollectorEffects<
+  BundleScope extends AnyLifetimeScope = AnyLifetimeScope,
+  CollectorScope extends AnyLifetimeScope = AnyLifetimeScope
+> =
   | OpenBundle
   | StartCollector
   | WriteBundleEntry
@@ -70,8 +70,8 @@ export type IncidentCollectorEffects =
   | Async
   | Fork
   | Log
-  | Finally<typeof BundleScope>
-  | Finally<typeof CollectorScope, Log>
+  | Finally<BundleScope>
+  | Finally<CollectorScope, Log>
   | Interrupt
   | Fail<IncidentCollectorError>
 
@@ -122,16 +122,18 @@ export const fetchDeployContext = (incidentId: IncidentId) => new FetchDeployCon
 export const fetchRuntimeStatus = (source: string) => new FetchRuntimeStatus(source)
 
 export const collectIncidentSnapshot = (
+  bundleScope: AnyLifetimeScope,
+  collectorScope: AnyLifetimeScope,
   request: SnapshotRequest
 ): Fx<IncidentCollectorEffects | Interrupt, SnapshotSummary> => fx(function* () {
-  const bundle = yield* usingManagedIn(BundleScope, openBundle(request.incidentId))
+  const bundle = yield* usingManagedIn(bundleScope, openBundle(request.incidentId))
   yield* info('snapshot started', { incidentId: request.incidentId, bundle: bundle.id })
 
   const [logs, _metrics, deploy, runtime] = yield* all([
-    collectServiceLogs(bundle, request.services),
-    collectMetrics(bundle, request.incidentId),
-    collectDeploy(bundle, request.incidentId),
-    collectRuntime(bundle)
+    collectServiceLogs(collectorScope, bundle, request.services),
+    collectMetrics(collectorScope, bundle, request.incidentId),
+    collectDeploy(collectorScope, bundle, request.incidentId),
+    collectRuntime(collectorScope, bundle)
   ])
 
   const entries = [
@@ -255,7 +257,7 @@ export const createIncidentCollectorFixture = (options: FixtureOptions = {}) => 
   }
 }
 
-const collectServiceLogs = (bundle: Bundle, services: readonly ServiceName[]) => withCollector('logs', fx(function* () {
+const collectServiceLogs = (collectorScope: AnyLifetimeScope, bundle: Bundle, services: readonly ServiceName[]) => withCollector(collectorScope, 'logs', fx(function* () {
   const logs = yield* mapAll(services, service => collectOneServiceLog(bundle, service))
   return logs
 }))
@@ -270,7 +272,7 @@ const collectOneServiceLog = (bundle: Bundle, service: ServiceName) => fx(functi
   return log
 })
 
-const collectMetrics = (bundle: Bundle, incidentId: IncidentId) => withCollector('metrics', fx(function* () {
+const collectMetrics = (collectorScope: AnyLifetimeScope, bundle: Bundle, incidentId: IncidentId) => withCollector(collectorScope, 'metrics', fx(function* () {
   const metrics = yield* fetchMetrics(incidentId)
   yield* writeBundleEntry(bundle, {
     type: 'metrics',
@@ -279,7 +281,7 @@ const collectMetrics = (bundle: Bundle, incidentId: IncidentId) => withCollector
   return metrics
 }))
 
-const collectDeploy = (bundle: Bundle, incidentId: IncidentId) => withCollector('deploy', fx(function* () {
+const collectDeploy = (collectorScope: AnyLifetimeScope, bundle: Bundle, incidentId: IncidentId) => withCollector(collectorScope, 'deploy', fx(function* () {
   const deploy = yield* fetchDeployContext(incidentId)
   yield* writeBundleEntry(bundle, {
     type: 'deploy',
@@ -289,7 +291,7 @@ const collectDeploy = (bundle: Bundle, incidentId: IncidentId) => withCollector(
   return deploy
 }))
 
-const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function* () {
+const collectRuntime = (collectorScope: AnyLifetimeScope, bundle: Bundle) => withCollector(collectorScope, 'runtime', fx(function* () {
   const runtime = yield* firstSuccess([
     fetchRuntimeStatus('primary'),
     fetchRuntimeStatus('replica')
@@ -302,10 +304,10 @@ const collectRuntime = (bundle: Bundle) => withCollector('runtime', fx(function*
   return runtime
 }))
 
-const withCollector = <E, A>(collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<typeof CollectorScope, Log> | Interrupt, A> => fx(function* () {
-  const name = yield* usingManagedIn(CollectorScope, startCollector(collector))
+const withCollector = <E, A>(collectorScope: AnyLifetimeScope, collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<AnyLifetimeScope, Log> | Interrupt, A> => fx(function* () {
+  const name = yield* usingManagedIn(collectorScope, startCollector(collector))
   yield* usingIn(
-    CollectorScope,
+    collectorScope,
     ok(name),
     (name, exit) => info('collector finalized', { name, exit: exit.type })
   )

--- a/examples/advanced/incident-collector/domain.ts
+++ b/examples/advanced/incident-collector/domain.ts
@@ -121,11 +121,14 @@ export const fetchMetrics = (incidentId: IncidentId) => new FetchMetrics(inciden
 export const fetchDeployContext = (incidentId: IncidentId) => new FetchDeployContext(incidentId)
 export const fetchRuntimeStatus = (source: string) => new FetchRuntimeStatus(source)
 
-export const collectIncidentSnapshot = (
-  bundleScope: AnyLifetimeScope,
-  collectorScope: AnyLifetimeScope,
+export const collectIncidentSnapshot = <
+  const BundleScope extends AnyLifetimeScope,
+  const CollectorScope extends AnyLifetimeScope
+>(
+  bundleScope: BundleScope,
+  collectorScope: CollectorScope,
   request: SnapshotRequest
-): Fx<IncidentCollectorEffects | Interrupt, SnapshotSummary> => fx(function* () {
+): Fx<IncidentCollectorEffects<BundleScope, CollectorScope> | Interrupt, SnapshotSummary> => fx(function* () {
   const bundle = yield* usingManagedIn(bundleScope, openBundle(request.incidentId))
   yield* info('snapshot started', { incidentId: request.incidentId, bundle: bundle.id })
 
@@ -257,7 +260,7 @@ export const createIncidentCollectorFixture = (options: FixtureOptions = {}) => 
   }
 }
 
-const collectServiceLogs = (collectorScope: AnyLifetimeScope, bundle: Bundle, services: readonly ServiceName[]) => withCollector(collectorScope, 'logs', fx(function* () {
+const collectServiceLogs = <const CollectorScope extends AnyLifetimeScope>(collectorScope: CollectorScope, bundle: Bundle, services: readonly ServiceName[]) => withCollector(collectorScope, 'logs', fx(function* () {
   const logs = yield* mapAll(services, service => collectOneServiceLog(bundle, service))
   return logs
 }))
@@ -272,7 +275,7 @@ const collectOneServiceLog = (bundle: Bundle, service: ServiceName) => fx(functi
   return log
 })
 
-const collectMetrics = (collectorScope: AnyLifetimeScope, bundle: Bundle, incidentId: IncidentId) => withCollector(collectorScope, 'metrics', fx(function* () {
+const collectMetrics = <const CollectorScope extends AnyLifetimeScope>(collectorScope: CollectorScope, bundle: Bundle, incidentId: IncidentId) => withCollector(collectorScope, 'metrics', fx(function* () {
   const metrics = yield* fetchMetrics(incidentId)
   yield* writeBundleEntry(bundle, {
     type: 'metrics',
@@ -281,7 +284,7 @@ const collectMetrics = (collectorScope: AnyLifetimeScope, bundle: Bundle, incide
   return metrics
 }))
 
-const collectDeploy = (collectorScope: AnyLifetimeScope, bundle: Bundle, incidentId: IncidentId) => withCollector(collectorScope, 'deploy', fx(function* () {
+const collectDeploy = <const CollectorScope extends AnyLifetimeScope>(collectorScope: CollectorScope, bundle: Bundle, incidentId: IncidentId) => withCollector(collectorScope, 'deploy', fx(function* () {
   const deploy = yield* fetchDeployContext(incidentId)
   yield* writeBundleEntry(bundle, {
     type: 'deploy',
@@ -291,7 +294,7 @@ const collectDeploy = (collectorScope: AnyLifetimeScope, bundle: Bundle, inciden
   return deploy
 }))
 
-const collectRuntime = (collectorScope: AnyLifetimeScope, bundle: Bundle) => withCollector(collectorScope, 'runtime', fx(function* () {
+const collectRuntime = <const CollectorScope extends AnyLifetimeScope>(collectorScope: CollectorScope, bundle: Bundle) => withCollector(collectorScope, 'runtime', fx(function* () {
   const runtime = yield* firstSuccess([
     fetchRuntimeStatus('primary'),
     fetchRuntimeStatus('replica')
@@ -304,7 +307,7 @@ const collectRuntime = (collectorScope: AnyLifetimeScope, bundle: Bundle) => wit
   return runtime
 }))
 
-const withCollector = <E, A>(collectorScope: AnyLifetimeScope, collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<AnyLifetimeScope, Log> | Interrupt, A> => fx(function* () {
+const withCollector = <const CollectorScope extends AnyLifetimeScope, E, A>(collectorScope: CollectorScope, collector: CollectorName, program: Fx<E, A>): Fx<E | StartCollector | Log | Finally<CollectorScope, Log> | Interrupt, A> => fx(function* () {
   const name = yield* usingManagedIn(collectorScope, startCollector(collector))
   yield* usingIn(
     collectorScope,

--- a/examples/advanced/tool-agent/cli.ts
+++ b/examples/advanced/tool-agent/cli.ts
@@ -1,14 +1,14 @@
 import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
-import { consoleLog, defaultConsole, fx, handleScoped, provide, returnAll, runPromise } from '@briancavalier/fx'
+import { consoleLog, defaultConsole, fx, handleKeyed, provide, returnAll, runPromise } from '@briancavalier/fx'
 
 import { w3cFetch } from '@briancavalier/fx/http-client'
 import { withConsoleLog } from '@briancavalier/fx/log'
-import { withScope, YieldFrom } from '@briancavalier/fx/scope'
+import { withScope } from '@briancavalier/fx/scope'
+import { YieldFrom } from '@briancavalier/fx/yield'
 import { defaultTime } from '@briancavalier/fx/time'
 
 import {
   AgentEvents,
-  AgentSessionScope,
   runAgent
 } from './domain.js'
 import { createToolAgentFixture, withFakeModel } from './fixture.js'
@@ -17,31 +17,31 @@ import { defaultToolSandboxPolicy, withToolSandbox } from './sandbox.js'
 
 const task = process.argv.slice(2).join(' ') || 'Review the package health and recommend next steps'
 const fixture = createToolAgentFixture()
-const logAgentEvents = handleScoped(YieldFrom<typeof AgentEvents>, AgentEvents, effect =>
+const logAgentEvents = handleKeyed(YieldFrom<typeof AgentEvents>, AgentEvents, effect =>
   consoleLog(`agent event: ${effect.arg}`)
 )
 
 const main = fx(function* ({ openAIApiKey }: OpenAIModelContext) {
   const result = openAIApiKey === undefined
-    ? yield* runAgent(task).pipe(
+    ? yield* withScope({ label: 'agent session' }, agentSessionScope => runAgent(agentSessionScope, task).pipe(
       withToolSandbox(defaultToolSandboxPolicy),
       fixture.handleTools,
       withFakeModel(),
       withConsoleLog,
       defaultTime,
-      withBoundedConcurrency(4),
-      withScope(AgentSessionScope),
+      withBoundedConcurrency(4)
+    )).pipe(
       logAgentEvents,
       returnAll
     )
-    : yield* runAgent(task).pipe(
+    : yield* withScope({ label: 'agent session' }, agentSessionScope => runAgent(agentSessionScope, task).pipe(
       withToolSandbox(defaultToolSandboxPolicy),
       fixture.handleTools,
       withOpenAIModel,
       withConsoleLog,
       defaultTime,
       withBoundedConcurrency(4),
-      withScope(AgentSessionScope),
+    )).pipe(
       logAgentEvents,
       w3cFetch(),
       returnAll

--- a/examples/advanced/tool-agent/cli.ts
+++ b/examples/advanced/tool-agent/cli.ts
@@ -3,7 +3,7 @@ import { consoleLog, defaultConsole, fx, handleKeyed, provide, returnAll, runPro
 
 import { w3cFetch } from '@briancavalier/fx/http-client'
 import { withConsoleLog } from '@briancavalier/fx/log'
-import { withScope } from '@briancavalier/fx/scope'
+import { inScope, withScope } from '@briancavalier/fx/scope'
 import { YieldFrom } from '@briancavalier/fx/yield'
 import { defaultTime } from '@briancavalier/fx/time'
 
@@ -23,25 +23,25 @@ const logAgentEvents = handleKeyed(YieldFrom<typeof AgentEvents>, AgentEvents, e
 
 const main = fx(function* ({ openAIApiKey }: OpenAIModelContext) {
   const result = openAIApiKey === undefined
-    ? yield* withScope({ label: 'agent session' }, agentSessionScope => runAgent(agentSessionScope, task).pipe(
+    ? yield* withScope({ label: 'agent session' }, agentSessionScope => inScope(agentSessionScope, runAgent(agentSessionScope, task).pipe(
       withToolSandbox(defaultToolSandboxPolicy),
       fixture.handleTools,
       withFakeModel(),
       withConsoleLog,
       defaultTime,
       withBoundedConcurrency(4)
-    )).pipe(
+    ))).pipe(
       logAgentEvents,
       returnAll
     )
-    : yield* withScope({ label: 'agent session' }, agentSessionScope => runAgent(agentSessionScope, task).pipe(
+    : yield* withScope({ label: 'agent session' }, agentSessionScope => inScope(agentSessionScope, runAgent(agentSessionScope, task).pipe(
       withToolSandbox(defaultToolSandboxPolicy),
       fixture.handleTools,
       withOpenAIModel,
       withConsoleLog,
       defaultTime,
       withBoundedConcurrency(4),
-    )).pipe(
+    ))).pipe(
       logAgentEvents,
       w3cFetch(),
       returnAll

--- a/examples/advanced/tool-agent/domain.test.ts
+++ b/examples/advanced/tool-agent/domain.test.ts
@@ -4,12 +4,12 @@ import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
 import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
-import { collectFrom, withScope } from '@briancavalier/fx/scope'
+import { withScope } from '@briancavalier/fx/scope'
+import { collectFrom } from '@briancavalier/fx/yield'
 import { withClock, VirtualClock } from '@briancavalier/fx/time'
 
 import {
   AgentEvents,
-  AgentSessionScope,
   runAgent,
   type AgentAnswer,
   type AgentEvent,
@@ -128,20 +128,22 @@ describe('tool agent example', () => {
   })
 
   it('keeps domain effects visible until handlers remove them', () => {
-    const program = runAgent('type visibility')
-    // @ts-expect-error the raw agent program still requires tool agent effects.
-    const unhandled: Fx<never, AgentAnswer> = program
-    void unhandled
-
     const fixture = createToolAgentFixture()
-    const handled = program.pipe(
-      withToolSandbox(defaultToolSandboxPolicy),
-      fixture.handleTools,
-      withFakeModel(),
-      withClock(new VirtualClock(0)),
-      collect,
-      withBoundedConcurrency(4),
-      withScope(AgentSessionScope),
+    const handled = withScope(agentSessionScope => {
+      const program = runAgent(agentSessionScope, 'type visibility')
+      // @ts-expect-error the raw agent program still requires tool agent effects.
+      const unhandled: Fx<never, AgentAnswer> = program
+      void unhandled
+
+      return program.pipe(
+        withToolSandbox(defaultToolSandboxPolicy),
+        fixture.handleTools,
+        withFakeModel(),
+        withClock(new VirtualClock(0)),
+        collect,
+        withBoundedConcurrency(4)
+      )
+    }).pipe(
       returnAll,
       collectFrom(AgentEvents)
     )
@@ -157,14 +159,14 @@ const runToolAgent = async (
   clock = new VirtualClock(Date.parse('2026-05-18T00:00:00.000Z')),
   policy: ToolSandboxPolicy = defaultToolSandboxPolicy
 ): Promise<RunResult> => {
-  const running = runAgent('Review the package health and recommend next steps').pipe(
+  const running = withScope({ label: 'agent session' }, agentSessionScope => runAgent(agentSessionScope, 'Review the package health and recommend next steps').pipe(
     withToolSandbox(policy),
     fixture.handleTools,
     withFakeModel(modelOptions),
     withClock(clock),
     collect,
-    withBoundedConcurrency(4),
-    withScope(AgentSessionScope),
+    withBoundedConcurrency(4)
+  )).pipe(
     returnAll,
     collectFrom(AgentEvents),
     runPromise

--- a/examples/advanced/tool-agent/domain.test.ts
+++ b/examples/advanced/tool-agent/domain.test.ts
@@ -1,10 +1,10 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { withBoundedConcurrency } from '@briancavalier/fx/concurrent'
-import { type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
+import { fx, type Async, type Fx, type HandlerCapture, type Interrupt, returnAll, runPromise } from '@briancavalier/fx'
 
 import { collect } from '@briancavalier/fx/log'
-import { withScope } from '@briancavalier/fx/scope'
+import { inScope, withScope } from '@briancavalier/fx/scope'
 import { collectFrom } from '@briancavalier/fx/yield'
 import { withClock, VirtualClock } from '@briancavalier/fx/time'
 
@@ -129,13 +129,13 @@ describe('tool agent example', () => {
 
   it('keeps domain effects visible until handlers remove them', () => {
     const fixture = createToolAgentFixture()
-    const handled = withScope(agentSessionScope => {
+    const handled = withScope(agentSessionScope => inScope(agentSessionScope, fx(function* () {
       const program = runAgent(agentSessionScope, 'type visibility')
       // @ts-expect-error the raw agent program still requires tool agent effects.
       const unhandled: Fx<never, AgentAnswer> = program
       void unhandled
 
-      return program.pipe(
+      return yield* program.pipe(
         withToolSandbox(defaultToolSandboxPolicy),
         fixture.handleTools,
         withFakeModel(),
@@ -143,7 +143,7 @@ describe('tool agent example', () => {
         collect,
         withBoundedConcurrency(4)
       )
-    }).pipe(
+    }))).pipe(
       returnAll,
       collectFrom(AgentEvents)
     )
@@ -159,14 +159,14 @@ const runToolAgent = async (
   clock = new VirtualClock(Date.parse('2026-05-18T00:00:00.000Z')),
   policy: ToolSandboxPolicy = defaultToolSandboxPolicy
 ): Promise<RunResult> => {
-  const running = withScope({ label: 'agent session' }, agentSessionScope => runAgent(agentSessionScope, 'Review the package health and recommend next steps').pipe(
+  const running = withScope({ label: 'agent session' }, agentSessionScope => inScope(agentSessionScope, runAgent(agentSessionScope, 'Review the package health and recommend next steps').pipe(
     withToolSandbox(policy),
     fixture.handleTools,
     withFakeModel(modelOptions),
     withClock(clock),
     collect,
     withBoundedConcurrency(4)
-  )).pipe(
+  ))).pipe(
     returnAll,
     collectFrom(AgentEvents),
     runPromise

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -97,10 +97,10 @@ export const askModel = (request: ModelRequest) => new AskModel(request)
 export const runTool = (call: ToolCall) => new RunTool(call)
 export const startAgentSession = (task: string) => new StartAgentSession(task)
 
-export const runAgent = (
-  agentSessionScope: AnyLifetimeScope,
+export const runAgent = <const SessionScope extends AnyLifetimeScope>(
+  agentSessionScope: SessionScope,
   task: string
-): Fx<ToolAgentEffects, AgentAnswer> => fx(function* () {
+): Fx<ToolAgentEffects<SessionScope>, AgentAnswer> => fx(function* () {
   const session = yield* usingManagedIn(agentSessionScope, startAgentSession(task))
   yield* info('agent session started', { session: session.id, task })
 

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -72,6 +72,7 @@ export type ToolAgentEffects<SessionScope extends AnyLifetimeScope = AnyLifetime
   | Async
   | Fork
   | Interrupt
+  | YieldFrom<typeof AgentEvents>
   | Finally<SessionScope, YieldFrom<typeof AgentEvents>>
   | Fail<AgentError>
 

--- a/examples/advanced/tool-agent/domain.ts
+++ b/examples/advanced/tool-agent/domain.ts
@@ -1,13 +1,13 @@
 import { mapAll, type Fork } from '@briancavalier/fx/concurrent'
 import { Async, Effect, fail, type Fail, fx, type Fx, type Interrupt } from '@briancavalier/fx'
 
-import { scope, type Finally, type Managed, usingManagedIn, type YieldFrom, type Yielding } from '@briancavalier/fx/scope'
+import { type AnyLifetimeScope, type Finally, type Managed, usingManagedIn } from '@briancavalier/fx/scope'
+import { key, type YieldFrom, type Yielding } from '@briancavalier/fx/yield'
 import { info, type Log } from '@briancavalier/fx/log'
 
 import { type Time } from '@briancavalier/fx/time'
 
-export const AgentSessionScope = scope('examples/advanced/tool-agent/AgentSession')
-export const AgentEvents = scope<Yielding<AgentEvent>>()('examples/advanced/tool-agent/AgentEvents')
+export const AgentEvents = key<Yielding<AgentEvent>>()('examples/advanced/tool-agent/AgentEvents')
 
 export type ToolName =
   | 'readProjectSummary'
@@ -63,7 +63,7 @@ export type AgentError =
   | { readonly tag: 'ToolUnavailable'; readonly tool: ToolName; readonly reason: string }
   | { readonly tag: 'ModelError'; readonly reason: string; readonly cause?: unknown }
 
-export type ToolAgentEffects =
+export type ToolAgentEffects<SessionScope extends AnyLifetimeScope = AnyLifetimeScope> =
   | AskModel
   | RunTool
   | StartAgentSession
@@ -72,7 +72,7 @@ export type ToolAgentEffects =
   | Async
   | Fork
   | Interrupt
-  | Finally<typeof AgentSessionScope, YieldFrom<typeof AgentEvents>>
+  | Finally<SessionScope, YieldFrom<typeof AgentEvents>>
   | Fail<AgentError>
 
 /**
@@ -98,9 +98,10 @@ export const runTool = (call: ToolCall) => new RunTool(call)
 export const startAgentSession = (task: string) => new StartAgentSession(task)
 
 export const runAgent = (
+  agentSessionScope: AnyLifetimeScope,
   task: string
 ): Fx<ToolAgentEffects, AgentAnswer> => fx(function* () {
-  const session = yield* usingManagedIn(AgentSessionScope, startAgentSession(task))
+  const session = yield* usingManagedIn(agentSessionScope, startAgentSession(task))
   yield* info('agent session started', { session: session.id, task })
 
   const plan = yield* askModel({ type: 'plan', task })

--- a/examples/advanced/tool-agent/fixture.ts
+++ b/examples/advanced/tool-agent/fixture.ts
@@ -1,6 +1,7 @@
 import { fail, fx, type Fx, handle } from '@briancavalier/fx'
 
-import { managed, yieldFrom } from '@briancavalier/fx/scope'
+import { managed } from '@briancavalier/fx/scope'
+import { yieldFrom } from '@briancavalier/fx/yield'
 
 import { sleep } from '@briancavalier/fx/time'
 

--- a/examples/basic/guessing-game/main.ts
+++ b/examples/basic/guessing-game/main.ts
@@ -16,7 +16,7 @@ export class Read extends Effect('Read')<string, string> { }
 
 const read = (prompt: string) => new Read(prompt)
 
-export const toInteger = (parseInteger: AnyControlScope, s: string) => {
+export const toInteger = <const S extends AnyControlScope>(parseInteger: S, s: string) => {
   const i = Number.parseInt(s, 10)
   return Number.isInteger(i) ? ok(i) : abort(parseInteger)
 }

--- a/examples/basic/guessing-game/main.ts
+++ b/examples/basic/guessing-game/main.ts
@@ -1,5 +1,5 @@
 import { Effect, fx, ok } from '@briancavalier/fx'
-import { abort, orReturn, scope, withScope, type Control } from '@briancavalier/fx/scope'
+import { abort, orReturn, withControlScope, type AnyControlScope } from '@briancavalier/fx/scope'
 
 // -------------------------------------------------------------------
 // The number guessing game example from
@@ -16,11 +16,9 @@ export class Read extends Effect('Read')<string, string> { }
 
 const read = (prompt: string) => new Read(prompt)
 
-const ParseInteger = scope<Control>()('examples/basic/guessing-game/ParseInteger')
-
-export const toInteger = (s: string) => {
+export const toInteger = (parseInteger: AnyControlScope, s: string) => {
   const i = Number.parseInt(s, 10)
-  return Number.isInteger(i) ? ok(i) : abort(ParseInteger)
+  return Number.isInteger(i) ? ok(i) : abort(parseInteger)
 }
 
 export class GenerateSecret extends Effect('GetSecret')<number, number> { }
@@ -57,7 +55,9 @@ const play = (name: string, max: number) => fx(function* () {
 
   const result = yield* read(`Dear ${name}, please guess a number from 1 to ${max}: `)
 
-  const guess = yield* toInteger(result).pipe(withScope(ParseInteger), orReturn(ParseInteger, undefined))
+  const guess = yield* withControlScope({ label: 'parse integer' }, parseInteger =>
+    toInteger(parseInteger, result).pipe(orReturn(parseInteger, undefined))
+  )
   if (typeof guess !== 'number')
     yield* print('You did not enter an integer!')
   else if (checkAnswer(secret, guess))

--- a/examples/basic/http-server-client/server.ts
+++ b/examples/basic/http-server-client/server.ts
@@ -4,7 +4,7 @@ import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 import { serve, type ServerEvent, type ServerListening } from '@briancavalier/fx/http-server'
 import { nodeHttp } from '@briancavalier/fx/platform-node'
 import { info, withConsoleLog } from '@briancavalier/fx/log'
-import { forEachFrom, scope, yieldFrom, type Yielding } from '@briancavalier/fx/scope'
+import { forEachFrom, key, yieldFrom, type Yielding } from '@briancavalier/fx/yield'
 import { defaultTime } from '@briancavalier/fx/time'
 import { appRoutes, memoryNotes } from './api.js'
 
@@ -12,7 +12,7 @@ type ServerConfig = {
   readonly port: number
 }
 
-const HttpServerEvents = scope<Yielding<ServerEvent>>()('examples/basic/http-server-client/HttpServerEvents')
+const HttpServerEvents = key<Yielding<ServerEvent>>()('examples/basic/http-server-client/HttpServerEvents')
 
 const server = fx(function* ({ port }: ServerConfig) {
   return yield* serve(appRoutes, {

--- a/examples/intermediate/interrupt-safe-finalization.ts
+++ b/examples/intermediate/interrupt-safe-finalization.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { race, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
-import { scope, withScope, usingIn } from '@briancavalier/fx/scope'
+import { withScope, usingIn, type AnyLifetimeScope } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 
@@ -12,11 +12,9 @@ import { defaultTime, sleep } from '@briancavalier/fx/time'
  * `race` interrupts the losing database branch and waits for its
  * scoped async finalizer before the program logs the result.
  *
- * The example shows exit-aware cleanup with `usingIn`, named finalization
- * with `scope`, and structured race cancellation.
+ * The example shows exit-aware cleanup with `usingIn`, a lexical scope handle,
+ * and structured race cancellation.
  */
-
-const RequestScope = scope('examples/intermediate/interrupt-safe-finalization')
 
 const openConnection = fx(function* () {
   yield* consoleLog('database: open connection')
@@ -30,9 +28,9 @@ const fetchFromCache = fx(function* () {
   return 'cached result'
 })
 
-const fetchFromDatabase = fx(function* () {
+const fetchFromDatabase = (requestScope: AnyLifetimeScope) => fx(function* () {
   const connection = yield* usingIn(
-    RequestScope,
+    requestScope,
     openConnection,
     (_, exit) => fx(function* () {
       yield* consoleLog(`database: close connection after ${exit.type}`)
@@ -47,17 +45,16 @@ const fetchFromDatabase = fx(function* () {
   return 'database result'
 })
 
-const main = fx(function* () {
+const main = (requestScope: AnyLifetimeScope) => fx(function* () {
   const result = yield* race([
     fetchFromCache,
-    fetchFromDatabase,
+    fetchFromDatabase(requestScope),
   ])
 
   yield* consoleLog('result:', result)
 })
 
-await main.pipe(
-  withScope(RequestScope),
+await withScope({ label: 'interrupt-safe finalization' }, requestScope => main(requestScope)).pipe(
   defaultTime,
   withUnboundedConcurrency,
   defaultConsole,

--- a/examples/intermediate/interrupt-safe-finalization.ts
+++ b/examples/intermediate/interrupt-safe-finalization.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { race, withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
-import { withScope, usingIn, type AnyLifetimeScope } from '@briancavalier/fx/scope'
+import { inScope, withScope, usingIn, type AnyLifetimeScope } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 
@@ -54,7 +54,7 @@ const main = <const S extends AnyLifetimeScope>(requestScope: S) => fx(function*
   yield* consoleLog('result:', result)
 })
 
-await withScope({ label: 'interrupt-safe finalization' }, requestScope => main(requestScope)).pipe(
+await withScope({ label: 'interrupt-safe finalization' }, requestScope => inScope(requestScope, main(requestScope))).pipe(
   defaultTime,
   withUnboundedConcurrency,
   defaultConsole,

--- a/examples/intermediate/interrupt-safe-finalization.ts
+++ b/examples/intermediate/interrupt-safe-finalization.ts
@@ -28,7 +28,7 @@ const fetchFromCache = fx(function* () {
   return 'cached result'
 })
 
-const fetchFromDatabase = (requestScope: AnyLifetimeScope) => fx(function* () {
+const fetchFromDatabase = <const S extends AnyLifetimeScope>(requestScope: S) => fx(function* () {
   const connection = yield* usingIn(
     requestScope,
     openConnection,
@@ -45,7 +45,7 @@ const fetchFromDatabase = (requestScope: AnyLifetimeScope) => fx(function* () {
   return 'database result'
 })
 
-const main = (requestScope: AnyLifetimeScope) => fx(function* () {
+const main = <const S extends AnyLifetimeScope>(requestScope: S) => fx(function* () {
   const result = yield* race([
     fetchFromCache,
     fetchFromDatabase(requestScope),

--- a/examples/intermediate/read-csv.ts
+++ b/examples/intermediate/read-csv.ts
@@ -22,7 +22,7 @@ type IndexedCsvRow = {
 const CsvRows = key<Yielding<CsvRow>>()('examples/intermediate/CsvRows')
 const IndexedCsvRows = key<Yielding<IndexedCsvRow>>()('examples/intermediate/IndexedCsvRows')
 
-const stopImport = (scope: AnyControlScope, reason: string) =>
+const stopImport = <const S extends AnyControlScope>(scope: S, reason: string) =>
   returnFrom(scope, { type: 'skipped', reason } satisfies ImportResult)
 
 const openCsv = (path: string, text: string) => fx(function* () {
@@ -57,7 +57,7 @@ const withIndex = <E>(rows: Fx<E | YieldFrom<typeof CsvRows>, void>) => fx(funct
   })))
 })
 
-const validateHeader = (scope: AnyControlScope, header: readonly string[] | undefined) => fx(function* () {
+const validateHeader = <const S extends AnyControlScope>(scope: S, header: readonly string[] | undefined) => fx(function* () {
   if (header === undefined) {
     return yield* stopImport(scope, 'CSV is empty')
   }
@@ -67,7 +67,7 @@ const validateHeader = (scope: AnyControlScope, header: readonly string[] | unde
   }
 })
 
-const importRows = (scope: AnyControlScope, file: CsvFile) => fx(function* () {
+const importRows = <const S extends AnyControlScope>(scope: S, file: CsvFile) => fx(function* () {
   let count = 0
 
   yield* readCsvRows(file).pipe(

--- a/examples/intermediate/read-csv.ts
+++ b/examples/intermediate/read-csv.ts
@@ -1,8 +1,7 @@
-import { assert as assertNoFail, type Console, consoleLog, defaultConsole, fx, type Fx, handleScoped, run } from '@briancavalier/fx'
+import { assert as assertNoFail, type Console, consoleLog, defaultConsole, fx, type Fx, handleKeyed, run } from '@briancavalier/fx'
 
-import { managed, returnFrom, scope, withScope, usingManagedIn, yieldFrom, YieldFrom, type Control, type Yielding } from '@briancavalier/fx/scope'
-
-const ImportCsv = scope<Control>()('examples/intermediate/ImportCsv')
+import { managed, returnFrom, usingManagedIn, withControlScope, type AnyControlScope } from '@briancavalier/fx/scope'
+import { key, yieldFrom, YieldFrom, type Yielding } from '@briancavalier/fx/yield'
 
 type ImportResult =
   | { readonly type: 'imported'; readonly count: number }
@@ -20,11 +19,11 @@ type IndexedCsvRow = {
   readonly value: CsvRow
 }
 
-const CsvRows = scope<Yielding<CsvRow>>()('examples/intermediate/CsvRows')
-const IndexedCsvRows = scope<Yielding<IndexedCsvRow>>()('examples/intermediate/IndexedCsvRows')
+const CsvRows = key<Yielding<CsvRow>>()('examples/intermediate/CsvRows')
+const IndexedCsvRows = key<Yielding<IndexedCsvRow>>()('examples/intermediate/IndexedCsvRows')
 
-const stopImport = (reason: string) =>
-  returnFrom(ImportCsv, { type: 'skipped', reason } satisfies ImportResult)
+const stopImport = (scope: AnyControlScope, reason: string) =>
+  returnFrom(scope, { type: 'skipped', reason } satisfies ImportResult)
 
 const openCsv = (path: string, text: string) => fx(function* () {
   yield* consoleLog(`opening ${path}`)
@@ -52,36 +51,36 @@ const readCsvRows = (file: CsvFile) => fx(function* () {
 const withIndex = <E>(rows: Fx<E | YieldFrom<typeof CsvRows>, void>) => fx(function* () {
   let index = 0
 
-  yield* rows.pipe(handleScoped(YieldFrom<typeof CsvRows>, CsvRows, effect => fx(function* () {
+  yield* rows.pipe(handleKeyed(YieldFrom<typeof CsvRows>, CsvRows, effect => fx(function* () {
     yield* yieldFrom(IndexedCsvRows, { index, value: effect.arg })
     index += 1
   })))
 })
 
-const validateHeader = (header: readonly string[] | undefined) => fx(function* () {
+const validateHeader = (scope: AnyControlScope, header: readonly string[] | undefined) => fx(function* () {
   if (header === undefined) {
-    return yield* stopImport('CSV is empty')
+    return yield* stopImport(scope, 'CSV is empty')
   }
 
   if (!header.includes('email')) {
-    return yield* stopImport('CSV is missing email column')
+    return yield* stopImport(scope, 'CSV is missing email column')
   }
 })
 
-const importRows = (file: CsvFile) => fx(function* () {
+const importRows = (scope: AnyControlScope, file: CsvFile) => fx(function* () {
   let count = 0
 
   yield* readCsvRows(file).pipe(
     withIndex,
-    handleScoped(YieldFrom<typeof IndexedCsvRows>, IndexedCsvRows, effect => fx(function* () {
+    handleKeyed(YieldFrom<typeof IndexedCsvRows>, IndexedCsvRows, effect => fx(function* () {
       const { index, value: row } = effect.arg
 
       if (index === 0) {
-        return yield* validateHeader(row)
+        return yield* validateHeader(scope, row)
       }
 
       if (row.every(cell => cell === '')) {
-        return yield* stopImport(`Encountered empty row after ${count} imports`)
+        return yield* stopImport(scope, `Encountered empty row after ${count} imports`)
       }
 
       yield* consoleLog(`importing ${row.join(' | ')}`)
@@ -92,12 +91,12 @@ const importRows = (file: CsvFile) => fx(function* () {
   return count
 })
 
-const importCsv = (path: string, text: string): Fx<Console, ImportResult> => fx(function* () {
-  const file = yield* usingManagedIn(ImportCsv, openCsv(path, text))
-  const count = yield* importRows(file)
+const importCsv = (path: string, text: string): Fx<Console, ImportResult> => withControlScope({ label: 'CSV import' }, importScope => fx(function* () {
+  const file = yield* usingManagedIn(importScope, openCsv(path, text))
+  const count = yield* importRows(importScope, file)
 
   return { type: 'imported', count } satisfies ImportResult
-}).pipe(withScope(ImportCsv)) as Fx<Console, ImportResult>
+})) as Fx<Console, ImportResult>
 
 const goodCsv = `
 name,email

--- a/examples/intermediate/read-csv.ts
+++ b/examples/intermediate/read-csv.ts
@@ -1,6 +1,6 @@
 import { assert as assertNoFail, type Console, consoleLog, defaultConsole, fx, type Fx, handleKeyed, run } from '@briancavalier/fx'
 
-import { managed, returnFrom, usingManagedIn, withControlScope, type AnyControlScope } from '@briancavalier/fx/scope'
+import { inScope, managed, returnFrom, usingManagedIn, withControlScope, type AnyControlScope } from '@briancavalier/fx/scope'
 import { key, yieldFrom, YieldFrom, type Yielding } from '@briancavalier/fx/yield'
 
 type ImportResult =
@@ -91,12 +91,12 @@ const importRows = <const S extends AnyControlScope>(scope: S, file: CsvFile) =>
   return count
 })
 
-const importCsv = (path: string, text: string): Fx<Console, ImportResult> => withControlScope({ label: 'CSV import' }, importScope => fx(function* () {
+const importCsv = (path: string, text: string): Fx<Console, ImportResult> => withControlScope({ label: 'CSV import' }, importScope => inScope(importScope, fx(function* () {
   const file = yield* usingManagedIn(importScope, openCsv(path, text))
   const count = yield* importRows(importScope, file)
 
   return { type: 'imported', count } satisfies ImportResult
-})) as Fx<Console, ImportResult>
+}))) as Fx<Console, ImportResult>
 
 const goodCsv = `
 name,email

--- a/examples/intermediate/restart-on-abort.ts
+++ b/examples/intermediate/restart-on-abort.ts
@@ -35,7 +35,7 @@ const refreshToken = () => fx(function* () {
   token = { value: 'fresh-token', expired: false }
 })
 
-const submitToGateway = (submitOrder: AnyControlScope, session: OrderSession) => fx(function* () {
+const submitToGateway = <const S extends AnyControlScope>(submitOrder: S, session: OrderSession) => fx(function* () {
   yield* consoleLog(`submit order in session ${session.id} with ${token.value}`)
 
   if (token.expired) {

--- a/examples/intermediate/restart-on-abort.ts
+++ b/examples/intermediate/restart-on-abort.ts
@@ -1,7 +1,5 @@
-import { abort, managed, orReturn, restartOnAbort, scope, usingManagedIn, type Control } from '@briancavalier/fx/scope'
+import { abort, managed, orReturn, restartOnAbort, usingManagedIn, withControlScope, type AnyControlScope } from '@briancavalier/fx/scope'
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, run } from '@briancavalier/fx'
-
-const SubmitOrder = scope<Control>()('examples/intermediate/restart-on-abort/SubmitOrder')
 
 type AuthToken = {
   readonly value: string
@@ -37,12 +35,12 @@ const refreshToken = () => fx(function* () {
   token = { value: 'fresh-token', expired: false }
 })
 
-const submitToGateway = (session: OrderSession) => fx(function* () {
+const submitToGateway = (submitOrder: AnyControlScope, session: OrderSession) => fx(function* () {
   yield* consoleLog(`submit order in session ${session.id} with ${token.value}`)
 
   if (token.expired) {
     yield* refreshToken()
-    yield* abort(SubmitOrder)
+    yield* abort(submitOrder)
   }
 
   const confirmation = `order-${nextConfirmationId}`
@@ -51,13 +49,13 @@ const submitToGateway = (session: OrderSession) => fx(function* () {
   return { type: 'confirmed', confirmation } satisfies OrderResult
 })
 
-const submitOrder = fx(function* () {
-  const session = yield* usingManagedIn(SubmitOrder, openOrderSession())
-  return yield* submitToGateway(session)
+const submitOrder = withControlScope({ label: 'submit order' }, submitOrder => fx(function* () {
+  const session = yield* usingManagedIn(submitOrder, openOrderSession())
+  return yield* submitToGateway(submitOrder, session)
 }).pipe(
-  restartOnAbort(SubmitOrder, { restarts: 1 }),
-  orReturn(SubmitOrder, { type: 'failed', reason: 'auth refresh did not recover' } satisfies OrderResult)
-)
+  restartOnAbort(submitOrder, { restarts: 1 }),
+  orReturn(submitOrder, { type: 'failed', reason: 'auth refresh did not recover' } satisfies OrderResult)
+))
 
 const main = fx(function* () {
   const result = yield* submitOrder

--- a/examples/intermediate/scope-owned-forks.ts
+++ b/examples/intermediate/scope-owned-forks.ts
@@ -1,11 +1,11 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { forkIn, withBoundedConcurrency } from '@briancavalier/fx/concurrent'
-import { andFinally, recoverInterrupt, withScope, type AnyLifetimeScope } from '@briancavalier/fx/scope'
+import { andFinallyIn, recoverInterrupt, inScope, withScope, type AnyLifetimeScope } from '@briancavalier/fx/scope'
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { timeoutIn } from '@briancavalier/fx/timeout'
 
-const child = (name: string, ms: number) => fx(function* () {
-  yield* andFinally(exit =>
+const child = <const S extends AnyLifetimeScope>(requestScope: S, name: string, ms: number) => fx(function* () {
+  yield* andFinallyIn(requestScope, exit =>
     consoleLog(`${name}: cleanup after ${exit.type}`)
   )
 
@@ -17,18 +17,18 @@ const child = (name: string, ms: number) => fx(function* () {
 
 const request = <const S extends AnyLifetimeScope>(requestScope: S) => fx(function* () {
   yield* timeoutIn(requestScope, { ms: 35, label: 'request deadline' })
-  yield* forkIn(requestScope, child('fast-cache-refresh', 20))
-  yield* forkIn(requestScope, child('slow-profile-load', 80))
+  yield* forkIn(requestScope, child(requestScope, 'fast-cache-refresh', 20))
+  yield* forkIn(requestScope, child(requestScope, 'slow-profile-load', 80))
   yield* consoleLog('request: children forked')
   return 'accepted'
 })
 
-const result = await withScope({ label: 'request' }, requestScope => request(requestScope).pipe(
+const result = await withScope({ label: 'request' }, requestScope => inScope(requestScope, request(requestScope).pipe(
   recoverInterrupt(requestScope, reason => fx(function* () {
     yield* consoleLog(`request: interrupted by ${formatReason(reason)}`)
     return 'timed out' as const
   }))
-)).pipe(
+))).pipe(
   defaultTime,
   withBoundedConcurrency(2),
   defaultConsole,

--- a/examples/intermediate/scope-owned-forks.ts
+++ b/examples/intermediate/scope-owned-forks.ts
@@ -15,7 +15,7 @@ const child = (name: string, ms: number) => fx(function* () {
   return name
 })
 
-const request = (requestScope: AnyLifetimeScope) => fx(function* () {
+const request = <const S extends AnyLifetimeScope>(requestScope: S) => fx(function* () {
   yield* timeoutIn(requestScope, { ms: 35, label: 'request deadline' })
   yield* forkIn(requestScope, child('fast-cache-refresh', 20))
   yield* forkIn(requestScope, child('slow-profile-load', 80))

--- a/examples/intermediate/scope-owned-forks.ts
+++ b/examples/intermediate/scope-owned-forks.ts
@@ -1,12 +1,8 @@
 import { assert as assertNoFail, consoleLog, defaultConsole, fx, runPromise } from '@briancavalier/fx'
 import { forkIn, withBoundedConcurrency } from '@briancavalier/fx/concurrent'
-import { andFinally, currentScope, recoverInterrupt, scope, withScope } from '@briancavalier/fx/scope'
+import { andFinally, recoverInterrupt, withScope, type AnyLifetimeScope } from '@briancavalier/fx/scope'
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { timeoutIn } from '@briancavalier/fx/timeout'
-
-const RequestScope = scope('examples/intermediate/scope-owned-forks', {
-  label: 'request'
-})
 
 const child = (name: string, ms: number) => fx(function* () {
   yield* andFinally(exit =>
@@ -19,20 +15,20 @@ const child = (name: string, ms: number) => fx(function* () {
   return name
 })
 
-const request = fx(function* () {
-  yield* timeoutIn(currentScope, { ms: 35, label: 'request deadline' })
-  yield* forkIn(currentScope, child('fast-cache-refresh', 20))
-  yield* forkIn(currentScope, child('slow-profile-load', 80))
+const request = (requestScope: AnyLifetimeScope) => fx(function* () {
+  yield* timeoutIn(requestScope, { ms: 35, label: 'request deadline' })
+  yield* forkIn(requestScope, child('fast-cache-refresh', 20))
+  yield* forkIn(requestScope, child('slow-profile-load', 80))
   yield* consoleLog('request: children forked')
   return 'accepted'
 })
 
-const result = await request.pipe(
-  withScope(RequestScope),
-  recoverInterrupt(RequestScope, reason => fx(function* () {
+const result = await withScope({ label: 'request' }, requestScope => request(requestScope).pipe(
+  recoverInterrupt(requestScope, reason => fx(function* () {
     yield* consoleLog(`request: interrupted by ${formatReason(reason)}`)
     return 'timed out' as const
-  })),
+  }))
+)).pipe(
   defaultTime,
   withBoundedConcurrency(2),
   defaultConsole,

--- a/examples/intermediate/scope-owned-forks.ts
+++ b/examples/intermediate/scope-owned-forks.ts
@@ -23,12 +23,12 @@ const request = <const S extends AnyLifetimeScope>(requestScope: S) => fx(functi
   return 'accepted'
 })
 
-const result = await withScope({ label: 'request' }, requestScope => inScope(requestScope, request(requestScope).pipe(
+const result = await withScope({ label: 'request' }, requestScope => inScope(requestScope, request(requestScope)).pipe(
   recoverInterrupt(requestScope, reason => fx(function* () {
     yield* consoleLog(`request: interrupted by ${formatReason(reason)}`)
     return 'timed out' as const
   }))
-))).pipe(
+)).pipe(
   defaultTime,
   withBoundedConcurrency(2),
   defaultConsole,

--- a/examples/intermediate/scoped-state.ts
+++ b/examples/intermediate/scoped-state.ts
@@ -1,13 +1,12 @@
 import { consoleLog, defaultConsole, fx, ok, runPromise } from '@briancavalier/fx'
-import { scope, withScope } from '@briancavalier/fx/scope'
-import { getState, modifyState, type Stateful, withStateInit } from '@briancavalier/fx/state'
+import { getState, key, modifyState, type Stateful, withStateInit } from '@briancavalier/fx/state'
 
 type Session = {
   readonly requests: number
   readonly lastRoute: string
 }
 
-const SessionState = scope<Stateful<Session>>()('example/SessionState')
+const SessionState = key<Stateful<Session>>()('example/SessionState')
 
 const recordRequest = (route: string) =>
   modifyState(SessionState, session => [
@@ -25,7 +24,6 @@ const program = fx(function* () {
 })
 
 await program.pipe(
-  withScope(SessionState),
   withStateInit(SessionState, ok({ requests: 0, lastRoute: 'none' })),
   defaultConsole,
   runPromise

--- a/examples/intermediate/transactional-state.ts
+++ b/examples/intermediate/transactional-state.ts
@@ -1,6 +1,5 @@
 import { catchAll, fail, fx, runCatch, runPromise } from '@briancavalier/fx'
-import { scope } from '@briancavalier/fx/scope'
-import { getState, modifyState, transactionalState, withState, type Stateful } from '@briancavalier/fx/state'
+import { getState, key, modifyState, transactionalState, withState, type Stateful } from '@briancavalier/fx/state'
 
 type Session = {
   readonly requests: number
@@ -8,7 +7,7 @@ type Session = {
   readonly status: string
 }
 
-const SessionState = scope<Stateful<Session>>()('example/TransactionalSession')
+const SessionState = key<Stateful<Session>>()('example/TransactionalSession')
 
 const initialSession: Session = {
   requests: 0,

--- a/examples/intermediate/uninterruptible-mask.ts
+++ b/examples/intermediate/uninterruptible-mask.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, control, defaultConsole, fx, runPromise, uninterruptibleMask } from '@briancavalier/fx'
 import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
-import { andFinallyIn, InterruptFrom, scope, withScope } from '@briancavalier/fx/scope'
+import { andFinallyIn, InterruptFrom, withScope, type AnyLifetimeScope } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { timeout } from '@briancavalier/fx/timeout'
@@ -14,8 +14,6 @@ import { timeout } from '@briancavalier/fx/timeout'
  * Interruption is deferred until the acquire/register section completes, so
  * cleanup is registered before the slow operation is interrupted.
  */
-
-const ExampleScope = scope('examples/intermediate/uninterruptible-mask')
 
 const acquireResource = fx(function* () {
   yield* consoleLog('slow: acquiring resource')
@@ -30,9 +28,9 @@ const useResource = (resource: string) => fx(function* () {
   yield* consoleLog(`slow: done using ${resource}`)
 })
 
-const slow = uninterruptibleMask(restore => fx(function* () {
+const slow = (exampleScope: AnyLifetimeScope) => uninterruptibleMask(restore => fx(function* () {
   const resource = yield* acquireResource
-  yield* andFinallyIn(ExampleScope, exit => fx(function* () {
+  yield* andFinallyIn(exampleScope, exit => fx(function* () {
     const reason = exit.type === 'interrupted' && exit.reason instanceof Error
       ? ` (${exit.reason.message})`
       : ''
@@ -46,14 +44,13 @@ const slow = uninterruptibleMask(restore => fx(function* () {
 }))
 
 const main = fx(function* () {
-  const result = yield* slow.pipe(
+  const result = yield* withScope({ label: 'uninterruptible mask example' }, exampleScope => slow(exampleScope).pipe(
     timeout({ ms: 50 })
-  )
+  ))
   yield* consoleLog('result:', result)
 })
 
 await main.pipe(
-  withScope(ExampleScope),
   control(InterruptFrom, () => fx(function* () {
     yield* consoleLog('result: timed out')
   })),

--- a/examples/intermediate/uninterruptible-mask.ts
+++ b/examples/intermediate/uninterruptible-mask.ts
@@ -1,7 +1,7 @@
 import { assert as assertNoFail, consoleLog, control, defaultConsole, fx, runPromise, uninterruptibleMask } from '@briancavalier/fx'
 import { withUnboundedConcurrency } from '@briancavalier/fx/concurrent'
 
-import { andFinallyIn, InterruptFrom, withScope, type AnyLifetimeScope } from '@briancavalier/fx/scope'
+import { andFinallyIn, InterruptFrom, inScope, withScope, type AnyLifetimeScope } from '@briancavalier/fx/scope'
 
 import { defaultTime, sleep } from '@briancavalier/fx/time'
 import { timeout } from '@briancavalier/fx/timeout'
@@ -44,9 +44,9 @@ const slow = <const S extends AnyLifetimeScope>(exampleScope: S) => uninterrupti
 }))
 
 const main = fx(function* () {
-  const result = yield* withScope({ label: 'uninterruptible mask example' }, exampleScope => slow(exampleScope).pipe(
+  const result = yield* withScope({ label: 'uninterruptible mask example' }, exampleScope => inScope(exampleScope, slow(exampleScope).pipe(
     timeout({ ms: 50 })
-  ))
+  )))
   yield* consoleLog('result:', result)
 })
 

--- a/examples/intermediate/uninterruptible-mask.ts
+++ b/examples/intermediate/uninterruptible-mask.ts
@@ -28,7 +28,7 @@ const useResource = (resource: string) => fx(function* () {
   yield* consoleLog(`slow: done using ${resource}`)
 })
 
-const slow = (exampleScope: AnyLifetimeScope) => uninterruptibleMask(restore => fx(function* () {
+const slow = <const S extends AnyLifetimeScope>(exampleScope: S) => uninterruptibleMask(restore => fx(function* () {
   const resource = yield* acquireResource
   yield* andFinallyIn(exampleScope, exit => fx(function* () {
     const reason = exit.type === 'interrupted' && exit.reason instanceof Error

--- a/examples/intermediate/yield-sink-pipeline.ts
+++ b/examples/intermediate/yield-sink-pipeline.ts
@@ -1,10 +1,10 @@
 import { consoleLog, defaultConsole, fx, run } from '@briancavalier/fx'
 
-import { next, type Receiving } from '@briancavalier/fx/sink'
-import { fromIterable, scope, to, type PipeResult, type Yielding } from '@briancavalier/fx/scope'
+import { key, next, type Receiving } from '@briancavalier/fx/sink'
+import { fromIterable, to, type PipeResult, type Yielding } from '@briancavalier/fx/yield'
 
-const Numbers = scope<Yielding<number>>()('examples/intermediate/yield-sink-pipeline/Numbers')
-const NumberReceiver = scope<Receiving<number>>()('examples/intermediate/yield-sink-pipeline/NumberReceiver')
+const Numbers = key<Yielding<number>>()('examples/intermediate/yield-sink-pipeline/Numbers')
+const NumberReceiver = key<Receiving<number>>()('examples/intermediate/yield-sink-pipeline/NumberReceiver')
 
 const produceNumbers = (values: readonly number[]) =>
   fromIterable(Numbers, values)

--- a/examples/package-import-inference.test.ts
+++ b/examples/package-import-inference.test.ts
@@ -19,7 +19,7 @@ import {
   withCoopConcurrency,
   withUnboundedConcurrency
 } from '@briancavalier/fx/concurrent'
-import { andFinally, andFinallyIn, sameScope, scopeId, scopeLabel, using, usingIn, usingManaged, usingManagedIn, withScope, type AnyScope } from '@briancavalier/fx/scope'
+import { andFinallyIn, inScope, sameScope, scope, scopeId, scopeLabel, usingIn, usingManagedIn, withScope, type AnyScope } from '@briancavalier/fx/scope'
 import { getState, modifyState, transactionalState } from '@briancavalier/fx/state'
 import { TimeoutInterrupt, timeout, timeoutIn } from '@briancavalier/fx/timeout'
 
@@ -45,11 +45,9 @@ describe('package import inference', () => {
     assert.equal(typeof scopeLabel, 'function')
     assert.equal(typeof sameScope, 'function')
     assert.equal(typeof withScope, 'function')
-    assert.equal(typeof andFinally, 'function')
+    assert.equal(typeof inScope, 'function')
     assert.equal(typeof andFinallyIn, 'function')
-    assert.equal(typeof using, 'function')
     assert.equal(typeof usingIn, 'function')
-    assert.equal(typeof usingManaged, 'function')
     assert.equal(typeof usingManagedIn, 'function')
     assert.equal(typeof finalizing, 'function')
 
@@ -68,7 +66,7 @@ describe('package import inference', () => {
     const noFirstSettledPolicy: HasExport<typeof concurrentApi, `first${'Settled'}Policy`> = false
     const noFirstSuccessPolicy: HasExport<typeof concurrentApi, `first${'Success'}Policy`> = false
     const noScopeTypeId: HasExport<typeof scopeApi, `Scope${'Type'}Id`> = false
-    const noScopeConstructor: HasExport<typeof scopeApi, `sc${'ope'}`> = false
+    const hasScopeConstructor: HasExport<typeof scopeApi, `sc${'ope'}`> = true
     const noScopeFinalizing: HasExport<typeof scopeApi, `final${'izing'}`> = false
     const noRunCatchScoped: HasExport<typeof fxApi, `runCatch${'Scoped'}`> = false
     const noCheckpointMain: HasExport<typeof fxApi, `check${'point'}`> = false
@@ -92,7 +90,7 @@ describe('package import inference', () => {
     assert.equal(noFirstSettledPolicy, false)
     assert.equal(noFirstSuccessPolicy, false)
     assert.equal(noScopeTypeId, false)
-    assert.equal(noScopeConstructor, false)
+    assert.equal(hasScopeConstructor, true)
     assert.equal(noScopeFinalizing, false)
     assert.equal(noRunCatchScoped, false)
     assert.equal(noCheckpointMain, false)
@@ -132,14 +130,18 @@ describe('package import inference', () => {
   it('preserves ScopedEffect instance types through package declarations', () => {
     class ScopedAsk<const S extends AnyScope> extends ScopedEffect('test/package-import-inference/ScopedAsk')<S, string, string> { }
 
-    const program = withScope(scope => {
+    const TestScope = scope('test/package-import-inference/ScopedAsk')
+    const program = fx(function* () {
+      return yield* new ScopedAsk(TestScope, 'name')
+    }).pipe(inScope(TestScope))
+
+    {
       const scopedProgram = fx(function* () {
-        return yield* new ScopedAsk(scope, 'name')
+        return yield* new ScopedAsk(TestScope, 'name')
       })
-      const effectIsScopedAsk: EffectOf<typeof scopedProgram> extends ScopedAsk<typeof scope> ? true : false = true
+      const effectIsScopedAsk: EffectOf<typeof scopedProgram> extends ScopedAsk<typeof TestScope> ? true : false = true
       assert.equal(effectIsScopedAsk, true)
-      return scopedProgram
-    })
+    }
 
     const effectIsAny: IsAny<EffectOf<typeof program>> = false
 

--- a/examples/package-import-inference.test.ts
+++ b/examples/package-import-inference.test.ts
@@ -6,6 +6,7 @@ import * as concurrentApi from '@briancavalier/fx/concurrent'
 import * as scopeApi from '@briancavalier/fx/scope'
 import * as stateApi from '@briancavalier/fx/state'
 import * as timeoutApi from '@briancavalier/fx/timeout'
+import * as yieldApi from '@briancavalier/fx/yield'
 import {
   RaceAllFailed,
   all,
@@ -83,6 +84,10 @@ describe('package import inference', () => {
     const noReturnExitScope: HasExport<typeof scopeApi, `return${'Exit'}`> = false
     const noResumeExitScope: HasExport<typeof scopeApi, `resume${'Exit'}`> = false
     const noTimeoutInScope: HasExport<typeof timeoutApi, `timeout${'In'}Scope`> = false
+    const noYieldFromScope: HasExport<typeof scopeApi, `yield${'From'}`> = false
+    const noYieldFromRequestScope: HasExport<typeof scopeApi, `Yield${'From'}`> = false
+    const hasYieldFrom: HasExport<typeof yieldApi, `yield${'From'}`> = true
+    const hasYieldFromRequest: HasExport<typeof yieldApi, `Yield${'From'}`> = true
     assert.equal(noConcurrentEffect, false)
     assert.equal(noConcurrentConstructor, false)
     assert.equal(noFirstSettled, false)
@@ -107,6 +112,10 @@ describe('package import inference', () => {
     assert.equal(noReturnExitScope, false)
     assert.equal(noResumeExitScope, false)
     assert.equal(noTimeoutInScope, false)
+    assert.equal(noYieldFromScope, false)
+    assert.equal(noYieldFromRequestScope, false)
+    assert.equal(hasYieldFrom, true)
+    assert.equal(hasYieldFromRequest, true)
   })
 
   it('preserves Effect instance types through package declarations', () => {

--- a/examples/package-import-inference.test.ts
+++ b/examples/package-import-inference.test.ts
@@ -19,7 +19,7 @@ import {
   withCoopConcurrency,
   withUnboundedConcurrency
 } from '@briancavalier/fx/concurrent'
-import { andFinally, andFinallyIn, sameScope, scope, scopeId, scopeLabel, using, usingIn, usingManaged, usingManagedIn, withScope, type AnyScope } from '@briancavalier/fx/scope'
+import { andFinally, andFinallyIn, sameScope, scopeId, scopeLabel, using, usingIn, usingManaged, usingManagedIn, withScope, type AnyScope } from '@briancavalier/fx/scope'
 import { getState, modifyState, transactionalState } from '@briancavalier/fx/state'
 import { TimeoutInterrupt, timeout, timeoutIn } from '@briancavalier/fx/timeout'
 
@@ -41,7 +41,6 @@ describe('package import inference', () => {
     assert.equal(typeof withCoopConcurrency, 'function')
     assert.equal(typeof RaceAllFailed, 'function')
 
-    assert.equal(typeof scope, 'function')
     assert.equal(typeof scopeId, 'function')
     assert.equal(typeof scopeLabel, 'function')
     assert.equal(typeof sameScope, 'function')
@@ -69,6 +68,7 @@ describe('package import inference', () => {
     const noFirstSettledPolicy: HasExport<typeof concurrentApi, `first${'Settled'}Policy`> = false
     const noFirstSuccessPolicy: HasExport<typeof concurrentApi, `first${'Success'}Policy`> = false
     const noScopeTypeId: HasExport<typeof scopeApi, `Scope${'Type'}Id`> = false
+    const noScopeConstructor: HasExport<typeof scopeApi, `sc${'ope'}`> = false
     const noScopeFinalizing: HasExport<typeof scopeApi, `final${'izing'}`> = false
     const noRunCatchScoped: HasExport<typeof fxApi, `runCatch${'Scoped'}`> = false
     const noCheckpointMain: HasExport<typeof fxApi, `check${'point'}`> = false
@@ -92,6 +92,7 @@ describe('package import inference', () => {
     assert.equal(noFirstSettledPolicy, false)
     assert.equal(noFirstSuccessPolicy, false)
     assert.equal(noScopeTypeId, false)
+    assert.equal(noScopeConstructor, false)
     assert.equal(noScopeFinalizing, false)
     assert.equal(noRunCatchScoped, false)
     assert.equal(noCheckpointMain, false)
@@ -129,21 +130,23 @@ describe('package import inference', () => {
   })
 
   it('preserves ScopedEffect instance types through package declarations', () => {
-    const Scope = scope('test/package-import-inference/ScopedAsk')
     class ScopedAsk<const S extends AnyScope> extends ScopedEffect('test/package-import-inference/ScopedAsk')<S, string, string> { }
 
-    const program = fx(function* () {
-      return yield* new ScopedAsk(Scope, 'name')
+    const program = withScope(scope => {
+      const scopedProgram = fx(function* () {
+        return yield* new ScopedAsk(scope, 'name')
+      })
+      const effectIsScopedAsk: EffectOf<typeof scopedProgram> extends ScopedAsk<typeof scope> ? true : false = true
+      assert.equal(effectIsScopedAsk, true)
+      return scopedProgram
     })
 
     const effectIsAny: IsAny<EffectOf<typeof program>> = false
-    const effectIsScopedAsk: EffectOf<typeof program> extends ScopedAsk<typeof Scope> ? true : false = true
 
     // @ts-expect-error ScopedAsk remains visible until a scoped handler removes it.
     const runnable: Fx<never, string> = program
 
     assert.equal(effectIsAny, false)
-    assert.equal(effectIsScopedAsk, true)
     void runnable
   })
 })

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
       "types": "./dist/exports/timeout.d.ts",
       "import": "./dist/exports/timeout.js"
     },
+    "./yield": {
+      "types": "./dist/exports/yield.d.ts",
+      "import": "./dist/exports/yield.js"
+    },
     "./trace": {
       "types": "./dist/exports/trace.d.ts",
       "import": "./dist/exports/trace.js"

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -7,7 +7,7 @@ import { fail, Fail, returnFail } from './Fail.js'
 import { andFinallyIn } from './Finalization.js'
 import { fx, ok, run, type Fx } from './Fx.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control } from './Scope.js'
+import { scope, withControlScope, withScope, type Control } from './Scope.js'
 
 describe('Abort', () => {
   const TestScope = scope<Control>()('test/Abort')
@@ -193,6 +193,30 @@ describe('Abort', () => {
       assert.ok(result.arg instanceof AggregateError)
       assert.deepEqual(result.arg.errors, [cleanupFailure])
       assert.equal(attempts, 1)
+    })
+
+    it('keeps lexical control handles open across restart attempt boundaries', () => {
+      let attempts = 0
+      const released = [] as string[]
+
+      const result = withControlScope({ label: 'restartable' }, controlScope => fx(function* () {
+        attempts += 1
+        const attempt = attempts
+        yield* andFinallyIn(controlScope, fx(function* () {
+          released.push(`release:${attempt}`)
+        }))
+
+        if (attempt === 1) yield* abort(controlScope)
+        return 'done'
+      }).pipe(
+        restartOnAbort(controlScope, { restarts: 1 }),
+        orReturn(controlScope, 'exhausted'),
+        returnFail
+      )).pipe(run)
+
+      assert.equal(result, 'done')
+      assert.equal(attempts, 2)
+      assert.deepEqual(released, ['release:1', 'release:2'])
     })
 
     it('preserves Abort typing until a downstream handler interprets exhaustion', () => {

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -57,6 +57,15 @@ describe('Abort', () => {
   })
 
   describe('restartOnAbort', () => {
+    it('requires an explicit control scope handle', () => {
+      const typecheck = (): void => {
+        // @ts-expect-error restartOnAbort requires an explicit control scope handle.
+        const invalid = restartOnAbort({ restarts: 1 })
+        void invalid
+      }
+      void typecheck
+    })
+
     it('restarts a scoped computation after abort and returns success', () => {
       let attempts = 0
 

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -7,7 +7,7 @@ import { fail, Fail, returnFail } from './Fail.js'
 import { andFinallyIn } from './Finalization.js'
 import { fx, ok, run, type Fx } from './Fx.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withControlScope, inScope, type Control } from './Scope.js'
+import { scope, withControlScope, inScope, type AnyControlScope, type Control } from './Scope.js'
 
 describe('Abort', () => {
   const TestScope = scope<Control>()('test/Abort')
@@ -53,6 +53,21 @@ describe('Abort', () => {
       }).pipe(inScope(TestScope), orReturn(TestScope, 'aborted'))
 
       assert.equal(Abort.is(f[Symbol.iterator]().next().value), true)
+    })
+
+    it('rejects cached aborts for closed lexical control handles', () => {
+      let leaked: AnyControlScope | undefined
+      let cached: Fx<Abort<AnyControlScope>, never> | undefined
+
+      run(withControlScope(scope => fx(function* () {
+        leaked = scope
+        cached = abort(scope)
+      })))
+
+      assert.throws(
+        () => cached!.pipe(orReturn(leaked!, 'aborted'), run),
+        /used after its scope exited/
+      )
     })
   })
 
@@ -181,6 +196,21 @@ describe('Abort', () => {
       assert.equal(Abort.is(next.value), true)
       assert.equal((next.value as Abort<typeof OtherScope>).scope, OtherScope)
       assert.equal(attempts, 1)
+    })
+
+    it('rejects cached aborts for closed lexical control handles before restarting', () => {
+      let leaked: AnyControlScope | undefined
+      let cached: Fx<Abort<AnyControlScope>, never> | undefined
+
+      run(withControlScope(scope => fx(function* () {
+        leaked = scope
+        cached = abort(scope)
+      })))
+
+      assert.throws(
+        () => cached!.pipe(restartOnAbort(leaked!, { restarts: 1 }), orReturn(leaked!, 'exhausted'), run),
+        /used after its scope exited/
+      )
     })
 
     it('stops restarting when cleanup fails after abort', () => {

--- a/src/Abort.test.ts
+++ b/src/Abort.test.ts
@@ -7,7 +7,7 @@ import { fail, Fail, returnFail } from './Fail.js'
 import { andFinallyIn } from './Finalization.js'
 import { fx, ok, run, type Fx } from './Fx.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withControlScope, withScope, type Control } from './Scope.js'
+import { scope, withControlScope, inScope, type Control } from './Scope.js'
 
 describe('Abort', () => {
   const TestScope = scope<Control>()('test/Abort')
@@ -19,27 +19,27 @@ describe('Abort', () => {
       const result = fx(function* () {
         yield* abort(SecondScope)
         return 'done'
-      }).pipe(withScope(FirstScope), orReturn(FirstScope, 'aborted'), run)
+      }).pipe(inScope(FirstScope), orReturn(FirstScope, 'aborted'), run)
 
       assert.equal(result, 'aborted')
     })
 
     it('given matching Abort with fallback, returns alternative', () => {
       const r = Math.random()
-      const a = abort(TestScope).pipe(withScope(TestScope), orReturn(TestScope, r), run)
+      const a = abort(TestScope).pipe(inScope(TestScope), orReturn(TestScope, r), run)
 
       assert.equal(a, r)
     })
 
     it('given success, returns original value', () => {
       const r = Math.random()
-      const a = ok(r).pipe(withScope(TestScope), orReturn(TestScope, r + 1), run)
+      const a = ok(r).pipe(inScope(TestScope), orReturn(TestScope, r + 1), run)
 
       assert.equal(a, r)
     })
 
     it('leaves matching Abort unhandled when fallback is omitted', () => {
-      const f = abort(TestScope).pipe(withScope(TestScope))
+      const f = abort(TestScope).pipe(inScope(TestScope))
       const _: typeof f extends import('./Fx.js').Fx<Abort<typeof TestScope>, never> ? true : false = true
 
       assert.equal(Abort.is(f[Symbol.iterator]().next().value), true)
@@ -50,7 +50,7 @@ describe('Abort', () => {
       const f = fx(function* () {
         yield* abort(OtherScope)
         return 'done'
-      }).pipe(withScope(TestScope), orReturn(TestScope, 'aborted'))
+      }).pipe(inScope(TestScope), orReturn(TestScope, 'aborted'))
 
       assert.equal(Abort.is(f[Symbol.iterator]().next().value), true)
     })

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -2,7 +2,7 @@ import { at } from './Breadcrumb.js'
 import { ScopedEffect, withOrigin } from './Effect.js'
 import { Fx, fx, ok } from './Fx.js'
 import { control } from './Handler.js'
-import { assertScopeOpen, withScope, type AnyControlScope, type ReturnValue, type ScopeEffects } from './Scope.js'
+import { assertScopeOpen, inScope, type AnyControlScope, type ReturnValue, type ScopeEffects } from './Scope.js'
 import { sameScope } from './internal/scopeIdentity.js'
 
 /**
@@ -65,7 +65,7 @@ export const restartOnAbortIn = <const Scope extends AnyControlScope>(
     let restarts = 0
     let aborted: Abort<Scope> | undefined
     const attempt = f.pipe(
-      withScope(scope),
+      inScope(scope),
       control(Abort, (_, abort) => {
         if (!sameScope(abort.scope, scope)) return abort
 

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -25,8 +25,11 @@ export const orReturn = <const Scope extends AnyControlScope, const R>(
   f: Fx<E, A>
 ): Fx<Exclude<E, Abort<Scope>>, A | R> =>
     f.pipe(
-      control(Abort, (_, abort) =>
-        (sameScope(abort.scope, scope) ? ok(value) : abort) as Fx<Exclude<E, Abort<Scope>>, A | R>)
+      control(Abort, (_, abort) => {
+        if (!sameScope(abort.scope, scope)) return abort as Fx<Exclude<E, Abort<Scope>>, A | R>
+        assertScopeOpen(abort.scope)
+        return ok(value) as Fx<Exclude<E, Abort<Scope>>, A | R>
+      })
     ) as Fx<Exclude<E, Abort<Scope>>, A | R>
 
 export interface RestartOnAbortOptions {
@@ -69,6 +72,7 @@ export const restartOnAbortIn = <const Scope extends AnyControlScope>(
       control(Abort, (_, abort) => {
         if (!sameScope(abort.scope, scope)) return abort
 
+        assertScopeOpen(abort.scope)
         aborted = abort as Abort<Scope>
         return ok(Restart)
       })

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -2,7 +2,7 @@ import { at } from './Breadcrumb.js'
 import { ScopedEffect, withOrigin } from './Effect.js'
 import { Fx, fx, ok } from './Fx.js'
 import { control } from './Handler.js'
-import { assertScopeOpen, withControlScope, withScope, type AnyControlScope, type ReturnValue, type ScopeEffects, type ScopeOptions } from './Scope.js'
+import { assertScopeOpen, withScope, type AnyControlScope, type ReturnValue, type ScopeEffects } from './Scope.js'
 import { sameScope } from './internal/scopeIdentity.js'
 
 /**
@@ -41,25 +41,15 @@ const Restart = Symbol('fx/Abort/restartOnAbort')
 /**
  * Restart a scoped computation when it aborts the named scope.
  */
-export function restartOnAbort(
-  options: RestartOnAbortOptions & ScopeOptions
-): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, AnyControlScope> | Abort<AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
 export function restartOnAbort<const Scope extends AnyControlScope>(
   scope: Scope,
   options: RestartOnAbortOptions
 ): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope> | Abort<Scope>, A | ReturnValue<E, Scope>>
-export function restartOnAbort(
-  optionsOrScope: (RestartOnAbortOptions & ScopeOptions) | AnyControlScope,
-  maybeOptions?: RestartOnAbortOptions
+export function restartOnAbort<const Scope extends AnyControlScope>(
+  scope: Scope,
+  options: RestartOnAbortOptions
 ) {
-  if (maybeOptions !== undefined) return restartOnAbortIn(optionsOrScope as AnyControlScope, maybeOptions)
-  const options = optionsOrScope as RestartOnAbortOptions & ScopeOptions
-  return <const E, const A>(
-    f: Fx<E, A>
-  ): Fx<ScopeEffects<E, AnyControlScope> | Abort<AnyControlScope>, A | ReturnValue<E, AnyControlScope>> =>
-    withControlScope(options, scope =>
-      restartOnAbortIn(scope as AnyControlScope, options)(f) as Fx<unknown, unknown>
-    ) as Fx<ScopeEffects<E, AnyControlScope> | Abort<AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+  return restartOnAbortIn(scope, options)
 }
 
 /**

--- a/src/Abort.ts
+++ b/src/Abort.ts
@@ -2,7 +2,7 @@ import { at } from './Breadcrumb.js'
 import { ScopedEffect, withOrigin } from './Effect.js'
 import { Fx, fx, ok } from './Fx.js'
 import { control } from './Handler.js'
-import { withScope, type AnyControlScope, type ReturnValue, type ScopeEffects } from './Scope.js'
+import { assertScopeOpen, withControlScope, withScope, type AnyControlScope, type ReturnValue, type ScopeEffects, type ScopeOptions } from './Scope.js'
 import { sameScope } from './internal/scopeIdentity.js'
 
 /**
@@ -10,8 +10,10 @@ import { sameScope } from './internal/scopeIdentity.js'
  */
 export class Abort<const Scope extends AnyControlScope> extends ScopedEffect('fx/Abort')<Scope, void, never> { }
 
-export const abort = <const Scope extends AnyControlScope>(scope: Scope): Fx<Abort<Scope>, never> =>
-  withOrigin(new Abort(scope, undefined), at('fx/Abort/abort', abort))
+export const abort = <const Scope extends AnyControlScope>(scope: Scope): Fx<Abort<Scope>, never> => {
+  assertScopeOpen(scope)
+  return withOrigin(new Abort(scope, undefined), at('fx/Abort/abort', abort))
+}
 
 /**
  * Return a default value from an abort of the named scope.
@@ -39,7 +41,31 @@ const Restart = Symbol('fx/Abort/restartOnAbort')
 /**
  * Restart a scoped computation when it aborts the named scope.
  */
-export const restartOnAbort = <const Scope extends AnyControlScope>(
+export function restartOnAbort(
+  options: RestartOnAbortOptions & ScopeOptions
+): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, AnyControlScope> | Abort<AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+export function restartOnAbort<const Scope extends AnyControlScope>(
+  scope: Scope,
+  options: RestartOnAbortOptions
+): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope> | Abort<Scope>, A | ReturnValue<E, Scope>>
+export function restartOnAbort(
+  optionsOrScope: (RestartOnAbortOptions & ScopeOptions) | AnyControlScope,
+  maybeOptions?: RestartOnAbortOptions
+) {
+  if (maybeOptions !== undefined) return restartOnAbortIn(optionsOrScope as AnyControlScope, maybeOptions)
+  const options = optionsOrScope as RestartOnAbortOptions & ScopeOptions
+  return <const E, const A>(
+    f: Fx<E, A>
+  ): Fx<ScopeEffects<E, AnyControlScope> | Abort<AnyControlScope>, A | ReturnValue<E, AnyControlScope>> =>
+    withControlScope(options, scope =>
+      restartOnAbortIn(scope as AnyControlScope, options)(f) as Fx<unknown, unknown>
+    ) as Fx<ScopeEffects<E, AnyControlScope> | Abort<AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+}
+
+/**
+ * Restart a scoped computation when it aborts the supplied scope handle.
+ */
+export const restartOnAbortIn = <const Scope extends AnyControlScope>(
   scope: Scope,
   options: RestartOnAbortOptions
 ) => <const E, const A>(

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -11,7 +11,7 @@ import { type HandlerCapture } from './HandlerCapture.js'
 import { interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible } from './Interrupt.js'
 import { ReturnFrom, returnFrom } from './ReturnFrom.js'
-import { scope, inScope, type Control, type Exit } from './Scope.js'
+import { scope, withScope, inScope, type Control, type Exit } from './Scope.js'
 import { Task, wait } from './Task.js'
 import { getTrace, snapshotError } from './Trace.js'
 
@@ -2381,6 +2381,33 @@ describe('Scope-owned fork lifetime', () => {
     assert.deepEqual(events, [])
     await task.promise
     assert.deepEqual(events, ['fork done'])
+  })
+
+  it('runs queued caller-owned fork work after lexical scope exit', async () => {
+    const events = [] as string[]
+
+    const result = await fx(function* () {
+      const task = yield* withScope(scope => inScope(scope, fx(function* () {
+        yield* fork(fx(function* () {
+          events.push('blocker start')
+          yield* delayFx(10)
+          events.push('blocker done')
+        }))
+        return yield* fork(fx(function* () {
+          events.push('queued child')
+          return 'child'
+        }))
+      })))
+
+      events.push('scope exited')
+      return yield* wait(task)
+    }).pipe(
+      withCoopConcurrency({ concurrency: 1 }),
+      runPromise
+    )
+
+    assert.equal(result, 'child')
+    assert.deepEqual(events, ['scope exited', 'blocker start', 'blocker done', 'queued child'])
   })
 
   it('keeps forkEach caller-owned across normal scope exit', async () => {

--- a/src/Concurrent.test.ts
+++ b/src/Concurrent.test.ts
@@ -11,7 +11,7 @@ import { type HandlerCapture } from './HandlerCapture.js'
 import { interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible } from './Interrupt.js'
 import { ReturnFrom, returnFrom } from './ReturnFrom.js'
-import { currentScope, scope, withScope, type Control, type Exit } from './Scope.js'
+import { scope, inScope, type Control, type Exit } from './Scope.js'
 import { Task, wait } from './Task.js'
 import { getTrace, snapshotError } from './Trace.js'
 
@@ -39,7 +39,7 @@ describe('Fork', () => {
       const first = firstSuccess([fail(new Error('nope')), ok('yes' as const)] as const)
       const scoped = fx(function* () {
         return yield* returnFrom(TestScope, 'early' as const)
-      }).pipe(withScope(TestScope))
+      }).pipe(inScope(TestScope))
 
       const checks = [
         false satisfies IsAny<EffectOf<typeof forked>>,
@@ -466,7 +466,7 @@ describe('Fork', () => {
         }))
         yield* fail(cause)
       })]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -494,7 +494,7 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -520,7 +520,7 @@ describe('Fork', () => {
       })
 
       const result = await all([slow, bad]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -550,7 +550,7 @@ describe('Fork', () => {
       })
 
       const result = await all([slow(firstReleaseFailure), bad, slow(secondReleaseFailure)]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -990,7 +990,7 @@ describe('Fork', () => {
 
       const result = await all([slow, bad]).pipe(
         withCoopConcurrency(),
-        withScope(TestScope),
+        inScope(TestScope),
         returnFail,
         runPromise
       )
@@ -1020,7 +1020,7 @@ describe('Fork', () => {
         assertPromise<string>(() => new Promise(resolve => setImmediate(() => resolve('winner'))))
       ]).pipe(
         withCoopConcurrency(),
-        withScope(TestScope),
+        inScope(TestScope),
         returnFail
       )
       // The runtime handles cleanup-yielded concurrency through captured handlers;
@@ -1055,7 +1055,7 @@ describe('Fork', () => {
         assertPromise<string>(() => new Promise(resolve => setImmediate(() => resolve('winner'))))
       ]).pipe(
         withCoopConcurrency(),
-        withScope(TestScope),
+        inScope(TestScope),
         returnFail
       )
       // The runtime handles cleanup-yielded concurrency through captured handlers;
@@ -1090,7 +1090,7 @@ describe('Fork', () => {
       ]).pipe(
         withCoopConcurrency(),
         handle(CurrentValue, () => ok('handled')),
-        withScope(TestScope),
+        inScope(TestScope),
         returnFail
       )
       // The runtime handles cleanup-yielded concurrency through captured handlers;
@@ -1302,7 +1302,7 @@ describe('Fork', () => {
           yield* awaitAbort()
         }))
       }).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withCoopConcurrency(),
         returnFail,
         runPromise
@@ -1450,7 +1450,7 @@ describe('Fork', () => {
 
       const promise = all([masked, bad]).pipe(
         withCoopConcurrency(),
-        withScope(TestScope),
+        inScope(TestScope),
         returnFail,
         runPromise
       )
@@ -1823,7 +1823,7 @@ describe('Fork', () => {
 
       const promise = all([masked, bad]).pipe(
         withCoopConcurrency(),
-        withScope(TestScope),
+        inScope(TestScope),
         returnFail,
         runPromise
       )
@@ -1916,7 +1916,7 @@ describe('Fork', () => {
       })
 
       const result = await race([ok('winner'), slow]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -1936,7 +1936,7 @@ describe('Fork', () => {
       })
 
       const result = await race([ok('winner'), slow]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -2020,7 +2020,7 @@ describe('Fork', () => {
       })
 
       const result = await firstSuccess([ok('winner'), slow]).pipe(
-        withScope(TestScope),
+        inScope(TestScope),
         withUnboundedConcurrency,
         returnFail,
         runPromise
@@ -2114,7 +2114,7 @@ describe('Scope-owned fork lifetime', () => {
       yield* delayFx(0)
       yield* interruptFrom(TestScope, reason)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, r => ok(r)),
       withUnboundedConcurrency,
       returnFail,
@@ -2148,7 +2148,7 @@ describe('Scope-owned fork lifetime', () => {
 
       return 'parent'
     }).pipe(
-      withScope(RaceScope),
+      inScope(RaceScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2176,12 +2176,12 @@ describe('Scope-owned fork lifetime', () => {
         }))
         yield* awaitAbort()
         events.push('inner after await')
-      }).pipe(withScope(InnerScope))
+      }).pipe(inScope(InnerScope))
 
       events.push('outer after inner')
       return 'parent'
     }).pipe(
-      withScope(OuterScope),
+      inScope(OuterScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2192,19 +2192,19 @@ describe('Scope-owned fork lifetime', () => {
     assert.deepEqual(events, ['inner cleanup'])
   })
 
-  it('runs forkIn current-scope children through handlers captured at the registration site', async () => {
-    const TestScope = scope('test/ForkIn/current-scope-captured-handler')
+  it('runs forkIn children through handlers captured at the registration site', async () => {
+    const TestScope = scope('test/ForkIn/captured-handler')
     class CurrentValue extends Effect('test/ForkIn/CurrentScopeCapturedHandler')<void, string> { }
 
     const result = await fx(function* () {
       const task = yield* fx(function* () {
-        return yield* forkIn(currentScope, new CurrentValue())
+        return yield* forkIn(TestScope, new CurrentValue())
       }).pipe(
         handle(CurrentValue, () => ok('local'))
       )
       return yield* wait(task)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2214,7 +2214,7 @@ describe('Scope-owned fork lifetime', () => {
     assert.equal(result, 'local')
   })
 
-  it('runs forkIn named-scope children in the named owner rather than a nested current scope', async () => {
+  it('runs forkIn children in the explicit owner rather than a nested scope', async () => {
     const OuterScope = scope('test/ForkIn/named-outer-owner')
     const InnerScope = scope('test/ForkIn/named-inner-not-owner')
     const events = [] as string[]
@@ -2222,13 +2222,13 @@ describe('Scope-owned fork lifetime', () => {
     const result = await fx(function* () {
       const task = yield* fx(function* () {
         return yield* forkIn(OuterScope, fx(function* () {
-          yield* andFinallyIn(currentScope, fx(function* () {
+          yield* andFinallyIn(OuterScope, fx(function* () {
             events.push('child cleanup')
           }))
           yield* awaitAbort()
         }))
       }).pipe(
-        withScope(InnerScope)
+        inScope(InnerScope)
       )
 
       events.push('after inner')
@@ -2236,7 +2236,7 @@ describe('Scope-owned fork lifetime', () => {
       yield* assertPromise(() => task.interrupt('done'))
       return events
     }).pipe(
-      withScope(OuterScope),
+      inScope(OuterScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2266,7 +2266,7 @@ describe('Scope-owned fork lifetime', () => {
 
       return 'parent'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, r => ok(r)),
       withUnboundedConcurrency,
       returnFail,
@@ -2298,7 +2298,7 @@ describe('Scope-owned fork lifetime', () => {
 
       return 'parent'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2322,7 +2322,7 @@ describe('Scope-owned fork lifetime', () => {
       yield* awaitAbort()
       completed = true
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2351,7 +2351,7 @@ describe('Scope-owned fork lifetime', () => {
 
       return 'parent'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2373,7 +2373,7 @@ describe('Scope-owned fork lifetime', () => {
         events.push('fork done')
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       runPromise
     )
@@ -2395,7 +2395,7 @@ describe('Scope-owned fork lifetime', () => {
         })
       ] as const)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       runPromise
     )
@@ -2417,7 +2417,7 @@ describe('Scope-owned fork lifetime', () => {
       }))
       return 'parent done'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2450,7 +2450,7 @@ describe('Scope-owned fork lifetime', () => {
         }))
         events.push('parent body done')
         return 'parent done'
-      }).pipe(withScope(TestScope)))
+      }).pipe(inScope(TestScope)))
 
       return yield* wait(task)
     }).pipe(
@@ -2480,7 +2480,7 @@ describe('Scope-owned fork lifetime', () => {
       yield* assertPromise(() => task.interrupt('manual'))
       return 'parent done'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency
     )
     const result = await withTimeout(runPromise(program as never), 100)
@@ -2502,7 +2502,7 @@ describe('Scope-owned fork lifetime', () => {
       yield* assertPromise(() => interrupted.interrupt('manual'))
       return 'parent done'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency
     )
     const result = await withTimeout(runPromise(program as never), 100)
@@ -2530,7 +2530,7 @@ describe('Scope-owned fork lifetime', () => {
       yield* delayFx(0)
       yield* interruptFrom(TestScope, reason)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, r => ok(r)),
       withBoundedConcurrency(1),
       returnFail,
@@ -2550,7 +2550,7 @@ describe('Scope-owned fork lifetime', () => {
         return yield* returnFrom(TestScope, 'early' as const)
       }))
       return task
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     false satisfies HasFail<EffectOf<typeof failedFork>>
     const failedTask: Fx<unknown, Task<never, Fail<'boom'>>> = failedFork
@@ -2573,7 +2573,7 @@ describe('Task interruption finalization', () => {
         yield* awaitAbort()
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2596,7 +2596,7 @@ describe('Task interruption finalization', () => {
         yield* awaitAbort()
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2620,7 +2620,7 @@ describe('Task interruption finalization', () => {
         yield* awaitAbort()
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2671,7 +2671,7 @@ describe('Task interruption finalization', () => {
         yield* awaitAbort()
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2698,7 +2698,7 @@ describe('Task interruption finalization', () => {
         )
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2723,7 +2723,7 @@ describe('Task interruption finalization', () => {
         }
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2756,7 +2756,7 @@ describe('Task interruption finalization', () => {
         )
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2777,7 +2777,7 @@ describe('Task interruption finalization', () => {
     })
 
     await assert.rejects(race([ok('winner'), slow]).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2805,7 +2805,7 @@ describe('Task interruption finalization', () => {
     })
 
     const result = await race([ok('winner'), slow]).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2830,7 +2830,7 @@ describe('Task interruption finalization', () => {
     )
 
     const result = await race([ok('winner'), slow]).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2865,7 +2865,7 @@ describe('Task interruption finalization', () => {
     })
 
     const result = await race([ok('winner'), slow]).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2889,7 +2889,7 @@ describe('Task interruption finalization', () => {
     })
 
     const result = await race([ok('winner'), slow]).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise
@@ -2914,7 +2914,7 @@ describe('Task interruption finalization', () => {
         yield* awaitAbort()
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       handle(Release, () => fx(function* () {
@@ -2939,7 +2939,7 @@ describe('Task interruption finalization', () => {
         yield* awaitAbort()
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       handle(Release, () => fx(function* () {
         released.push('task')
       })),

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -4,7 +4,7 @@ import { Fail, fail } from './Fail.js'
 import { Fx, flatMap, fx } from './Fx.js'
 import { HandlerCapture, withCapturedHandlers } from './HandlerCapture.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control } from './Scope.js'
+import { assertScopeOpen, withControlScope, withScope } from './Scope.js'
 import { Task } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
@@ -92,6 +92,7 @@ export const forkIn = <const Scope extends AnyLifetimeScope, const E, const A>(
   f: Fx<E, A>,
   options?: ForkOptions
 ): Fx<Exclude<E, Async | Fail<any>> | ScopedFork<Scope> | HandlerCapture<'fx/Concurrent/ForkIn'>, Task<A, ErrorsOf<E>>> => {
+  assertScopeOpen(scope)
   const trace = traceOrigin(options, 'fx/Concurrent/forkIn', forkIn, 'fork')
   return new ScopedFork(scope, { fx: f, ...trace, scheduling: options?.scheduling }) as Fx<ScopedFork<Scope>, Task<A, ErrorsOf<E>>>
 }
@@ -126,15 +127,14 @@ export const all = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   fxs: readonly [...Fxs],
   options?: TraceOptions
 ) => {
-  const concurrentScope = scope(Symbol('fx/Concurrent/all'), { diagnostic: false })
   const trace = traceOrigin(options, 'fx/Concurrent/all', all, 'all')
-  return fx(function* () {
+  return withScope({ diagnostic: false }, concurrentScope => fx(function* () {
     const tasks = yield* forkEachScoped(concurrentScope, fxs, trace)
     const results = yield* waitAllTasks(tasks)
     return results as { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }
   // The internal scope is private, so its ReturnFrom branch is not observable
   // through the public all result type.
-  }).pipe(withScope(concurrentScope)) as Fx<StructuredEffects<Fxs>, { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }>
+  })) as Fx<StructuredEffects<Fxs>, { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }>
 }
 
 /**
@@ -155,9 +155,8 @@ export const race = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   fxs: readonly [...Fxs],
   options?: TraceOptions
 ) => {
-  const concurrentScope = scope<Control>()(Symbol('fx/Concurrent/race'), { diagnostic: false })
   const trace = traceOrigin(options, 'fx/Concurrent/race', race, 'race')
-  return new RuntimeCloseBoundary(fx(function* () {
+  return new RuntimeCloseBoundary(withControlScope({ diagnostic: false }, concurrentScope => fx(function* () {
     if (fxs.length === 0) return yield* never()
     const tasks = yield* forkEachScoped(concurrentScope, fxs, trace)
     const result = yield* waitFirstSettled(tasks)
@@ -166,7 +165,7 @@ export const race = <const Fxs extends readonly Fx<unknown, unknown>[]>(
     return yield* returnFrom(concurrentScope, result.value)
   // The internal scope is private, so its ReturnFrom branch is exactly the race
   // result value.
-  }).pipe(withScope(concurrentScope))) as Fx<StructuredEffects<Fxs>, ResultOf<Fxs[number]>>
+  }))) as Fx<StructuredEffects<Fxs>, ResultOf<Fxs[number]>>
 }
 
 /**
@@ -176,9 +175,8 @@ export const firstSuccess = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   fxs: readonly [...Fxs],
   options?: TraceOptions
 ) => {
-  const concurrentScope = scope<Control>()(Symbol('fx/Concurrent/firstSuccess'), { diagnostic: false })
   const trace = traceOrigin(options, 'fx/Concurrent/firstSuccess', firstSuccess, 'race')
-  return new RuntimeCloseBoundary(fx(function* () {
+  return new RuntimeCloseBoundary(withControlScope({ diagnostic: false }, concurrentScope => fx(function* () {
     if (fxs.length === 0) return yield* fail(new RaceAllFailed([]))
     const tasks = yield* forkEachScoped(concurrentScope, fxs, trace, 'task')
     const result = yield* waitFirstSuccess(tasks)
@@ -187,7 +185,7 @@ export const firstSuccess = <const Fxs extends readonly Fx<unknown, unknown>[]>(
     return yield* returnFrom(concurrentScope, result.value)
   // The internal scope is private, so its ReturnFrom branch is exactly the
   // first successful result value.
-  }).pipe(withScope(concurrentScope))) as Fx<FirstSuccessEffects<Fxs>, ResultOf<Fxs[number]>>
+  }))) as Fx<FirstSuccessEffects<Fxs>, ResultOf<Fxs[number]>>
 }
 
 const forkEachScoped = <const Scope extends AnyLifetimeScope, const Fxs extends readonly Fx<unknown, unknown>[]>(

--- a/src/Concurrent.ts
+++ b/src/Concurrent.ts
@@ -4,7 +4,7 @@ import { Fail, fail } from './Fail.js'
 import { Fx, flatMap, fx } from './Fx.js'
 import { HandlerCapture, withCapturedHandlers } from './HandlerCapture.js'
 import { returnFrom } from './ReturnFrom.js'
-import { assertScopeOpen, withControlScope, withScope } from './Scope.js'
+import { assertScopeOpen, inScope, withControlScope, withScope } from './Scope.js'
 import { Task } from './Task.js'
 import type { TraceFrameKind, TraceOptions, TraceOrigin } from './Trace.js'
 import { Trace, captureTrace } from './Trace.js'
@@ -78,13 +78,13 @@ export const fork = <const E, const A>(
  * returned task's lifetime, while the nearest fork concurrency handler decides
  * when the task is allowed to start. Apply the matching {@link withScope}
  * inside an outer fork scheduler, for example
- * `program.pipe(withScope(scope), withUnboundedConcurrency)`.
+ * `program.pipe(inScope(scope), withUnboundedConcurrency)`.
  *
  * Advanced: `scheduling: 'unmetered'` is passed through to the fork scheduler
  * without changing scope ownership.
  *
  * The types follow normal effect elimination: `forkIn` introduces a
- * `ScopedFork<Scope>`, `withScope(scope)` handles it and may introduce `Fork`,
+ * `ScopedFork<Scope>`, `inScope(scope)` handles it and may introduce `Fork`,
  * and a fork scheduler handles `Fork` before execution.
  */
 export const forkIn = <const Scope extends AnyLifetimeScope, const E, const A>(
@@ -128,13 +128,13 @@ export const all = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   options?: TraceOptions
 ) => {
   const trace = traceOrigin(options, 'fx/Concurrent/all', all, 'all')
-  return withScope({ diagnostic: false }, concurrentScope => fx(function* () {
+  return withScope({ diagnostic: false }, concurrentScope => inScope(concurrentScope, fx(function* () {
     const tasks = yield* forkEachScoped(concurrentScope, fxs, trace)
     const results = yield* waitAllTasks(tasks)
     return results as { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }
   // The internal scope is private, so its ReturnFrom branch is not observable
   // through the public all result type.
-  })) as Fx<StructuredEffects<Fxs>, { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }>
+  })) as Fx<unknown, unknown>) as Fx<StructuredEffects<Fxs>, { readonly [K in keyof Fxs]: ResultOf<Fxs[K]> }>
 }
 
 /**
@@ -156,7 +156,7 @@ export const race = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   options?: TraceOptions
 ) => {
   const trace = traceOrigin(options, 'fx/Concurrent/race', race, 'race')
-  return new RuntimeCloseBoundary(withControlScope({ diagnostic: false }, concurrentScope => fx(function* () {
+  return new RuntimeCloseBoundary(withControlScope({ diagnostic: false }, concurrentScope => inScope(concurrentScope, fx(function* () {
     if (fxs.length === 0) return yield* never()
     const tasks = yield* forkEachScoped(concurrentScope, fxs, trace)
     const result = yield* waitFirstSettled(tasks)
@@ -165,7 +165,7 @@ export const race = <const Fxs extends readonly Fx<unknown, unknown>[]>(
     return yield* returnFrom(concurrentScope, result.value)
   // The internal scope is private, so its ReturnFrom branch is exactly the race
   // result value.
-  }))) as Fx<StructuredEffects<Fxs>, ResultOf<Fxs[number]>>
+  })) as Fx<unknown, unknown>)) as Fx<StructuredEffects<Fxs>, ResultOf<Fxs[number]>>
 }
 
 /**
@@ -176,7 +176,7 @@ export const firstSuccess = <const Fxs extends readonly Fx<unknown, unknown>[]>(
   options?: TraceOptions
 ) => {
   const trace = traceOrigin(options, 'fx/Concurrent/firstSuccess', firstSuccess, 'race')
-  return new RuntimeCloseBoundary(withControlScope({ diagnostic: false }, concurrentScope => fx(function* () {
+  return new RuntimeCloseBoundary(withControlScope({ diagnostic: false }, concurrentScope => inScope(concurrentScope, fx(function* () {
     if (fxs.length === 0) return yield* fail(new RaceAllFailed([]))
     const tasks = yield* forkEachScoped(concurrentScope, fxs, trace, 'task')
     const result = yield* waitFirstSuccess(tasks)
@@ -185,7 +185,7 @@ export const firstSuccess = <const Fxs extends readonly Fx<unknown, unknown>[]>(
     return yield* returnFrom(concurrentScope, result.value)
   // The internal scope is private, so its ReturnFrom branch is exactly the
   // first successful result value.
-  }))) as Fx<FirstSuccessEffects<Fxs>, ResultOf<Fxs[number]>>
+  })) as Fx<unknown, unknown>)) as Fx<FirstSuccessEffects<Fxs>, ResultOf<Fxs[number]>>
 }
 
 const forkEachScoped = <const Scope extends AnyLifetimeScope, const Fxs extends readonly Fx<unknown, unknown>[]>(

--- a/src/Effect.test.ts
+++ b/src/Effect.test.ts
@@ -2,7 +2,10 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { at } from './Breadcrumb.js'
 import { Effect, EffectOriginTypeId, originOf, ScopedEffect, traceOriginOf, withOrigin, withTraceOrigin } from './Effect.js'
-import { scope } from './Scope.js'
+import { fx, ok, run, type Fx } from './Fx.js'
+import { handleScoped } from './Handler.js'
+import type { Interrupt } from './Interrupt.js'
+import { scope, withScope, type AnyScope } from './Scope.js'
 import { captureTrace, setTraceCapturePolicy } from './Trace.js'
 
 describe('Effect', () => {
@@ -44,6 +47,32 @@ describe('Effect', () => {
       const done = iterator.next('done')
       assert.equal(done.done, true)
       assert.equal(done.value, 'done')
+    })
+
+    it('rejects closed lexical handles when yielded', () => {
+      class T<const Scope extends AnyScope> extends ScopedEffect('T/ScopedClosed')<Scope, void, string> { }
+      let cached: Fx<unknown, unknown> | undefined
+
+      run(withScope(scope => fx(function* () {
+        cached = new T(scope, undefined)
+      })))
+
+      assert.throws(
+        () => run(cached! as Fx<Interrupt, unknown>),
+        /used after its scope exited/
+      )
+    })
+
+    it('handles open lexical handles through scoped handlers', () => {
+      class T<const Scope extends AnyScope> extends ScopedEffect('T/ScopedHandled')<Scope, string, string> { }
+
+      const result = run(withScope(scope => fx(function* () {
+        return yield* new T(scope, 'handled')
+      }).pipe(
+        handleScoped(T, scope, effect => ok(effect.arg))
+      )))
+
+      assert.equal(result, 'handled')
     })
   })
 

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -6,6 +6,7 @@ import { captureTrace } from './Trace.js'
 import type { Trace, TraceOrigin } from './Trace.js'
 import { Once } from './internal/generator.js'
 import { Pipeable, pipeThis } from './internal/pipe.js'
+import { assertScopeOpen } from './internal/scopeLifetime.js'
 
 export interface EffectType {
   readonly _fxEffectId: unknown
@@ -125,6 +126,11 @@ export const ScopedEffect = <const T extends string>(id: T) => class <
 > extends Effect(id)<A, R> implements ScopedEffectInstance<T, Scope, A, R> {
   constructor(public readonly scope: Scope, arg: A) {
     super(arg)
+  }
+
+  [Symbol.iterator](): Iterator<this, R, any> {
+    assertScopeOpen(this.scope)
+    return super[Symbol.iterator]() as Iterator<this, R, any>
   }
 } as ScopedEffectClass<T>
 

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -1,5 +1,6 @@
 import type { Breadcrumb } from './Breadcrumb.js'
 import { Fx } from './Fx.js'
+import type { AnyKey } from './Key.js'
 import type { AnyScope } from './Scope.js'
 import { captureTrace } from './Trace.js'
 import type { Trace, TraceOrigin } from './Trace.js'
@@ -39,12 +40,25 @@ export interface ScopedEffectInstance<Id, Scope extends AnyScope, A, R> extends 
   readonly scope: Scope
 }
 
+export interface KeyedEffectInstance<Id, Key extends AnyKey, A, R> extends EffectInstance<Id, A, R> {
+  readonly key: Key
+}
+
 export interface ScopedEffectClass<Id> extends EffectType {
   readonly _fxEffectId: Id
   new<const Scope extends AnyScope, A = void, R = unknown>(
     scope: Scope,
     arg: A
   ): ScopedEffectInstance<Id, Scope, A, R>
+  is<E extends EffectType>(this: E, x: unknown): x is InstanceType<E>
+}
+
+export interface KeyedEffectClass<Id> extends EffectType {
+  readonly _fxEffectId: Id
+  new<const Key extends AnyKey, A = void, R = unknown>(
+    key: Key,
+    arg: A
+  ): KeyedEffectInstance<Id, Key, A, R>
   is<E extends EffectType>(this: E, x: unknown): x is InstanceType<E>
 }
 
@@ -113,6 +127,23 @@ export const ScopedEffect = <const T extends string>(id: T) => class <
     super(arg)
   }
 } as ScopedEffectClass<T>
+
+/**
+ * Define an effect type whose requests are associated with a typed key.
+ *
+ * Keyed effects let handlers interpret only requests for a matching stable
+ * protocol key. Use them for slots and channels such as State, YieldFrom, and
+ * Sink, not for lifetime or control regions.
+ */
+export const KeyedEffect = <const T extends string>(id: T) => class <
+  const Key extends AnyKey,
+  A = void,
+  R = unknown
+> extends Effect(id)<A, R> implements KeyedEffectInstance<T, Key, A, R> {
+  constructor(public readonly key: Key, arg: A) {
+    super(arg)
+  }
+} as KeyedEffectClass<T>
 
 export const isEffect = <E>(e: E): e is E & AnyEffect =>
   !!e && (e as any)._fxTypeId === EffectTypeId

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -1,9 +1,11 @@
 import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
+import { assertPromise } from './Async.js'
+import { fork, withUnboundedConcurrency } from './Concurrent.js'
 import { abort, Abort, orReturn } from './Abort.js'
 import { Fail, fail, returnFail } from './Fail.js'
-import { fx, ok, run, type Fx } from './Fx.js'
+import { fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { andFinallyIn, managed, usingIn, usingManagedIn, type Finally, type Managed } from './Finalization.js'
 import type { Interrupt } from './Interrupt.js'
 import { key } from './Key.js'
@@ -36,9 +38,9 @@ describe('Finalization', () => {
       () => yieldFrom(CleanupEvents, 'cleanup')
     )))
 
-    const _: typeof resource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
-    const __: typeof exitResource extends Fx<Finally<typeof TestScope, Fail<Error>> | Interrupt, 'resource'> ? true : false = true
-    const ___: typeof managedResource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
+    const _: typeof resource extends Fx<YieldFrom<typeof CleanupEvents> | Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
+    const __: typeof exitResource extends Fx<Fail<Error> | Finally<typeof TestScope, Fail<Error>> | Interrupt, 'resource'> ? true : false = true
+    const ___: typeof managedResource extends Fx<YieldFrom<typeof CleanupEvents> | Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
 
     assert.equal(typeof _, 'boolean')
     assert.equal(typeof __, 'boolean')
@@ -248,6 +250,34 @@ describe('Finalization', () => {
     assert.equal(acquired, false)
   })
 
+  it('usingIn releases resources acquired after lexical scope exit', async () => {
+    const released = [] as string[]
+    const exits = [] as Exit[]
+    let resolve!: (value: string) => void
+
+    const task = await withScope(scope => fx(function* () {
+      const task = yield* fork(usingIn(
+        scope,
+        assertPromise<string>(() => new Promise(r => {
+          resolve = r
+        })),
+        (resource, exit) => fx(function* () {
+          released.push(resource)
+          exits.push(exit)
+        })
+      ).pipe(inScope(scope)))
+      return yield* assertPromise(() => eventually(() => resolve !== undefined).then(() => task))
+    })).pipe(withUnboundedConcurrency).pipe(runPromise)
+
+    resolve('resource')
+
+    await assert.rejects(task.promise, hasStaleScopeCause)
+    assert.deepEqual(released, ['resource'])
+    assert.equal(exits.length, 1)
+    assert.equal(exits[0]?.type, 'interrupted')
+    assert.match(String(exits[0]?.reason), /used after its scope exited/)
+  })
+
   it('usingIn does not register cleanup when initialization fails', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
@@ -401,6 +431,33 @@ describe('Finalization', () => {
     assert.equal(acquired, false)
   })
 
+  it('usingManagedIn releases resources acquired after lexical scope exit', async () => {
+    const released = [] as string[]
+    const exits = [] as Exit[]
+    let resolve!: (value: Managed<string>) => void
+
+    const task = await withScope(scope => fx(function* () {
+      const task = yield* fork(usingManagedIn(
+        scope,
+        assertPromise<Managed<string>>(() => new Promise(r => {
+          resolve = r
+        }))
+      ).pipe(inScope(scope)))
+      return yield* assertPromise(() => eventually(() => resolve !== undefined).then(() => task))
+    })).pipe(withUnboundedConcurrency).pipe(runPromise)
+
+    resolve(managed('resource', exit => fx(function* () {
+      released.push('resource')
+      exits.push(exit)
+    })))
+
+    await assert.rejects(task.promise, hasStaleScopeCause)
+    assert.deepEqual(released, ['resource'])
+    assert.equal(exits.length, 1)
+    assert.equal(exits[0]?.type, 'interrupted')
+    assert.match(String(exits[0]?.reason), /used after its scope exited/)
+  })
+
   it('usingManagedIn does not register cleanup when initialization fails', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
@@ -521,3 +578,16 @@ const drainSync = (f: Fx<unknown, unknown>): void => {
   const iterator = f[Symbol.iterator]()
   for (let result = iterator.next(); !result.done; result = iterator.next()) { }
 }
+
+const eventually = async (predicate: () => boolean): Promise<void> => {
+  for (let i = 0; i < 100; ++i) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 1))
+  }
+  throw new Error('timed out waiting for condition')
+}
+
+const hasStaleScopeCause = (error: unknown): boolean =>
+  error instanceof Error
+  && error.cause instanceof Error
+  && /used after its scope exited/.test(error.cause.message)

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -4,11 +4,11 @@ import { describe, it } from 'node:test'
 import { abort, Abort, orReturn } from './Abort.js'
 import { Fail, fail, returnFail } from './Fail.js'
 import { fx, ok, run, type Fx } from './Fx.js'
-import { andFinally, andFinallyIn, managed, using, usingIn, usingManaged, usingManagedIn, type Finally, type Managed } from './Finalization.js'
+import { andFinallyIn, managed, usingIn, usingManagedIn, type Finally, type Managed } from './Finalization.js'
 import type { Interrupt } from './Interrupt.js'
 import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
-import { currentScope, scope, withScope, type Control, type Exit } from './Scope.js'
+import { scope, inScope, type Control, type Exit } from './Scope.js'
 import { collectFrom, YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 describe('Finalization', () => {
@@ -19,18 +19,12 @@ describe('Finalization', () => {
     const releaseFailure = new Error('release failed')
     const finalizer = andFinallyIn(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
     const exitFinalizer = andFinallyIn(TestScope, () => fail(releaseFailure))
-    const currentFinalizer = andFinally(yieldFrom(CleanupEvents, 'cleanup'))
-    const currentExitFinalizer = andFinally(() => fail(releaseFailure))
 
     const _: typeof finalizer extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>>, void> ? true : false = true
     const __: typeof exitFinalizer extends Fx<Finally<typeof TestScope, Fail<Error>>, void> ? true : false = true
-    const ___: typeof currentFinalizer extends Fx<Finally<typeof currentScope, YieldFrom<typeof CleanupEvents>>, void> ? true : false = true
-    const ____: typeof currentExitFinalizer extends Fx<Finally<typeof currentScope, Fail<Error>>, void> ? true : false = true
 
     assert.equal(typeof _, 'boolean')
     assert.equal(typeof __, 'boolean')
-    assert.equal(typeof ___, 'boolean')
-    assert.equal(typeof ____, 'boolean')
   })
 
   it('preserves finalizer effects in resource helper types', () => {
@@ -41,46 +35,21 @@ describe('Finalization', () => {
       'resource',
       () => yieldFrom(CleanupEvents, 'cleanup')
     )))
-    const currentResource = using(ok('resource'), () => yieldFrom(CleanupEvents, 'cleanup'))
-    const currentManagedResource = usingManaged(ok(managed(
-      'resource',
-      () => yieldFrom(CleanupEvents, 'cleanup')
-    )))
 
     const _: typeof resource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
     const __: typeof exitResource extends Fx<Finally<typeof TestScope, Fail<Error>> | Interrupt, 'resource'> ? true : false = true
     const ___: typeof managedResource extends Fx<Finally<typeof TestScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
-    const ____: typeof currentResource extends Fx<Finally<typeof currentScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
-    const _____: typeof currentManagedResource extends Fx<Finally<typeof currentScope, YieldFrom<typeof CleanupEvents>> | Interrupt, 'resource'> ? true : false = true
 
     assert.equal(typeof _, 'boolean')
     assert.equal(typeof __, 'boolean')
     assert.equal(typeof ___, 'boolean')
-    assert.equal(typeof ____, 'boolean')
-    assert.equal(typeof _____, 'boolean')
-  })
-
-  it('eliminates current-scope resource helpers at a scope boundary', () => {
-    const scoped = fx(function* () {
-      yield* andFinally(yieldFrom(CleanupEvents, 'cleanup'))
-      const resource = yield* using(ok('resource' as const), () => yieldFrom(CleanupEvents, 'cleanup'))
-      const managedResource = yield* usingManaged(ok(managed(
-        'managed' as const,
-        () => yieldFrom(CleanupEvents, 'cleanup')
-      )))
-      return [resource, managedResource] as const
-    }).pipe(withScope(TestScope))
-
-    const _: typeof scoped extends Fx<YieldFrom<typeof CleanupEvents> | Fail<AggregateError> | Interrupt, readonly ['resource', 'managed']> ? true : false = true
-
-    assert.equal(typeof _, 'boolean')
   })
 
   it('exposes non-failure finalizer effects after scope', () => {
     const scoped = fx(function* () {
       yield* andFinallyIn(TestScope, yieldFrom(CleanupEvents, 'cleanup'))
       return 'done'
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const _: typeof scoped extends Fx<YieldFrom<typeof CleanupEvents> | Fail<AggregateError>, 'done'> ? true : false = true
 
@@ -98,7 +67,7 @@ describe('Finalization', () => {
     const scoped = fx(function* () {
       yield* andFinallyIn(TestScope, fail(releaseFailure))
       return 'done'
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const _: typeof scoped extends Fx<Fail<AggregateError>, 'done'> ? true : false = true
 
@@ -115,7 +84,7 @@ describe('Finalization', () => {
     const scoped = fx(function* () {
       yield* andFinallyIn(OtherScope, yieldFrom(CleanupEvents, 'cleanup'))
       return 'done'
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const _: typeof scoped extends Fx<Finally<typeof OtherScope, YieldFrom<typeof CleanupEvents>> | Fail<AggregateError>, 'done'> ? true : false = true
     const next = scoped[Symbol.iterator]().next()
@@ -133,7 +102,7 @@ describe('Finalization', () => {
       yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* andFinallyIn(TestScope, record(released, 'C'))
       return 'done'
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'done')
     assert.deepEqual(released, ['C', 'B', 'A'])
@@ -148,7 +117,7 @@ describe('Finalization', () => {
       yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* andFinallyIn(TestScope, record(released, 'C'))
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -165,7 +134,7 @@ describe('Finalization', () => {
       yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* andFinallyIn(TestScope, record(released, 'C', cFailure))
       return 'done'
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
@@ -184,7 +153,7 @@ describe('Finalization', () => {
       yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* andFinallyIn(TestScope, record(released, 'C', cFailure))
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
@@ -200,7 +169,7 @@ describe('Finalization', () => {
         exits.push(exit)
       }))
       return 'done'
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'done')
     assert.deepEqual(exits, [{ type: 'success', value: 'done' }])
@@ -215,7 +184,7 @@ describe('Finalization', () => {
         exits.push(exit)
       }))
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -239,7 +208,7 @@ describe('Finalization', () => {
         exits.push(exit)
       }))
       return 'done'
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'done')
     assert.deepEqual(released, ['B', 'A'])
@@ -255,7 +224,7 @@ describe('Finalization', () => {
       return yield* usingIn(TestScope, ok('resource'),
         resource => record(released, resource)
       )
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(released, ['resource'])
@@ -269,7 +238,7 @@ describe('Finalization', () => {
       return yield* usingIn(TestScope, fail(initFailure),
         resource => record(released, String(resource))
       )
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, initFailure)
@@ -286,7 +255,7 @@ describe('Finalization', () => {
         resource => record(released, resource)
       )
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -305,7 +274,7 @@ describe('Finalization', () => {
       )
       events.push(`use ${resource}`)
       return resource
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(events, ['use resource', 'release resource', 'cleanup'])
@@ -322,7 +291,7 @@ describe('Finalization', () => {
           exits.push(exit)
         })
       )
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(released, ['resource'])
@@ -343,7 +312,7 @@ describe('Finalization', () => {
         })
       )
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -364,7 +333,7 @@ describe('Finalization', () => {
         () => fail(releaseFailure)
       )
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.ok(result.arg instanceof AggregateError)
@@ -390,7 +359,7 @@ describe('Finalization', () => {
         'resource',
         () => record(released, 'resource')
       )))
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'resource')
     assert.deepEqual(released, ['resource'])
@@ -402,7 +371,7 @@ describe('Finalization', () => {
 
     const result = run(fx(function* () {
       return yield* usingManagedIn(TestScope, fail(initFailure) as Fx<Fail<Error>, Managed<string>>)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, initFailure)
@@ -421,7 +390,7 @@ describe('Finalization', () => {
         })
       )))
       yield* fail(programFailure)
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.ok(Fail.is(result))
     assert.equal(result.arg, programFailure)
@@ -438,7 +407,7 @@ describe('Finalization', () => {
       yield* andFinallyIn(TestScope, record(released, 'A'))
       yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* returnFrom(TestScope, 'returned')
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'returned')
     assert.deepEqual(released, ['B', 'A'])
@@ -452,7 +421,7 @@ describe('Finalization', () => {
         exits.push(exit)
       }))
       yield* returnFrom(TestScope, 'returned')
-    }).pipe(withScope(TestScope), returnFail))
+    }).pipe(inScope(TestScope), returnFail))
 
     assert.equal(result, 'returned')
     assert.deepEqual(exits, [{
@@ -469,7 +438,7 @@ describe('Finalization', () => {
       yield* andFinallyIn(TestScope, record(released, 'A'))
       yield* andFinallyIn(TestScope, record(released, 'B'))
       yield* abort(TestScope)
-    }).pipe(withScope(TestScope), orReturn(TestScope, 'aborted'), returnFail))
+    }).pipe(inScope(TestScope), orReturn(TestScope, 'aborted'), returnFail))
 
     assert.equal(result, 'aborted')
     assert.deepEqual(released, ['B', 'A'])
@@ -483,7 +452,7 @@ describe('Finalization', () => {
         exits.push(exit)
       }))
       yield* abort(TestScope)
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const next = f[Symbol.iterator]().next()
 
@@ -498,7 +467,7 @@ describe('Finalization', () => {
     const f = fx(function* () {
       yield* andFinallyIn(OtherScope, record(released, 'other'))
       return 'done'
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const next = f[Symbol.iterator]().next()
 

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -6,13 +6,14 @@ import { Fail, fail, returnFail } from './Fail.js'
 import { fx, ok, run, type Fx } from './Fx.js'
 import { andFinally, andFinallyIn, managed, using, usingIn, usingManaged, usingManagedIn, type Finally, type Managed } from './Finalization.js'
 import type { Interrupt } from './Interrupt.js'
+import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
 import { currentScope, scope, withScope, type Control, type Exit } from './Scope.js'
 import { collectFrom, YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 describe('Finalization', () => {
   const TestScope = scope<Control>()('test/Finalization')
-  const CleanupEvents = scope<Yielding<'cleanup'>>()('test/Finalization/cleanup')
+  const CleanupEvents = key<Yielding<'cleanup'>>()('test/Finalization/cleanup')
 
   it('preserves finalizer effects in constructor types', () => {
     const releaseFailure = new Error('release failed')
@@ -116,7 +117,7 @@ describe('Finalization', () => {
       return 'done'
     }).pipe(withScope(TestScope))
 
-    const _: typeof scoped extends Fx<Finally<typeof OtherScope, YieldFrom<typeof CleanupEvents>>, 'done'> ? true : false = true
+    const _: typeof scoped extends Fx<Finally<typeof OtherScope, YieldFrom<typeof CleanupEvents>> | Fail<AggregateError>, 'done'> ? true : false = true
     const next = scoped[Symbol.iterator]().next()
 
     assert.equal(typeof _, 'boolean')

--- a/src/Finalization.test.ts
+++ b/src/Finalization.test.ts
@@ -8,7 +8,7 @@ import { andFinallyIn, managed, usingIn, usingManagedIn, type Finally, type Mana
 import type { Interrupt } from './Interrupt.js'
 import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, inScope, type Control, type Exit } from './Scope.js'
+import { scope, inScope, withScope, type AnyLifetimeScope, type Control, type Exit } from './Scope.js'
 import { collectFrom, YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 
 describe('Finalization', () => {
@@ -230,6 +230,24 @@ describe('Finalization', () => {
     assert.deepEqual(released, ['resource'])
   })
 
+  it('usingIn rejects closed scope handles before initialization', () => {
+    let leaked: AnyLifetimeScope | undefined
+    let acquired = false
+
+    run(withScope(scope => fx(function* () {
+      leaked = scope
+    })))
+
+    assert.throws(
+      () => drainSync(usingIn(leaked!, fx(function* () {
+        acquired = true
+        return 'resource'
+      }), () => ok(undefined))),
+      /used after its scope exited/
+    )
+    assert.equal(acquired, false)
+  })
+
   it('usingIn does not register cleanup when initialization fails', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
@@ -365,6 +383,24 @@ describe('Finalization', () => {
     assert.deepEqual(released, ['resource'])
   })
 
+  it('usingManagedIn rejects closed scope handles before initialization', () => {
+    let leaked: AnyLifetimeScope | undefined
+    let acquired = false
+
+    run(withScope(scope => fx(function* () {
+      leaked = scope
+    })))
+
+    assert.throws(
+      () => drainSync(usingManagedIn(leaked!, fx(function* () {
+        acquired = true
+        return managed('resource', () => ok(undefined))
+      }))),
+      /used after its scope exited/
+    )
+    assert.equal(acquired, false)
+  })
+
   it('usingManagedIn does not register cleanup when initialization fails', () => {
     const released = [] as string[]
     const initFailure = new Error('init failed')
@@ -480,3 +516,8 @@ const record = (released: string[], label: string, failure?: unknown) => fx(func
   released.push(label)
   if (failure !== undefined) yield* fail(failure)
 })
+
+const drainSync = (f: Fx<unknown, unknown>): void => {
+  const iterator = f[Symbol.iterator]()
+  for (let result = iterator.next(); !result.done; result = iterator.next()) { }
+}

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -66,10 +66,15 @@ export const usingIn = <const Scope extends AnyLifetimeScope, const IE, const FE
   scope: Scope,
   initially: Fx<IE, R>,
   finally_: (r: R, exit: Exit) => Fx<FE, void>
-): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
+): Fx<IE | FE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
   assertScopeOpen(scope)
   const r = yield* initially
-  yield* andFinallyIn(scope, exit => finally_(r, exit))
+  try {
+    yield* andFinallyIn(scope, exit => finally_(r, exit))
+  } catch (error) {
+    yield* finally_(r, staleRegistrationExit(scope, error))
+    throw error
+  }
   return r
 }))
 
@@ -94,9 +99,23 @@ export const managed = <const A, const E>(
 export const usingManagedIn = <const Scope extends AnyLifetimeScope, const IE, const FE, const A>(
   scope: Scope,
   initially: Fx<IE, Managed<A, FE>>
-): Fx<IE | Finally<Scope, FE> | Interrupt, A> => uninterruptible(fx(function* () {
+): Fx<IE | FE | Finally<Scope, FE> | Interrupt, A> => uninterruptible(fx(function* () {
   assertScopeOpen(scope)
   const m = yield* initially
-  yield* andFinallyIn(scope, m.finalizer)
+  try {
+    yield* andFinallyIn(scope, m.finalizer)
+  } catch (error) {
+    yield* m.finalizer(staleRegistrationExit(scope, error))
+    throw error
+  }
   return m.value
 }))
+
+const staleRegistrationExit = <const Scope extends AnyLifetimeScope>(
+  scope: Scope,
+  reason: unknown
+): Exit<Scope> => ({
+    type: 'interrupted',
+    scope,
+    reason
+  })

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -2,7 +2,7 @@ import { ScopedEffect } from './Effect.js'
 import { Fx, fx } from './Fx.js'
 import { uninterruptible } from './Interrupt.js'
 import type { Interrupt } from './Interrupt.js'
-import { assertScopeOpen, currentScope, type AnyLifetimeScope, type Exit } from './Scope.js'
+import { assertScopeOpen, type AnyLifetimeScope, type Exit } from './Scope.js'
 
 // ----------------------------------------------------------------------
 // Guaranteed finalization effects within a scope
@@ -22,30 +22,11 @@ export type Finalizer<E = unknown> = (exit: Exit) => Fx<E, void>
 /**
  * Request that a cleanup operation be run when the scope exits.
  *
- * A `withScope(...)` handler interprets `Finally` requests for its matching scope
+ * A `inScope(...)` handler interprets `Finally` requests for its matching scope
  * and runs registered finalizers when that scope succeeds, fails, returns,
  * aborts, or is interrupted.
  */
 export class Finally<const Scope extends AnyLifetimeScope, E = never> extends ScopedEffect('fx/Finally')<Scope, Finalizer<E>, void> { }
-
-/**
- * Register a cleanup operation to run when the current scope exits.
- *
- * Use this when the finalizer does not need to inspect the scope exit.
- */
-export function andFinally<E>(f: Fx<E, void>): Fx<Finally<typeof currentScope, E>, void>
-/**
- * Register a cleanup operation that receives the current scope's exit.
- *
- * Use this when cleanup behavior depends on whether the scope succeeded,
- * failed, returned, aborted, or was interrupted.
- */
-export function andFinally<E>(f: (exit: Exit) => Fx<E, void>): Fx<Finally<typeof currentScope, E>, void>
-export function andFinally<E>(
-  f: Fx<E, void> | ((exit: Exit) => Fx<E, void>)
-): Fx<Finally<typeof currentScope, E>, void> {
-  return new Finally(currentScope, typeof f === 'function' ? f : () => f)
-}
 
 /**
  * Register a cleanup operation to run when the named scope exits.
@@ -75,18 +56,6 @@ export function andFinallyIn<const Scope extends AnyLifetimeScope, E>(
 }
 
 /**
- * Run an initial operation, register cleanup for its result, and return it.
- *
- * Acquisition and finalizer registration happen in an uninterruptible region so
- * an acquired resource is not left without cleanup.
- */
-export const using = <const IE, const FE, const R>(
-  initially: Fx<IE, R>,
-  finally_: (r: R, exit: Exit) => Fx<FE, void>
-): Fx<IE | Finally<typeof currentScope, FE> | Interrupt, R> =>
-    usingIn(currentScope, initially, finally_)
-
-/**
  * Run an initial operation, register cleanup for its result in a named scope,
  * and return it.
  *
@@ -113,18 +82,6 @@ export const managed = <const A, const E>(
   value,
   finalizer
 })
-
-/**
- * Run an initial operation that returns a managed value, register its cleanup,
- * and return its value.
- *
- * Use this when acquisition naturally returns the value and its finalizer
- * together.
- */
-export const usingManaged = <const IE, const FE, const A>(
-  initially: Fx<IE, Managed<A, FE>>
-): Fx<IE | Finally<typeof currentScope, FE> | Interrupt, A> =>
-    usingManagedIn(currentScope, initially)
 
 /**
  * Run an initial operation that returns a managed value, register its cleanup in

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -2,7 +2,7 @@ import { ScopedEffect } from './Effect.js'
 import { Fx, fx } from './Fx.js'
 import { uninterruptible } from './Interrupt.js'
 import type { Interrupt } from './Interrupt.js'
-import { currentScope, type AnyLifetimeScope, type Exit } from './Scope.js'
+import { assertScopeOpen, currentScope, type AnyLifetimeScope, type Exit } from './Scope.js'
 
 // ----------------------------------------------------------------------
 // Guaranteed finalization effects within a scope
@@ -70,6 +70,7 @@ export function andFinallyIn<const Scope extends AnyLifetimeScope, E>(
   scope: Scope,
   f: Fx<E, void> | ((exit: Exit) => Fx<E, void>)
 ): Fx<Finally<Scope, E>, void> {
+  assertScopeOpen(scope)
   return new Finally(scope, typeof f === 'function' ? f : () => f)
 }
 

--- a/src/Finalization.ts
+++ b/src/Finalization.ts
@@ -67,6 +67,7 @@ export const usingIn = <const Scope extends AnyLifetimeScope, const IE, const FE
   initially: Fx<IE, R>,
   finally_: (r: R, exit: Exit) => Fx<FE, void>
 ): Fx<IE | Finally<Scope, FE> | Interrupt, R> => uninterruptible(fx(function* () {
+  assertScopeOpen(scope)
   const r = yield* initially
   yield* andFinallyIn(scope, exit => finally_(r, exit))
   return r
@@ -94,6 +95,7 @@ export const usingManagedIn = <const Scope extends AnyLifetimeScope, const IE, c
   scope: Scope,
   initially: Fx<IE, Managed<A, FE>>
 ): Fx<IE | Finally<Scope, FE> | Interrupt, A> => uninterruptible(fx(function* () {
+  assertScopeOpen(scope)
   const m = yield* initially
   yield* andFinallyIn(scope, m.finalizer)
   return m.value

--- a/src/Handler.test.ts
+++ b/src/Handler.test.ts
@@ -41,7 +41,7 @@ describe('Handler', () => {
       const next = f[Symbol.iterator]().next()
 
       assert.equal(Request.is(next.value), true)
-      const effect = next.value as Request<typeof OtherScope>
+      const effect = next.value as unknown as Request<typeof OtherScope>
       assert.equal(effect.scope, OtherScope)
       assert.deepEqual(effect.arg, { value: 2 })
     })

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -1,7 +1,9 @@
 import { EffectType } from './Effect.js'
 import { Fx } from './Fx.js'
+import type { AnyKey } from './Key.js'
 import type { AnyScope } from './Scope.js'
 import { Answer, Arg, Control, Handler } from './internal/Handler.js'
+import { sameKey } from './internal/keyIdentity.js'
 import { sameScope } from './internal/scopeIdentity.js'
 export type { Arg }
 
@@ -17,6 +19,9 @@ export type HandleReturn<E, A, R> = E extends A ? R : never
 
 type MatchedScopedEffect<A, Scope extends AnyScope> =
   A & { readonly scope: Scope }
+
+type MatchedKeyedEffect<A, Key extends AnyKey> =
+  A & { readonly key: Key }
 
 type ResidualScopedEffect<E, Scope extends AnyScope> =
   E extends { readonly scope: infer EffectScope extends AnyScope }
@@ -37,11 +42,36 @@ export type HandleScoped<E, A, Scope extends AnyScope, B = never> =
     : E
   : E
 
+type ResidualKeyedEffect<E, Key extends AnyKey> =
+  E extends { readonly key: infer EffectKey extends AnyKey }
+  ? Exclude<EffectKey, Key> extends never
+    ? never
+    : E & { readonly key: Exclude<EffectKey, Key> }
+  : E
+
+/**
+ * Replace matching keyed effects in `E` with effects produced by a handler.
+ */
+export type HandleKeyed<E, A, Key extends AnyKey, B = never> =
+  E extends A
+  ? E extends { readonly key: infer EffectKey extends AnyKey }
+    ? Extract<EffectKey, Key> extends never
+      ? E
+      : B | ResidualKeyedEffect<E, Key>
+    : E
+  : E
+
 type ScopedEffectType =
   EffectType & { new(...args: readonly any[]): { readonly scope: AnyScope } }
 
 type EffectScope<T extends ScopedEffectType> =
   InstanceType<T>['scope']
+
+type KeyedEffectType =
+  EffectType & { new(...args: readonly any[]): { readonly key: AnyKey } }
+
+type EffectKey<T extends KeyedEffectType> =
+  InstanceType<T>['key']
 
 /**
  * Handle effects of the given type.
@@ -106,6 +136,26 @@ export const handleScoped = <T extends ScopedEffectType, const Scope extends Eff
 
       return effect as Fx<InstanceType<T>, Answer<T>>
     }) as Fx<HandleScoped<E, InstanceType<T>, Scope, HandlerEffects>, A>
+
+/**
+ * Handle keyed effects of the given type from one key.
+ *
+ * Effects of the same type from other keys are left unhandled.
+ */
+export const handleKeyed = <T extends KeyedEffectType, const Key extends EffectKey<T>, HandlerEffects>(
+  e: T,
+  key: Key,
+  f: (effect: MatchedKeyedEffect<InstanceType<T>, Key>) => Fx<HandlerEffects, Answer<T>>
+) => <const E, const A>(
+  fx: Fx<E, A>
+): Fx<HandleKeyed<E, InstanceType<T>, Key, HandlerEffects>, A> =>
+    new Handler(fx, e._fxEffectId, effect => {
+      if (sameKey(effect.key, key)) {
+        return f(effect as MatchedKeyedEffect<InstanceType<T>, Key>)
+      }
+
+      return effect as Fx<InstanceType<T>, Answer<T>>
+    }) as Fx<HandleKeyed<E, InstanceType<T>, Key, HandlerEffects>, A>
 
 /**
  * Handle effects of the given type with control over resuming the program.

--- a/src/HttpServer.test.ts
+++ b/src/HttpServer.test.ts
@@ -6,7 +6,6 @@ import { forkIn } from './Concurrent.js'
 import { Get, provideFrom } from './Env.js'
 import { Effect } from './Effect.js'
 import { Fail, assert as assertNoFail, fail } from './Fail.js'
-import { andFinally } from './Finalization.js'
 import { ok, fx, run, runPromise, runTask, type Fx } from './Fx.js'
 import { handle } from './Handler.js'
 import {
@@ -28,8 +27,9 @@ import {
 } from './HttpServer.js'
 import { NodeHttpError, nodeHttp, type NodeHttpServerFactory } from './HttpServerNode.js'
 import { HandlerCapture } from './HandlerCapture.js'
+import { ScopedFork } from './internal/scopedFork.js'
 import type { Interrupt } from './Interrupt.js'
-import { currentScope } from './Scope.js'
+import { scope } from './Scope.js'
 import { YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
 import { key } from './Key.js'
 
@@ -536,28 +536,6 @@ describe('HttpServer', () => {
       })
     })
 
-    it('runs current-scope finalizers when the response closes before finishing', async () => {
-      const exits: string[] = []
-      const app = route('GET', '/slow', fx(function* () {
-        yield* andFinally(exit => ok(void exits.push(exit.type)))
-        yield* waitForInterrupt()
-        return text('late')
-      }))
-
-      const runnable = serve(app, { port: 0, host: '127.0.0.1' }).pipe(
-        nodeHttp()
-      )
-      const _: Fx<Async | Interrupt | HandlerCapture<string> | Fail<NodeHttpError>, void> = runnable
-      void _
-
-      await withServer(createServer => serve(app, { port: 0, host: '127.0.0.1' }).pipe(
-        nodeHttp({ createServer })
-      ), async port => {
-        await httpAbortGet(port, '/slow')
-        await eventually(() => exits.includes('interrupted'))
-      })
-    })
-
     it('does not treat normal response close after finish as a failed request', async () => {
       const app = route('GET', '/health', ok(text('ok')))
       const events: ServerEvent[] = []
@@ -604,16 +582,17 @@ describe('HttpServer', () => {
       })
     })
 
-    it('does not expose request-owned current-scope forks from server program types', () => {
+    it('keeps explicit route scoped forks visible until their owner is handled', () => {
+      const RouteScope = scope('test/HttpServer/route-fork')
       const app = route('GET', '/fork', fx(function* () {
-        yield* forkIn(currentScope, ok('child'))
+        yield* forkIn(RouteScope, ok('child'))
         return text('ok')
       }))
 
       const runnable = serve(app, { port: 0, host: '127.0.0.1' }).pipe(
         nodeHttp()
       )
-      const _: Fx<Async | Interrupt | HandlerCapture<string> | Fail<NodeHttpError>, void> = runnable
+      const _: Fx<Async | Interrupt | HandlerCapture<string> | Fail<NodeHttpError> | ScopedFork<typeof RouteScope>, void> = runnable
       void _
     })
 

--- a/src/HttpServer.test.ts
+++ b/src/HttpServer.test.ts
@@ -29,10 +29,11 @@ import {
 import { NodeHttpError, nodeHttp, type NodeHttpServerFactory } from './HttpServerNode.js'
 import { HandlerCapture } from './HandlerCapture.js'
 import type { Interrupt } from './Interrupt.js'
-import { currentScope, scope } from './Scope.js'
+import { currentScope } from './Scope.js'
 import { YieldFrom, yieldFrom, type Yielding } from './YieldFrom.js'
+import { key } from './Key.js'
 
-const HttpServerEvents = scope<Yielding<ServerEvent>>()('test/HttpServer/events')
+const HttpServerEvents = key<Yielding<ServerEvent>>()('test/HttpServer/events')
 
 describe('HttpServer', () => {
   describe('route AST', () => {

--- a/src/HttpServer.ts
+++ b/src/HttpServer.ts
@@ -2,13 +2,10 @@ import { Async } from './Async.js'
 import { Effect } from './Effect.js'
 import { Get, provide, provideFrom, type ExcludeEnv } from './Env.js'
 import { Fail } from './Fail.js'
-import { Finally } from './Finalization.js'
 import { Fx, flatMap, ok } from './Fx.js'
 import { HandlerCapture, captureHandlers, type CapturedHandler } from './HandlerCapture.js'
 import { type Headers, type Method } from './HttpClient.js'
 import { Fork } from './internal/concurrent/effects.js'
-import { ScopedFork } from './internal/scopedFork.js'
-import { currentScope } from './Scope.js'
 
 /**
  * A transport-neutral HTTP server request.
@@ -232,31 +229,6 @@ export const provideRoutesFrom =
 
 export type ServerRouteEffects = Async | Fail<any> | Fork | HandlerCapture<string>
 
-export type ServerRequestScopeEffects<E> =
-  HandleServerRequestScopeEffect<E> | ServerRequestScopedForkEffects<E> | ServerRequestCleanupEffects<E> | ServerRequestCleanupFailure<E>
-
-type HandleServerRequestScopeEffect<E> =
-  E extends Finally<typeof currentScope, any> ? never
-  : E extends ScopedFork<typeof currentScope> ? never
-  : E
-
-type ServerRequestScopedForkEffects<E> =
-  E extends ScopedFork<typeof currentScope> ? Fork | Async | Fail<unknown> : never
-
-type MatchingServerRequestFinally<E> =
-  Extract<E, Finally<typeof currentScope, any>>
-
-type ServerRequestFinalizerEffects<E> =
-  MatchingServerRequestFinally<E> extends never
-    ? never
-    : MatchingServerRequestFinally<E> extends Finally<typeof currentScope, infer FE> ? FE : never
-
-type ServerRequestCleanupEffects<E> =
-  Exclude<ServerRequestFinalizerEffects<E>, Fail<any>>
-
-type ServerRequestCleanupFailure<E> =
-  MatchingServerRequestFinally<E> extends never ? never : Fail<AggregateError>
-
 export const ServeScope = 'fx/HttpServer/Serve'
 
 /**
@@ -280,14 +252,12 @@ export type ServeOptions<OE = never> = {
  * Request that an HTTP server run the provided routes.
  *
  * `serve` captures the surrounding handler context so route handlers can use
- * application handlers installed at the server boundary. Server interpreters
- * run each matched route handler in a request lifetime scope, so current-scope
- * finalizers and scoped forks are owned by the request.
+ * application handlers installed at the server boundary.
  */
 export const serve = <E, OE = never>(
   routes: Routes<E>,
   options: ServeOptions<OE>
-): Fx<Exclude<ServerRequestScopeEffects<E>, ServerRouteEffects> | OE | Serve<E, OE> | HandlerCapture<typeof ServeScope>, void> =>
+): Fx<Exclude<E, ServerRouteEffects> | OE | Serve<E, OE> | HandlerCapture<typeof ServeScope>, void> =>
   captureHandlers(ServeScope).pipe(
     flatMap(context => new Serve<E, OE>({ routes, options, context }))
   )

--- a/src/HttpServerNode.ts
+++ b/src/HttpServerNode.ts
@@ -22,7 +22,7 @@ import {
 import { HandlerCapture, handleCaptured, withCapturedHandlers, withHandlerContext } from './HandlerCapture.js'
 import type { Interrupt } from './Interrupt.js'
 import * as Queue from './internal/Queue.js'
-import { scope, withScope } from './Scope.js'
+import { scope, inScope } from './Scope.js'
 
 export type NodeHttpOptions = {
   readonly createServer?: NodeHttpServerFactory
@@ -233,7 +233,7 @@ const runNodeRequest = async <E>(
   })
 
   const task = withHandlerContext(context, program as Fx<unknown, void>).pipe(
-    withScope(requestScope),
+    inScope(requestScope),
     catchAll(cause => {
       failure = { error: cause }
       return outgoing.destroyed

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -9,7 +9,7 @@ import { bracket, finalizing, fx, ok, run, runPromise, runTask, type Fx } from '
 import { control, handle } from './Handler.js'
 import { InterruptFrom, interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
-import { scope, withScope, type Exit } from './Scope.js'
+import { scope, inScope, type Exit } from './Scope.js'
 
 describe('Typed interruption', () => {
   const TestScope = scope('test/InterruptFrom')
@@ -25,7 +25,7 @@ describe('Typed interruption', () => {
       }))
       yield* interruptFrom(TestScope, reason)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, r => {
         recoveredReason = r
         return ok('interrupted')
@@ -42,7 +42,7 @@ describe('Typed interruption', () => {
   it('types recovery reasons as unknown', () => {
     const reason = { type: 'test-interrupt' } as const
     const recovered = interruptFrom(TestScope, reason).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, r => {
         const _: unknown = r
         void _
@@ -56,7 +56,7 @@ describe('Typed interruption', () => {
 
   it('rejects incompatible recovery reason annotations', () => {
     const recovered = interruptFrom(TestScope, 123).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       // @ts-expect-error recovery reasons are unknown until narrowed by the handler
       recoverInterrupt(TestScope, (r: string) => ok(r))
     )
@@ -71,7 +71,7 @@ describe('Typed interruption', () => {
       yield* interruptFrom(OtherScope, 'other')
       return 'done'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, () => ok('interrupted'))
     )
 
@@ -88,7 +88,7 @@ describe('Typed interruption', () => {
       yield* andFinallyIn(TestScope, fail(cleanupFailure))
       yield* interruptFrom(TestScope)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       recoverInterrupt(TestScope, () => ok('interrupted')),
       returnFail,
       run
@@ -109,7 +109,7 @@ describe('Typed interruption', () => {
       }))
       yield* interruptFrom(TestScope, reason)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
       returnFail,
       run
@@ -120,7 +120,7 @@ describe('Typed interruption', () => {
   })
 
   it('leaves the interrupt visible after scope cleanup', () => {
-    const f = interruptFrom(TestScope).pipe(withScope(TestScope))
+    const f = interruptFrom(TestScope).pipe(inScope(TestScope))
     const next = f[Symbol.iterator]().next()
 
     assert.equal(InterruptFrom.is(next.value), true)
@@ -132,7 +132,7 @@ describe('Typed interruption', () => {
     const f = fx(function* () {
       yield* interruptFrom(OtherScope)
       return 'done'
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const next = f[Symbol.iterator]().next()
 
@@ -147,7 +147,7 @@ describe('Typed interruption', () => {
       yield* andFinallyIn(TestScope, fail(cleanupFailure))
       yield* interruptFrom(TestScope)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
       returnFail,
       run
@@ -255,7 +255,7 @@ describe('Interrupt masking', () => {
         })
       )
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       returnFail,
       runTask
     )
@@ -281,7 +281,7 @@ describe('Interrupt masking', () => {
         }))
       )
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       returnFail,
       runTask
     )
@@ -579,7 +579,7 @@ describe('Interrupt masking', () => {
     })
 
     const result = race([ok('winner'), loser]).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       withUnboundedConcurrency,
       returnFail,
       runPromise

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -121,6 +121,7 @@ describe('Typed interruption', () => {
 
   it('leaves the interrupt visible after scope cleanup', () => {
     const f = interruptFrom(TestScope).pipe(inScope(TestScope))
+    const _: typeof f extends Fx<InterruptFrom<typeof TestScope>, never> ? true : false = true
     const next = f[Symbol.iterator]().next()
 
     assert.equal(InterruptFrom.is(next.value), true)

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -9,7 +9,7 @@ import { bracket, finalizing, fx, ok, run, runPromise, runTask, type Fx } from '
 import { control, handle } from './Handler.js'
 import { InterruptFrom, interruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { uninterruptible, uninterruptibleMask, type Interrupt, type RestoreInterrupt } from './Interrupt.js'
-import { scope, inScope, type Exit } from './Scope.js'
+import { scope, withScope, inScope, type AnyLifetimeScope, type Exit } from './Scope.js'
 
 describe('Typed interruption', () => {
   const TestScope = scope('test/InterruptFrom')
@@ -52,6 +52,29 @@ describe('Typed interruption', () => {
 
     const _: Fx<never, 'interrupted'> = recovered
     void _
+  })
+
+  it('rejects cached interruptions for closed lexical handles before recovering', () => {
+    let leaked: AnyLifetimeScope | undefined
+    let cached: Fx<InterruptFrom<AnyLifetimeScope, 'reason'>, never> | undefined
+    let recovered = false
+
+    run(withScope(scope => fx(function* () {
+      leaked = scope
+      cached = interruptFrom(scope, 'reason' as const)
+    })))
+
+    assert.throws(
+      () => cached!.pipe(
+        recoverInterrupt(leaked!, () => fx(function* () {
+          recovered = true
+          return 'interrupted'
+        })),
+        run
+      ),
+      /used after its scope exited/
+    )
+    assert.equal(recovered, false)
   })
 
   it('rejects incompatible recovery reason annotations', () => {

--- a/src/Interrupt.test.ts
+++ b/src/Interrupt.test.ts
@@ -78,7 +78,7 @@ describe('Typed interruption', () => {
     const next = f[Symbol.iterator]().next()
 
     assert.equal(InterruptFrom.is(next.value), true)
-    assert.equal((next.value as InterruptFrom<typeof OtherScope, 'other'>).scope, OtherScope)
+    assert.equal((next.value as unknown as InterruptFrom<typeof OtherScope, 'other'>).scope, OtherScope)
   })
 
   it('surfaces cleanup failures before recovering an interruption', () => {

--- a/src/InterruptFrom.ts
+++ b/src/InterruptFrom.ts
@@ -40,10 +40,11 @@ export const recoverInterrupt = <const Scope extends AnyLifetimeScope, const Han
   f: Fx<E, A>
 ): Fx<RecoverInterrupt<E, Scope, HandlerEffects>, A | R> =>
     f.pipe(
-      control(InterruptFrom, (_, interrupt): Fx<HandlerEffects | InterruptFrom<AnyLifetimeScope, unknown>, R> =>
-        (sameScope(interrupt.scope, scope)
-          ? handler(interrupt.arg)
-          : interrupt as Fx<InterruptFrom<AnyLifetimeScope, unknown>, never>) as Fx<HandlerEffects | InterruptFrom<AnyLifetimeScope, unknown>, R>)
+      control(InterruptFrom, (_, interrupt): Fx<HandlerEffects | InterruptFrom<AnyLifetimeScope, unknown>, R> => {
+        if (!sameScope(interrupt.scope, scope)) return interrupt as Fx<InterruptFrom<AnyLifetimeScope, unknown>, never>
+        assertScopeOpen(interrupt.scope)
+        return handler(interrupt.arg) as Fx<HandlerEffects | InterruptFrom<AnyLifetimeScope, unknown>, R>
+      })
     ) as Fx<RecoverInterrupt<E, Scope, HandlerEffects>, A | R>
 
 type RecoverInterrupt<E, Scope extends AnyLifetimeScope, HandlerEffects> =

--- a/src/InterruptFrom.ts
+++ b/src/InterruptFrom.ts
@@ -2,7 +2,7 @@ import { at } from './Breadcrumb.js'
 import { ScopedEffect, withOrigin } from './Effect.js'
 import { Fx } from './Fx.js'
 import { control } from './Handler.js'
-import type { AnyLifetimeScope, AnyScope } from './Scope.js'
+import { assertScopeOpen, type AnyLifetimeScope, type AnyScope } from './Scope.js'
 import { sameScope } from './internal/scopeIdentity.js'
 
 /**
@@ -19,6 +19,7 @@ export function interruptFrom<const Scope extends AnyLifetimeScope, const Reason
   reason: Reason
 ): Fx<InterruptFrom<Scope, Reason>, never>
 export function interruptFrom(scope: AnyLifetimeScope, reason?: unknown): Fx<InterruptFrom<AnyLifetimeScope, unknown>, never> {
+  assertScopeOpen(scope)
   return withOrigin(
     new InterruptFrom(scope, reason),
     at('fx/InterruptFrom/interruptFrom', interruptFrom)

--- a/src/Key.test.ts
+++ b/src/Key.test.ts
@@ -1,0 +1,49 @@
+import * as assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { key, sameKey, type Key } from './Key.js'
+import type { Yielding } from './YieldFrom.js'
+
+describe('Key', () => {
+  it('matches keys by singleton id', () => {
+    const First = key<Yielding<number>>()('test/Key/same-id')
+    const Second = key<Yielding<number>>()('test/Key/same-id')
+    const Other = key<Yielding<number>>()('test/Key/other-id')
+
+    assert.equal(sameKey(First, Second), true)
+    assert.equal(sameKey(First, Other), false)
+  })
+
+  it('preserves exact singleton id types', () => {
+    const Literal = key<Yielding<number>>()('test/Key/literal-id')
+    const _: Key<'test/Key/literal-id'> & Yielding<number> = Literal
+
+    const SymbolId = Symbol('test/Key/symbol-id')
+    const SymbolKey = key<Yielding<number>>()(SymbolId)
+    const __: Key<typeof SymbolId> & Yielding<number> = SymbolKey
+
+    void _
+    void __
+  })
+
+  it('rejects widened key ids', () => {
+    const stringId: string = 'test/Key/string-id'
+    const numberId: number = 1
+    const symbolId: symbol = Symbol('test/Key/wide-symbol-id')
+
+    // @ts-expect-error key ids must be exact singleton ids.
+    key<Yielding<number>>()(stringId)
+    // @ts-expect-error key ids must be exact singleton ids.
+    key<Yielding<number>>()(numberId)
+    // @ts-expect-error key ids must be exact singleton ids.
+    key<Yielding<number>>()(symbolId)
+  })
+
+  it('rejects union key ids', () => {
+    const unionId: 'test/Key/a' | 'test/Key/b' =
+      Math.random() > 0.5 ? 'test/Key/a' : 'test/Key/b'
+
+    // @ts-expect-error key ids must be one exact singleton id.
+    key<Yielding<number>>()(unionId)
+  })
+})

--- a/src/Key.ts
+++ b/src/Key.ts
@@ -12,8 +12,8 @@ export interface Key<Id extends PropertyKey = PropertyKey> extends KeyIdentity<I
 
 export type AnyKey = Key<PropertyKey>
 
-export function key<Brand>(): <const Id extends PropertyKey>(id: Id, metadata?: KeyMetadata) => Key<Id> & Brand
-export function key<const Id extends PropertyKey>(id: Id, metadata?: KeyMetadata): Key<Id>
+export function key<Brand>(): <const Id extends PropertyKey>(id: Id & SingletonKeyId<Id>, metadata?: KeyMetadata) => Key<Id> & Brand
+export function key<const Id extends PropertyKey>(id: Id & SingletonKeyId<Id>, metadata?: KeyMetadata): Key<Id>
 export function key(id?: PropertyKey, metadata: KeyMetadata = {}): any {
   if (id === undefined) return key
   const token = { ...metadata }
@@ -28,3 +28,15 @@ export function key(id?: PropertyKey, metadata: KeyMetadata = {}): any {
 
 export const keyLabel = (key: AnyKey): string =>
   key.label ?? String(keyId(key))
+
+type SingletonKeyId<Id extends PropertyKey> =
+  string extends Id ? never
+  : number extends Id ? never
+  : symbol extends Id ? never
+  : IsUnion<Id> extends true ? never
+  : Id
+
+type IsUnion<T, U = T> =
+  T extends unknown
+  ? [U] extends [T] ? false : true
+  : false

--- a/src/Key.ts
+++ b/src/Key.ts
@@ -1,0 +1,30 @@
+import { KeyTypeId, keyId, sameKey, type KeyIdentity } from './internal/keyIdentity.js'
+
+export { keyId, sameKey }
+
+export interface KeyMetadata {
+  readonly label?: string
+}
+
+export interface Key<Id extends PropertyKey = PropertyKey> extends KeyIdentity<Id> {
+  readonly label?: string
+}
+
+export type AnyKey = Key<PropertyKey>
+
+export function key<Brand>(): <const Id extends PropertyKey>(id: Id, metadata?: KeyMetadata) => Key<Id> & Brand
+export function key<const Id extends PropertyKey>(id: Id, metadata?: KeyMetadata): Key<Id>
+export function key(id?: PropertyKey, metadata: KeyMetadata = {}): any {
+  if (id === undefined) return key
+  const token = { ...metadata }
+  Object.defineProperty(token, KeyTypeId, {
+    value: id,
+    enumerable: false,
+    writable: false,
+    configurable: false
+  })
+  return token
+}
+
+export const keyLabel = (key: AnyKey): string =>
+  key.label ?? String(keyId(key))

--- a/src/NodeRuntime.test.ts
+++ b/src/NodeRuntime.test.ts
@@ -5,7 +5,7 @@ import { assert as assertNoFail } from './Fail.js'
 import { andFinallyIn } from './Finalization.js'
 import { fx, type Fx } from './Fx.js'
 import { runNodeMain, runNodePromise, type NodeSignalName, type NodeSignalProcess } from './NodeRuntime.js'
-import { scope, withScope } from './Scope.js'
+import { scope, inScope } from './Scope.js'
 
 describe('NodeRuntime', () => {
   it('installs and removes SIGINT and SIGTERM listeners by default', async () => {
@@ -49,7 +49,7 @@ describe('NodeRuntime', () => {
         asyncAborted = true
       })
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       assertNoFail
     ), { process })
 

--- a/src/ReturnFrom.test.ts
+++ b/src/ReturnFrom.test.ts
@@ -45,7 +45,7 @@ describe('ReturnFrom', () => {
     const next = f[Symbol.iterator]().next()
 
     assert.equal(ReturnFrom.is(next.value), true)
-    const effect = next.value as ReturnFrom<typeof OtherScope, 'other'>
+    const effect = next.value as unknown as ReturnFrom<typeof OtherScope, 'other'>
     assert.equal(effect.scope, OtherScope)
     assert.equal(effect.arg, 'other')
   })

--- a/src/ReturnFrom.test.ts
+++ b/src/ReturnFrom.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { fx, run } from './Fx.js'
 import { ReturnFrom, returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control } from './Scope.js'
+import { scope, inScope, type Control } from './Scope.js'
 
 describe('ReturnFrom', () => {
   const TestScope = scope<Control>()('test/ReturnFrom')
@@ -12,7 +12,7 @@ describe('ReturnFrom', () => {
       yield* returnFrom(TestScope, 'early')
       return 'late'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       run
     )
 
@@ -27,7 +27,7 @@ describe('ReturnFrom', () => {
       ran = true
       return 'late'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       run
     )
 
@@ -40,7 +40,7 @@ describe('ReturnFrom', () => {
     const f = fx(function* () {
       yield* returnFrom(OtherScope, 'other')
       return 'late'
-    }).pipe(withScope(TestScope))
+    }).pipe(inScope(TestScope))
 
     const next = f[Symbol.iterator]().next()
 
@@ -57,9 +57,9 @@ describe('ReturnFrom', () => {
       return yield* fx(function* () {
         yield* returnFrom(TestScope, 'inner')
         return 'late'
-      }).pipe(withScope(OtherScope))
+      }).pipe(inScope(OtherScope))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       run
     )
 

--- a/src/ReturnFrom.ts
+++ b/src/ReturnFrom.ts
@@ -1,6 +1,6 @@
 import { ScopedEffect } from './Effect.js'
 import { Fx } from './Fx.js'
-import type { AnyControlScope } from './Scope.js'
+import { assertScopeOpen, type AnyControlScope } from './Scope.js'
 
 /**
  * Return early from the named scope with a value.
@@ -10,5 +10,7 @@ export class ReturnFrom<const Scope extends AnyControlScope, const A> extends Sc
 export const returnFrom = <const Scope extends AnyControlScope, const A>(
   scope: Scope,
   value: A
-): Fx<ReturnFrom<Scope, A>, never> =>
-  new ReturnFrom(scope, value)
+): Fx<ReturnFrom<Scope, A>, never> => {
+  assertScopeOpen(scope)
+  return new ReturnFrom(scope, value)
+}

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -255,7 +255,7 @@ export type ScopeEffects<E, Scope extends AnyLifetimeScope> =
   HandleScopeEffect<E, Scope> | ScopedForkEffects<E, Scope> | CleanupEffects<E, Scope> | CleanupFailure<E, Scope>
 
 type HandleScopeEffect<E, Scope extends AnyLifetimeScope> =
-  Exclude<E, Finally<Scope, any> | ReturnFrom<ControlScopeOf<Scope>, any> | ScopedFork<Scope> | InterruptFrom<Scope, any>>
+  Exclude<E, Finally<Scope, any> | ReturnFrom<ControlScopeOf<Scope>, any> | ScopedFork<Scope>>
 
 type ScopedForkEffects<E, Scope extends AnyLifetimeScope> =
   Extract<E, ScopedFork<Scope>> extends never ? never : Fork | Async | Fail<unknown>

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -15,6 +15,7 @@ import { isInterpretingReturn, isInterruptedReturn } from './internal/iteratorCl
 import { Pipeable, pipeThis } from './internal/pipe.js'
 import { interruptionReason, RuntimeScopeExit, withActiveScope, withScopeExitSource, withoutScopeExitSources, type ActiveScopeDiagnostic } from './internal/runtimeContext.js'
 import { ScopeTypeId, sameScope, scopeId, type ScopeIdentity } from './internal/scopeIdentity.js'
+import { assertScopeOpen as assertOpenScope, closeScope, markScopeCloseable } from './internal/scopeLifetime.js'
 import { rootHandlerCaptureTarget, ScopedHandlerCapture } from './internal/scopedHandlerCapture.js'
 import { settledTaskQueue } from './internal/settledQueue.js'
 import { ScopedFork } from './internal/scopedFork.js'
@@ -55,9 +56,6 @@ export type ControlScope<S = unknown, Id extends PropertyKey = PropertyKey> = Sc
 export type AnyLifetimeScope = LifetimeScope<any, PropertyKey>
 export type AnyControlScope = ControlScope<any, PropertyKey>
 
-const closedScopes = new WeakSet<object>()
-const closeableScopes = new WeakSet<object>()
-
 const createScope = <Brand>(
   metadata: ScopeOptions = {},
   id: PropertyKey = Symbol(metadata.label ?? 'fx/Scope'),
@@ -72,19 +70,12 @@ const createScope = <Brand>(
     writable: false,
     configurable: false
   })
-  if (closeable) closeableScopes.add(token)
+  if (closeable) markScopeCloseable(token)
   return token as Scope<PropertyKey> & Lifetime & ScopeHandle<unknown> & Brand
 }
 
-export const assertScopeOpen = (scope: AnyScope): void => {
-  if (closedScopes.has(scope)) {
-    throw new Error(`Scope handle ${scopeLabel(scope)} was used after its scope exited`)
-  }
-}
-
-const closeScope = (scope: AnyScope): void => {
-  if (closeableScopes.has(scope)) closedScopes.add(scope)
-}
+export const assertScopeOpen = (scope: AnyScope): void =>
+  assertOpenScope(scope, scopeLabel(scope))
 
 const createLifetimeScope = (metadata?: ScopeOptions): AnyLifetimeScope =>
   createScope(metadata)

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -206,7 +206,14 @@ export function withScope<const E, const A>(
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
   return fx(function* () {
     const scope = createLifetimeScope(options)
-    return yield* new ScopeBoundary(f(scope as unknown as LifetimeScope<never>), scope, undefined, true)
+    let bodyFx: Fx<E, A>
+    try {
+      bodyFx = f(scope as unknown as LifetimeScope<never>)
+    } catch (error) {
+      closeScope(scope)
+      throw error
+    }
+    return yield* new ScopeBoundary(bodyFx, scope, undefined, true)
   }) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
 }
 
@@ -225,7 +232,14 @@ export function withControlScope<const E, const A>(
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
   return fx(function* () {
     const scope = createControlScope(options)
-    return yield* new ScopeBoundary(f(scope as unknown as ControlScope<never>), scope, undefined, true)
+    let bodyFx: Fx<E, A>
+    try {
+      bodyFx = f(scope as unknown as ControlScope<never>)
+    } catch (error) {
+      closeScope(scope)
+      throw error
+    }
+    return yield* new ScopeBoundary(bodyFx, scope, undefined, true)
   }) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
 }
 

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -35,9 +35,7 @@ export interface Scope<Id extends PropertyKey = PropertyKey> extends ScopeIdenti
 
 declare const LifetimeTypeId: unique symbol
 declare const ControlTypeId: unique symbol
-declare const CurrentScopeTypeId: unique symbol
 declare const ScopeHandleTypeId: unique symbol
-const CurrentScopeId = Symbol('fx/Scope/current')
 
 export type Lifetime = {
   readonly [LifetimeTypeId]: true
@@ -48,7 +46,7 @@ export type Control = {
 }
 
 export type ScopeHandle<S = unknown> = {
-  readonly [ScopeHandleTypeId]?: S
+  readonly [ScopeHandleTypeId]?: (scope: S) => S
 }
 
 export type AnyScope = Scope<PropertyKey>
@@ -56,9 +54,6 @@ export type LifetimeScope<S = unknown, Id extends PropertyKey = PropertyKey> = S
 export type ControlScope<S = unknown, Id extends PropertyKey = PropertyKey> = Scope<Id> & Lifetime & Control & ScopeHandle<S>
 export type AnyLifetimeScope = LifetimeScope<any, PropertyKey>
 export type AnyControlScope = ControlScope<any, PropertyKey>
-export type CurrentLifetimeScope = LifetimeScope<typeof CurrentScopeId> & {
-  readonly [CurrentScopeTypeId]: true
-}
 
 const closedScopes = new WeakSet<object>()
 const closeableScopes = new WeakSet<object>()
@@ -82,13 +77,13 @@ const createScope = <Brand>(
 }
 
 export const assertScopeOpen = (scope: AnyScope): void => {
-  if (!sameScope(scope, currentScope) && closedScopes.has(scope)) {
+  if (closedScopes.has(scope)) {
     throw new Error(`Scope handle ${scopeLabel(scope)} was used after its scope exited`)
   }
 }
 
 const closeScope = (scope: AnyScope): void => {
-  if (!sameScope(scope, currentScope) && closeableScopes.has(scope)) closedScopes.add(scope)
+  if (closeableScopes.has(scope)) closedScopes.add(scope)
 }
 
 const createLifetimeScope = (metadata?: ScopeOptions): AnyLifetimeScope =>
@@ -109,17 +104,6 @@ export function scopeLabel(scope: undefined): 'undefined'
 export function scopeLabel(scope: AnyScope | undefined): string {
   if (scope === undefined) return 'undefined'
   return scope.label ?? String(scopeId(scope))
-}
-
-const createCurrentScope = (): CurrentLifetimeScope => {
-  const token = { diagnostic: false }
-  Object.defineProperty(token, ScopeTypeId, {
-    value: CurrentScopeId,
-    enumerable: false,
-    writable: false,
-    configurable: false
-  })
-  return token as CurrentLifetimeScope
 }
 
 const scopeDiagnostic = (scope: AnyScope): ActiveScopeDiagnostic => {
@@ -168,40 +152,56 @@ export interface Interrupted<Scope extends AnyScope> {
   readonly reason?: unknown
 }
 
-/**
- * Logical nearest lifetime scope token.
- *
- * A `withScope(...)` handler treats lifetime effects addressed to this token as
- * requests for that handler's own scope boundary. This token is not a captured
- * snapshot: saving it and using it inside a nested `withScope(...)` targets the
- * nested boundary.
- */
-export const currentScope: CurrentLifetimeScope = createCurrentScope() as CurrentLifetimeScope & {
-  readonly [CurrentScopeTypeId]: true
-}
-
-export function withScope<const S, const E, const A>(
-  body: (scope: LifetimeScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, LifetimeScope<S>>, A | ReturnValue<E, LifetimeScope<S>>>
-export function withScope<const S, const E, const A>(
-  options: ScopeOptions,
-  body: (scope: LifetimeScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, LifetimeScope<S>>, A | ReturnValue<E, LifetimeScope<S>>>
-export function withScope<const Scope extends AnyLifetimeScope>(
+export function inScope<const Scope extends AnyLifetimeScope, const E, const A>(
+  scope: Scope,
+  f: Fx<E, A>
+): Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>>
+export function inScope<const Scope extends AnyLifetimeScope>(
   scope: Scope
 ): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>>
-export function withScope<const E, const A>(
-  optionsOrBody: ScopeOptions | AnyLifetimeScope | ((scope: AnyLifetimeScope) => Fx<E, A>),
-  body?: (scope: AnyLifetimeScope) => Fx<E, A>
-): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>> | (<const E2, const A2>(f: Fx<E2, A2>) => Fx<ScopeEffects<E2, AnyLifetimeScope>, A2 | ReturnValue<E2, AnyLifetimeScope>>) {
-  if (typeof optionsOrBody === 'object' && ScopeTypeId in optionsOrBody) {
-    const scope = optionsOrBody as AnyLifetimeScope
+export function inScope<const E, const A>(
+  f: Fx<E, A>
+): Fx<E, A>
+export function inScope<const E, const A>(
+  options: ScopeOptions,
+  f: Fx<E, A>
+): Fx<E, A>
+export function inScope<const E, const A>(
+  scopeOptionsOrFx: ScopeOptions | AnyLifetimeScope | Fx<E, A>,
+  maybeFx?: Fx<E, A>
+): any {
+  if (typeof scopeOptionsOrFx === 'object' && ScopeTypeId in scopeOptionsOrFx) {
+    const scope = scopeOptionsOrFx as AnyLifetimeScope
     assertScopeOpen(scope)
+    if (maybeFx !== undefined) {
+      assertScopeOpen(scope)
+      return new ScopeBoundary(maybeFx, scope) as Fx<ScopeEffects<E, typeof scope>, A | ReturnValue<E, typeof scope>>
+    }
     return <const E2, const A2>(f: Fx<E2, A2>) => {
       assertScopeOpen(scope)
       return new ScopeBoundary(f, scope) as Fx<ScopeEffects<E2, typeof scope>, A2 | ReturnValue<E2, typeof scope>>
     }
   }
+
+  const options = maybeFx === undefined ? undefined : scopeOptionsOrFx as ScopeOptions
+  const f = maybeFx === undefined ? scopeOptionsOrFx as Fx<E, A> : maybeFx
+  return fx(function* () {
+    const scope = createLifetimeScope(options)
+    return yield* new ScopeBoundary(f, scope, undefined, true)
+  }) as Fx<E, A>
+}
+
+export function withScope<const E, const A>(
+  body: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<E, A>
+export function withScope<const E, const A>(
+  options: ScopeOptions,
+  body: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<E, A>
+export function withScope<const E, const A>(
+  optionsOrBody: ScopeOptions | (<S>(scope: LifetimeScope<S>) => Fx<E, A>),
+  body?: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<E, A> {
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
   return fx(function* () {
@@ -213,21 +213,25 @@ export function withScope<const E, const A>(
       closeScope(scope)
       throw error
     }
-    return yield* new ScopeBoundary(bodyFx, scope, undefined, true)
-  }) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
+    try {
+      return yield* bodyFx
+    } finally {
+      closeScope(scope)
+    }
+  })
 }
 
-export function withControlScope<const S, const E, const A>(
-  body: (scope: ControlScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, ControlScope<S>>, A | ReturnValue<E, ControlScope<S>>>
-export function withControlScope<const S, const E, const A>(
-  options: ScopeOptions,
-  body: (scope: ControlScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, ControlScope<S>>, A | ReturnValue<E, ControlScope<S>>>
 export function withControlScope<const E, const A>(
-  optionsOrBody: ScopeOptions | ((scope: AnyControlScope) => Fx<E, A>),
-  body?: (scope: AnyControlScope) => Fx<E, A>
-): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>> {
+  body: <S>(scope: ControlScope<S>) => Fx<E, A>
+): Fx<E, A>
+export function withControlScope<const E, const A>(
+  options: ScopeOptions,
+  body: <S>(scope: ControlScope<S>) => Fx<E, A>
+): Fx<E, A>
+export function withControlScope<const E, const A>(
+  optionsOrBody: ScopeOptions | (<S>(scope: ControlScope<S>) => Fx<E, A>),
+  body?: <S>(scope: ControlScope<S>) => Fx<E, A>
+): Fx<E, A> {
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
   return fx(function* () {
@@ -239,27 +243,25 @@ export function withControlScope<const E, const A>(
       closeScope(scope)
       throw error
     }
-    return yield* new ScopeBoundary(bodyFx, scope, undefined, true)
-  }) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+    try {
+      return yield* bodyFx
+    } finally {
+      closeScope(scope)
+    }
+  })
 }
 
 export type ScopeEffects<E, Scope extends AnyLifetimeScope> =
   HandleScopeEffect<E, Scope> | ScopedForkEffects<E, Scope> | CleanupEffects<E, Scope> | CleanupFailure<E, Scope>
 
 type HandleScopeEffect<E, Scope extends AnyLifetimeScope> =
-  E extends Finally<HandledScope<Scope>, any> ? never
-  : E extends ReturnFrom<ControlScopeOf<Scope>, any> ? never
-  : E extends ScopedFork<HandledScope<Scope>> ? never
-  : E extends InterruptFrom<CurrentLifetimeScope, infer Reason> ? InterruptFrom<Scope, Reason>
-  : E
+  Exclude<E, Finally<Scope, any> | ReturnFrom<ControlScopeOf<Scope>, any> | ScopedFork<Scope> | InterruptFrom<Scope, any>>
 
 type ScopedForkEffects<E, Scope extends AnyLifetimeScope> =
-  E extends ScopedFork<HandledScope<Scope>> ? Fork | Async | Fail<unknown> : never
+  Extract<E, ScopedFork<Scope>> extends never ? never : Fork | Async | Fail<unknown>
 
 type MatchingFinally<E, Scope extends AnyLifetimeScope> =
-  Extract<E, Finally<HandledScope<Scope>, any>>
-
-type HandledScope<Scope extends AnyLifetimeScope> = Scope | CurrentLifetimeScope
+  Extract<E, Finally<Scope, any>>
 
 type ControlScopeOf<Scope extends AnyLifetimeScope> =
   Scope extends AnyControlScope ? Scope : never
@@ -267,7 +269,7 @@ type ControlScopeOf<Scope extends AnyLifetimeScope> =
 type FinalizerEffects<E, Scope extends AnyLifetimeScope> =
   MatchingFinally<E, Scope> extends never
     ? never
-    : MatchingFinally<E, Scope> extends Finally<HandledScope<Scope>, infer FE> ? FE : never
+    : MatchingFinally<E, Scope> extends Finally<Scope, infer FE> ? FE : never
 
 type CleanupEffects<E, Scope extends AnyLifetimeScope> =
   Exclude<FinalizerEffects<E, Scope>, Fail<any>>
@@ -366,12 +368,11 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
 
       const effectScope = (effect as { readonly scope?: AnyScope }).scope
       const matchesScope = effectScope !== undefined && sameScope(effectScope, scope)
-      const matchesLifetimeScope = matchesScope || (effectScope !== undefined && sameScope(effectScope, currentScope))
 
-      if (matchesLifetimeScope && Finally.is(effect)) {
+      if (matchesScope && Finally.is(effect)) {
         controller.addFinalizer(effect.arg)
         return continueWith(undefined)
-      } else if (matchesLifetimeScope && ScopedFork.is(effect)) {
+      } else if (matchesScope && ScopedFork.is(effect)) {
         const context = yield* new ScopedHandlerCapture(rootHandlerCaptureTarget)
         const task = yield* controller.fork({
           ...effect.arg,
@@ -392,14 +393,13 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
           return doneWith(undefined as A)
         }
         return doneWith(yield* finishRoot(exit, effect))
-      } else if (matchesLifetimeScope && InterruptFrom.is(effect)) {
+      } else if (matchesScope && InterruptFrom.is(effect)) {
         const exit = interruptedExit(scope, effect.arg)
-        const interrupt = matchesScope ? effect : new InterruptFrom(scope, effect.arg)
         if (!root) {
           controller.requestExit(exit)
           return doneWith(undefined as A)
         }
-        return doneWith(yield* finishRoot(exit, interrupt))
+        return doneWith(yield* finishRoot(exit, effect))
       } else if (Fail.is(effect)) {
         const exit = { type: 'failure', failure: effect } satisfies Exit
         if (!root) {

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -23,7 +23,7 @@ import type { Task } from './Task.js'
 
 export { sameScope, scopeId }
 
-export interface ScopeMetadata {
+export interface ScopeOptions {
   readonly label?: string
   readonly diagnostic?: boolean
 }
@@ -36,6 +36,7 @@ export interface Scope<Id extends PropertyKey = PropertyKey> extends ScopeIdenti
 declare const LifetimeTypeId: unique symbol
 declare const ControlTypeId: unique symbol
 declare const CurrentScopeTypeId: unique symbol
+declare const ScopeHandleTypeId: unique symbol
 const CurrentScopeId = Symbol('fx/Scope/current')
 
 export type Lifetime = {
@@ -46,31 +47,80 @@ export type Control = {
   readonly [ControlTypeId]: true
 }
 
+export type ScopeHandle<S = unknown> = {
+  readonly [ScopeHandleTypeId]?: S
+}
+
 export type AnyScope = Scope<PropertyKey>
-export type LifetimeScope<Id extends PropertyKey = PropertyKey> = Scope<Id> & Lifetime
-export type ControlScope<Id extends PropertyKey = PropertyKey> = Scope<Id> & Lifetime & Control
-export type AnyLifetimeScope = LifetimeScope<PropertyKey>
-export type AnyControlScope = ControlScope<PropertyKey>
+export type LifetimeScope<S = unknown, Id extends PropertyKey = PropertyKey> = Scope<Id> & Lifetime & ScopeHandle<S>
+export type ControlScope<S = unknown, Id extends PropertyKey = PropertyKey> = Scope<Id> & Lifetime & Control & ScopeHandle<S>
+export type AnyLifetimeScope = LifetimeScope<any, PropertyKey>
+export type AnyControlScope = ControlScope<any, PropertyKey>
 export type CurrentLifetimeScope = LifetimeScope<typeof CurrentScopeId> & {
   readonly [CurrentScopeTypeId]: true
 }
 
-export function scope<Brand>(): <const Id extends PropertyKey>(id: Id, metadata?: ScopeMetadata) => Scope<Id> & Lifetime & Brand
-export function scope<const Id extends PropertyKey>(id: Id, metadata?: ScopeMetadata): Scope<Id> & Lifetime
-export function scope(id?: PropertyKey, metadata: ScopeMetadata = {}): any {
-  if (id === undefined) return scope
-  const token = { ...metadata }
+const closedScopes = new WeakSet<object>()
+const closeableScopes = new WeakSet<object>()
+
+const createScope = <Brand>(
+  metadata: ScopeOptions = {},
+  id: PropertyKey = Symbol(metadata.label ?? 'fx/Scope'),
+  closeable = true
+): Scope<PropertyKey> & Lifetime & ScopeHandle<unknown> & Brand => {
+  const token = metadata.diagnostic === undefined
+    ? { label: metadata.label ?? String(id) }
+    : { label: metadata.label ?? String(id), diagnostic: metadata.diagnostic }
   Object.defineProperty(token, ScopeTypeId, {
     value: id,
     enumerable: false,
     writable: false,
     configurable: false
   })
-  return token
+  if (closeable) closeableScopes.add(token)
+  return token as Scope<PropertyKey> & Lifetime & ScopeHandle<unknown> & Brand
 }
 
-export const scopeLabel = (scope: AnyScope): string =>
-  scope.label ?? String(scopeId(scope))
+export const assertScopeOpen = (scope: AnyScope): void => {
+  if (!sameScope(scope, currentScope) && closedScopes.has(scope)) {
+    throw new Error(`Scope handle ${scopeLabel(scope)} was used after its scope exited`)
+  }
+}
+
+const closeScope = (scope: AnyScope): void => {
+  if (!sameScope(scope, currentScope) && closeableScopes.has(scope)) closedScopes.add(scope)
+}
+
+const createLifetimeScope = (metadata?: ScopeOptions): AnyLifetimeScope =>
+  createScope(metadata)
+
+const createControlScope = (metadata?: ScopeOptions): AnyControlScope =>
+  createScope<Control>(metadata)
+
+export function scope<Brand>(): <const Id extends PropertyKey>(id: Id, metadata?: ScopeOptions) => Scope<Id> & Lifetime & ScopeHandle<any> & Brand
+export function scope<const Id extends PropertyKey>(id: Id, metadata?: ScopeOptions): Scope<Id> & Lifetime & ScopeHandle<any>
+export function scope(id?: PropertyKey, metadata: ScopeOptions = {}): any {
+  if (id === undefined) return (id: PropertyKey, metadata?: ScopeOptions) => createScope(metadata, id, false)
+  return createScope(metadata, id, false)
+}
+
+export function scopeLabel(scope: AnyScope): string
+export function scopeLabel(scope: undefined): 'undefined'
+export function scopeLabel(scope: AnyScope | undefined): string {
+  if (scope === undefined) return 'undefined'
+  return scope.label ?? String(scopeId(scope))
+}
+
+const createCurrentScope = (): CurrentLifetimeScope => {
+  const token = { diagnostic: false }
+  Object.defineProperty(token, ScopeTypeId, {
+    value: CurrentScopeId,
+    enumerable: false,
+    writable: false,
+    configurable: false
+  })
+  return token as CurrentLifetimeScope
+}
 
 const scopeDiagnostic = (scope: AnyScope): ActiveScopeDiagnostic => {
   return {
@@ -126,18 +176,50 @@ export interface Interrupted<Scope extends AnyScope> {
  * snapshot: saving it and using it inside a nested `withScope(...)` targets the
  * nested boundary.
  */
-export const currentScope: CurrentLifetimeScope = scope<{
+export const currentScope: CurrentLifetimeScope = createCurrentScope() as CurrentLifetimeScope & {
   readonly [CurrentScopeTypeId]: true
-}>()(CurrentScopeId, { diagnostic: false })
+}
 
+export function withScope<const E, const A>(
+  body: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
+export function withScope<const E, const A>(
+  options: ScopeOptions,
+  body: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
 export function withScope<const Scope extends AnyLifetimeScope>(
   scope: Scope
-): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>> {
-  return <const E, const A>(f: Fx<E, A>) => {
-    // ScopeBoundary interprets effects dynamically; this assertion connects the
-    // runtime interpreter boundary to the public scoped-effect elimination type.
-    return new ScopeBoundary(f, scope) as Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>>
+): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>>
+export function withScope<const E, const A>(
+  optionsOrBody: ScopeOptions | AnyLifetimeScope | (<S>(scope: LifetimeScope<S>) => Fx<E, A>),
+  body?: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>> | (<const E2, const A2>(f: Fx<E2, A2>) => Fx<ScopeEffects<E2, AnyLifetimeScope>, A2 | ReturnValue<E2, AnyLifetimeScope>>) {
+  if (typeof optionsOrBody === 'object' && ScopeTypeId in optionsOrBody) {
+    const scope = optionsOrBody as AnyLifetimeScope
+    return <const E2, const A2>(f: Fx<E2, A2>) =>
+      new ScopeBoundary(f, scope) as Fx<ScopeEffects<E2, AnyLifetimeScope>, A2 | ReturnValue<E2, AnyLifetimeScope>>
   }
+  const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
+  const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
+  const scope = createLifetimeScope(options)
+  return new ScopeBoundary(f(scope as unknown as LifetimeScope<never>), scope) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
+}
+
+export function withControlScope<const E, const A>(
+  body: <S>(scope: ControlScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+export function withControlScope<const E, const A>(
+  options: ScopeOptions,
+  body: <S>(scope: ControlScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+export function withControlScope<const E, const A>(
+  optionsOrBody: ScopeOptions | (<S>(scope: ControlScope<S>) => Fx<E, A>),
+  body?: <S>(scope: ControlScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>> {
+  const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
+  const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
+  const scope = createControlScope(options)
+  return new ScopeBoundary(f(scope as unknown as ControlScope<never>), scope) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
 }
 
 export type ScopeEffects<E, Scope extends AnyLifetimeScope> =
@@ -356,6 +438,7 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
         : yield* collectInterruptedChildCleanupFailures(completed, isInterpretingReturn(), i, step)
       const filteredCleanupFailures = cleanupFailures.flatMap(cleanupFailuresOf)
       if (filteredCleanupFailures.length > 0) yield* withMaybeActiveScope(failCleanup(filteredCleanupFailures))
+      if (root) closeScope(scope)
     }
   }
 }

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -202,7 +202,7 @@ export function withScope<const E, const A>(
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
   const scope = createLifetimeScope(options)
-  return new ScopeBoundary(f(scope as unknown as LifetimeScope<never>), scope) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
+  return new ScopeBoundary(f(scope as unknown as LifetimeScope<never>), scope, undefined, true) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
 }
 
 export function withControlScope<const E, const A>(
@@ -219,7 +219,7 @@ export function withControlScope<const E, const A>(
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
   const scope = createControlScope(options)
-  return new ScopeBoundary(f(scope as unknown as ControlScope<never>), scope) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+  return new ScopeBoundary(f(scope as unknown as ControlScope<never>), scope, undefined, true) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
 }
 
 export type ScopeEffects<E, Scope extends AnyLifetimeScope> =
@@ -268,7 +268,8 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
   constructor(
     public readonly fx: Fx<E, A>,
     public readonly scope: Scope,
-    controller?: ScopeController<Scope>
+    controller?: ScopeController<Scope>,
+    private readonly closeOnExit = false
   ) {
     this.controller = controller
     this.root = controller === undefined
@@ -438,7 +439,7 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
         : yield* collectInterruptedChildCleanupFailures(completed, isInterpretingReturn(), i, step)
       const filteredCleanupFailures = cleanupFailures.flatMap(cleanupFailuresOf)
       if (filteredCleanupFailures.length > 0) yield* withMaybeActiveScope(failCleanup(filteredCleanupFailures))
-      if (root) closeScope(scope)
+      if (root && this.closeOnExit) closeScope(scope)
     }
   }
 }

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -197,8 +197,10 @@ export function withScope<const E, const A>(
   if (typeof optionsOrBody === 'object' && ScopeTypeId in optionsOrBody) {
     const scope = optionsOrBody as AnyLifetimeScope
     assertScopeOpen(scope)
-    return <const E2, const A2>(f: Fx<E2, A2>) =>
-      new ScopeBoundary(f, scope) as Fx<ScopeEffects<E2, typeof scope>, A2 | ReturnValue<E2, typeof scope>>
+    return <const E2, const A2>(f: Fx<E2, A2>) => {
+      assertScopeOpen(scope)
+      return new ScopeBoundary(f, scope) as Fx<ScopeEffects<E2, typeof scope>, A2 | ReturnValue<E2, typeof scope>>
+    }
   }
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -201,8 +201,10 @@ export function withScope<const E, const A>(
   }
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
-  const scope = createLifetimeScope(options)
-  return new ScopeBoundary(f(scope as unknown as LifetimeScope<never>), scope, undefined, true) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
+  return fx(function* () {
+    const scope = createLifetimeScope(options)
+    return yield* new ScopeBoundary(f(scope as unknown as LifetimeScope<never>), scope, undefined, true)
+  }) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
 }
 
 export function withControlScope<const E, const A>(
@@ -218,8 +220,10 @@ export function withControlScope<const E, const A>(
 ): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>> {
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
-  const scope = createControlScope(options)
-  return new ScopeBoundary(f(scope as unknown as ControlScope<never>), scope, undefined, true) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+  return fx(function* () {
+    const scope = createControlScope(options)
+    return yield* new ScopeBoundary(f(scope as unknown as ControlScope<never>), scope, undefined, true)
+  }) as Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
 }
 
 export type ScopeEffects<E, Scope extends AnyLifetimeScope> =

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -180,24 +180,25 @@ export const currentScope: CurrentLifetimeScope = createCurrentScope() as Curren
   readonly [CurrentScopeTypeId]: true
 }
 
-export function withScope<const E, const A>(
-  body: <S>(scope: LifetimeScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
-export function withScope<const E, const A>(
+export function withScope<const S, const E, const A>(
+  body: (scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, LifetimeScope<S>>, A | ReturnValue<E, LifetimeScope<S>>>
+export function withScope<const S, const E, const A>(
   options: ScopeOptions,
-  body: <S>(scope: LifetimeScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
+  body: (scope: LifetimeScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, LifetimeScope<S>>, A | ReturnValue<E, LifetimeScope<S>>>
 export function withScope<const Scope extends AnyLifetimeScope>(
   scope: Scope
 ): <const E, const A>(f: Fx<E, A>) => Fx<ScopeEffects<E, Scope>, A | ReturnValue<E, Scope>>
 export function withScope<const E, const A>(
-  optionsOrBody: ScopeOptions | AnyLifetimeScope | (<S>(scope: LifetimeScope<S>) => Fx<E, A>),
-  body?: <S>(scope: LifetimeScope<S>) => Fx<E, A>
+  optionsOrBody: ScopeOptions | AnyLifetimeScope | ((scope: AnyLifetimeScope) => Fx<E, A>),
+  body?: (scope: AnyLifetimeScope) => Fx<E, A>
 ): Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>> | (<const E2, const A2>(f: Fx<E2, A2>) => Fx<ScopeEffects<E2, AnyLifetimeScope>, A2 | ReturnValue<E2, AnyLifetimeScope>>) {
   if (typeof optionsOrBody === 'object' && ScopeTypeId in optionsOrBody) {
     const scope = optionsOrBody as AnyLifetimeScope
+    assertScopeOpen(scope)
     return <const E2, const A2>(f: Fx<E2, A2>) =>
-      new ScopeBoundary(f, scope) as Fx<ScopeEffects<E2, AnyLifetimeScope>, A2 | ReturnValue<E2, AnyLifetimeScope>>
+      new ScopeBoundary(f, scope) as Fx<ScopeEffects<E2, typeof scope>, A2 | ReturnValue<E2, typeof scope>>
   }
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!
@@ -207,16 +208,16 @@ export function withScope<const E, const A>(
   }) as Fx<ScopeEffects<E, AnyLifetimeScope>, A | ReturnValue<E, AnyLifetimeScope>>
 }
 
-export function withControlScope<const E, const A>(
-  body: <S>(scope: ControlScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
-export function withControlScope<const E, const A>(
+export function withControlScope<const S, const E, const A>(
+  body: (scope: ControlScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, ControlScope<S>>, A | ReturnValue<E, ControlScope<S>>>
+export function withControlScope<const S, const E, const A>(
   options: ScopeOptions,
-  body: <S>(scope: ControlScope<S>) => Fx<E, A>
-): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>>
+  body: (scope: ControlScope<S>) => Fx<E, A>
+): Fx<ScopeEffects<E, ControlScope<S>>, A | ReturnValue<E, ControlScope<S>>>
 export function withControlScope<const E, const A>(
-  optionsOrBody: ScopeOptions | (<S>(scope: ControlScope<S>) => Fx<E, A>),
-  body?: <S>(scope: ControlScope<S>) => Fx<E, A>
+  optionsOrBody: ScopeOptions | ((scope: AnyControlScope) => Fx<E, A>),
+  body?: (scope: AnyControlScope) => Fx<E, A>
 ): Fx<ScopeEffects<E, AnyControlScope>, A | ReturnValue<E, AnyControlScope>> {
   const options = typeof optionsOrBody === 'function' ? undefined : optionsOrBody
   const f = typeof optionsOrBody === 'function' ? optionsOrBody : body!

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -292,26 +292,28 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
     public readonly fx: Fx<E, A>,
     public readonly scope: Scope,
     controller?: ScopeController<Scope>,
-    private readonly closeOnExit = false
+    private readonly closeOnExit = false,
+    private readonly checkOnEnter = true
   ) {
     this.controller = controller
     this.root = controller === undefined
   }
 
   wrap(fx: Fx<unknown, unknown>): Fx<unknown, unknown> {
-    return new ScopeBoundary(fx, this.scope)
+    // Captured handlers may replay after lexical exit; matching scoped effects still assert below.
+    return new ScopeBoundary(fx, this.scope, undefined, false, false)
   }
 
   wrapShared(fx: Fx<unknown, unknown>): Fx<unknown, unknown> {
     return this.controller === undefined
-      ? new ScopeBoundary(fx, this.scope)
-      : new ScopeBoundary(fx, this.scope, this.controller)
+      ? new ScopeBoundary(fx, this.scope, undefined, false, false)
+      : new ScopeBoundary(fx, this.scope, this.controller, false, false)
   }
 
   *[Symbol.iterator](): Iterator<unknown, A> {
     const { scope } = this
     const root = this.root
-    if (root) assertScopeOpen(scope)
+    if (root && this.checkOnEnter) assertScopeOpen(scope)
     const controller = this.controller ?? new ScopeController(scope)
     const activeScope = root && scope.diagnostic !== false ? scopeDiagnostic(scope) : undefined
     const withMaybeActiveScope = <E, A>(fx: Fx<E, A>): Fx<E, A> =>
@@ -319,10 +321,10 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
     const scopedFx = root ? controller.withExitSource(this.fx) : this.fx
     const i = withMaybeActiveScope(scopedFx)[Symbol.iterator]()
     const captured: CapturedHandler = {
-      wrap: fx => new ScopeBoundary(fx, scope)
+      wrap: fx => new ScopeBoundary(fx, scope, undefined, false, false)
     }
     const capturedShared: CapturedHandler = {
-      wrap: fx => new ScopeBoundary(fx, scope, controller)
+      wrap: fx => new ScopeBoundary(fx, scope, controller, false, false)
     }
     let released = false
     const release = function* (exit: Exit<Scope>): Generator<unknown, ScopeRelease<Scope>> {
@@ -368,6 +370,7 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
 
       const effectScope = (effect as { readonly scope?: AnyScope }).scope
       const matchesScope = effectScope !== undefined && sameScope(effectScope, scope)
+      if (matchesScope) assertScopeOpen(effectScope)
 
       if (matchesScope && Finally.is(effect)) {
         controller.addFinalizer(effect.arg)

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -294,8 +294,9 @@ class ScopeBoundary<E, A, Scope extends AnyLifetimeScope> implements Fx<unknown,
 
   *[Symbol.iterator](): Iterator<unknown, A> {
     const { scope } = this
-    const controller = this.controller ?? new ScopeController(scope)
     const root = this.root
+    if (root) assertScopeOpen(scope)
+    const controller = this.controller ?? new ScopeController(scope)
     const activeScope = root && scope.diagnostic !== false ? scopeDiagnostic(scope) : undefined
     const withMaybeActiveScope = <E, A>(fx: Fx<E, A>): Fx<E, A> =>
       activeScope === undefined ? fx : withActiveScope(activeScope, fx)

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -9,11 +9,41 @@ import { fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { interruptFrom, InterruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { returnFrom, ReturnFrom } from './ReturnFrom.js'
 import { scoped } from './Scoped.js'
-import { currentScope, scope, withScope, type Control } from './Scope.js'
+import { currentScope, sameScope, scope, withScope, type AnyLifetimeScope, type Control } from './Scope.js'
 import { getState, modifyState } from './State.js'
 import { yieldFrom } from './YieldFrom.js'
 
 describe('currentScope', () => {
+  it('creates distinct lexical handles for scopes with the same label', () => {
+    let first: AnyLifetimeScope | undefined
+    let second: AnyLifetimeScope | undefined
+
+    const result = withScope({ label: 'request' }, outer => fx(function* () {
+      first = outer
+      return yield* withScope({ label: 'request' }, inner => fx(function* () {
+        second = inner
+        return sameScope(outer, inner)
+      }))
+    })).pipe(run)
+
+    assert.equal(result, false)
+    assert.equal(first?.label, 'request')
+    assert.equal(second?.label, 'request')
+  })
+
+  it('rejects scope handles used after their lexical scope exits', () => {
+    let leaked: AnyLifetimeScope | undefined
+
+    withScope(scope => fx(function* () {
+      leaked = scope
+    })).pipe(run)
+
+    assert.throws(
+      () => andFinallyIn(leaked!, ok(undefined)),
+      /used after its scope exited/
+    )
+  })
+
   it('is eliminated by withScope', () => {
     const TestScope = scope('test/CurrentScope/type')
     const program = andFinally(ok(undefined)).pipe(withScope(TestScope))

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -70,6 +70,19 @@ describe('currentScope', () => {
     )
   })
 
+  it('rejects escaped scope boundaries for closed lexical handles', () => {
+    let escaped: Fx<unknown, unknown> | undefined
+
+    withScope(scope => fx(function* () {
+      escaped = andFinally(ok(undefined)).pipe(withScope(scope))
+    })).pipe(run)
+
+    assert.throws(
+      () => escaped![Symbol.iterator]().next(),
+      /used after its scope exited/
+    )
+  })
+
   it('allocates lexical lifetime handles per execution', () => {
     const handles: AnyLifetimeScope[] = []
     const program = withScope({ label: 'repeatable' }, scope => fx(function* () {

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { abort, Abort } from './Abort.js'
+import { abort, Abort, orReturn } from './Abort.js'
 import { forkIn, withUnboundedConcurrency } from './Concurrent.js'
 import { assert as assertNoFail, fail, Fail, returnFail } from './Fail.js'
 import { andFinally, andFinallyIn } from './Finalization.js'
@@ -9,7 +9,7 @@ import { fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { interruptFrom, InterruptFrom, recoverInterrupt } from './InterruptFrom.js'
 import { returnFrom, ReturnFrom } from './ReturnFrom.js'
 import { scoped } from './Scoped.js'
-import { currentScope, sameScope, scope, withScope, type AnyLifetimeScope, type Control } from './Scope.js'
+import { currentScope, sameScope, scope, withControlScope, withScope, type AnyControlScope, type AnyLifetimeScope, type Control } from './Scope.js'
 import { getState, modifyState } from './State.js'
 import { yieldFrom } from './YieldFrom.js'
 
@@ -42,6 +42,38 @@ describe('currentScope', () => {
       () => andFinallyIn(leaked!, ok(undefined)),
       /used after its scope exited/
     )
+  })
+
+  it('allocates lexical lifetime handles per execution', () => {
+    const handles: AnyLifetimeScope[] = []
+    const program = withScope({ label: 'repeatable' }, scope => fx(function* () {
+      handles.push(scope)
+      yield* andFinallyIn(scope, ok(undefined))
+      return 'ok' as const
+    })).pipe(returnFail)
+
+    assert.equal(run(program), 'ok')
+    assert.equal(run(program), 'ok')
+    assert.equal(handles.length, 2)
+    assert.equal(handles[0]?.label, 'repeatable')
+    assert.equal(handles[1]?.label, 'repeatable')
+    assert.equal(sameScope(handles[0]!, handles[1]!), false)
+  })
+
+  it('allocates lexical control handles per execution', () => {
+    const handles: AnyControlScope[] = []
+    const program = withControlScope({ label: 'repeatable control' }, scope => fx(function* () {
+      handles.push(scope)
+      yield* abort(scope)
+      return 'late' as const
+    }).pipe(orReturn(scope, 'aborted' as const), returnFail))
+
+    assert.equal(run(program), 'aborted')
+    assert.equal(run(program), 'aborted')
+    assert.equal(handles.length, 2)
+    assert.equal(handles[0]?.label, 'repeatable control')
+    assert.equal(handles[1]?.label, 'repeatable control')
+    assert.equal(sameScope(handles[0]!, handles[1]!), false)
   })
 
   it('is eliminated by withScope', () => {

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -83,6 +83,40 @@ describe('currentScope', () => {
     )
   })
 
+  it('closes lexical lifetime handles when body construction throws', () => {
+    let leaked: AnyLifetimeScope | undefined
+
+    assert.throws(
+      () => withScope(scope => {
+        leaked = scope
+        throw new Error('construction failed')
+      })[Symbol.iterator]().next(),
+      /construction failed/
+    )
+
+    assert.throws(
+      () => andFinallyIn(leaked!, ok(undefined)),
+      /used after its scope exited/
+    )
+  })
+
+  it('closes lexical control handles when body construction throws', () => {
+    let leaked: AnyControlScope | undefined
+
+    assert.throws(
+      () => withControlScope(scope => {
+        leaked = scope
+        throw new Error('construction failed')
+      })[Symbol.iterator]().next(),
+      /construction failed/
+    )
+
+    assert.throws(
+      () => abort(leaked!),
+      /used after its scope exited/
+    )
+  })
+
   it('allocates lexical lifetime handles per execution', () => {
     const handles: AnyLifetimeScope[] = []
     const program = withScope({ label: 'repeatable' }, scope => fx(function* () {

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -1,19 +1,18 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { abort, Abort, orReturn } from './Abort.js'
+import { abort, orReturn } from './Abort.js'
 import { forkIn, withUnboundedConcurrency } from './Concurrent.js'
-import { assert as assertNoFail, fail, Fail, returnFail } from './Fail.js'
-import { andFinally, andFinallyIn } from './Finalization.js'
+import { assert as assertNoFail, Fail, returnFail } from './Fail.js'
+import { andFinallyIn, type Finally } from './Finalization.js'
 import { fx, ok, run, runPromise, type Fx } from './Fx.js'
-import { interruptFrom, InterruptFrom, recoverInterrupt } from './InterruptFrom.js'
+import { key } from './Key.js'
 import { returnFrom, ReturnFrom } from './ReturnFrom.js'
 import { scoped } from './Scoped.js'
-import { currentScope, sameScope, scope, withControlScope, withScope, type AnyControlScope, type AnyLifetimeScope, type Control } from './Scope.js'
-import { getState, modifyState } from './State.js'
-import { yieldFrom } from './YieldFrom.js'
+import { inScope, sameScope, scope, withControlScope, withScope, type AnyControlScope, type AnyLifetimeScope, type Control } from './Scope.js'
+import { modifyState, type ModifyState, type Stateful } from './State.js'
 
-describe('currentScope', () => {
+describe('lexical scope handles', () => {
   it('creates distinct lexical handles for scopes with the same label', () => {
     let first: AnyLifetimeScope | undefined
     let second: AnyLifetimeScope | undefined
@@ -44,7 +43,7 @@ describe('currentScope', () => {
     )
   })
 
-  it('rejects closed lexical handles passed to explicit withScope', () => {
+  it('rejects closed lexical handles passed to explicit inScope', () => {
     let leaked: AnyLifetimeScope | undefined
 
     withScope(scope => fx(function* () {
@@ -52,20 +51,20 @@ describe('currentScope', () => {
     })).pipe(run)
 
     assert.throws(
-      () => withScope(leaked!),
+      () => inScope(leaked!),
       /used after its scope exited/
     )
   })
 
-  it('rejects cached withScope pipeables for closed lexical handles', () => {
+  it('rejects cached inScope pipeables for closed lexical handles', () => {
     let cached: ((f: Fx<unknown, unknown>) => Fx<unknown, unknown>) | undefined
 
     withScope(scope => fx(function* () {
-      cached = withScope(scope)
+      cached = inScope(scope)
     })).pipe(run)
 
     assert.throws(
-      () => cached!(andFinally(ok(undefined))),
+      () => cached!(andFinallyIn(scope('test/unused'), ok(undefined))),
       /used after its scope exited/
     )
   })
@@ -74,7 +73,7 @@ describe('currentScope', () => {
     let escaped: Fx<unknown, unknown> | undefined
 
     withScope(scope => fx(function* () {
-      escaped = andFinally(ok(undefined)).pipe(withScope(scope))
+      escaped = andFinallyIn(scope, ok(undefined)).pipe(inScope(scope))
     })).pipe(run)
 
     assert.throws(
@@ -119,11 +118,11 @@ describe('currentScope', () => {
 
   it('allocates lexical lifetime handles per execution', () => {
     const handles: AnyLifetimeScope[] = []
-    const program = withScope({ label: 'repeatable' }, scope => fx(function* () {
+    const program = withScope({ label: 'repeatable' }, scope => inScope(scope, fx(function* () {
       handles.push(scope)
       yield* andFinallyIn(scope, ok(undefined))
       return 'ok' as const
-    })).pipe(returnFail)
+    }))).pipe(returnFail)
 
     assert.equal(run(program), 'ok')
     assert.equal(run(program), 'ok')
@@ -135,11 +134,11 @@ describe('currentScope', () => {
 
   it('allocates lexical control handles per execution', () => {
     const handles: AnyControlScope[] = []
-    const program = withControlScope({ label: 'repeatable control' }, scope => fx(function* () {
+    const program = withControlScope({ label: 'repeatable control' }, scope => inScope(scope, fx(function* () {
       handles.push(scope)
       yield* abort(scope)
       return 'late' as const
-    }).pipe(orReturn(scope, 'aborted' as const), returnFail))
+    }).pipe(orReturn(scope, 'aborted' as const), returnFail)))
 
     assert.equal(run(program), 'aborted')
     assert.equal(run(program), 'aborted')
@@ -150,7 +149,7 @@ describe('currentScope', () => {
   })
 
   it('does not type callback scopes as handling effects for outer lifetime handles', () => {
-    const OwnerScope = scope('test/CurrentScope/owner')
+    const OwnerScope = scope('test/Scope/owner')
     const program = withScope(_ => forkIn(OwnerScope, ok('child')))
 
     // @ts-expect-error The fresh lexical scope does not own OwnerScope effects.
@@ -159,7 +158,7 @@ describe('currentScope', () => {
   })
 
   it('does not type callback control scopes as handling effects for outer control handles', () => {
-    const OwnerScope = scope<Control>()('test/CurrentScope/control-owner')
+    const OwnerScope = scope<Control>()('test/Scope/control-owner')
     const program = withControlScope(_ => abort(OwnerScope))
 
     // @ts-expect-error The fresh lexical scope does not handle OwnerScope aborts.
@@ -167,163 +166,42 @@ describe('currentScope', () => {
     void runnable
   })
 
-  it('is eliminated by withScope', () => {
-    const TestScope = scope('test/CurrentScope/type')
-    const program = andFinally(ok(undefined)).pipe(withScope(TestScope))
+  it('requires inScope to handle effects targeting the fresh scope', () => {
+    // @ts-expect-error The fresh lexical scope's finalizer is not handled by allocation alone.
+    withScope(scope => andFinallyIn(scope, ok(undefined)))
+  })
+
+  it('keeps explicit scope handles distinct at inner boundaries', () => {
+    const CounterState = key<Stateful<number>>()('test/Scope/nested-counter')
+    const Outer = scope('test/Scope/nested-outer')
+    const Inner = scope('test/Scope/nested-inner')
+
+    const program = inScope(Inner, andFinallyIn(Outer, modifyState(CounterState, count => [count + 1, undefined])))
+
+    // @ts-expect-error The inner boundary does not handle the outer finalizer.
+    const runnable: Fx<never, void> = program
+    void runnable
+
+    type Effects = typeof program extends Fx<infer E, void> ? E : never
+    const finalizerRemains: Extract<Effects, Finally<typeof Outer, ModifyState<typeof CounterState>>> extends never ? false : true = true
+    assert.equal(finalizerRemains, true)
+  })
+
+  it('eliminates effects for the explicit scope boundary', () => {
+    const TestScope = scope('test/Scope/type')
+    const program = andFinallyIn(TestScope, ok(undefined)).pipe(inScope(TestScope))
 
     const _: typeof program extends Fx<Fail<AggregateError>, void> ? true : false = true
 
     assert.equal(run(program.pipe(returnFail)) instanceof Fail, false)
   })
-
-  it('supports lifetime APIs without exposing control protocols', async () => {
-    const events: string[] = []
-
-    const result = await scoped(fx(function* () {
-      yield* andFinally(fx(function* () {
-        events.push('cleanup')
-      }))
-      yield* forkIn(currentScope, fx(function* () {
-        events.push('child')
-      }))
-      events.push('parent')
-      return 'done' as const
-    })).pipe(
-      withUnboundedConcurrency,
-      assertNoFail,
-      runPromise
-    )
-
-    assert.equal(result, 'done')
-    assert.deepEqual(events, ['parent', 'child', 'cleanup'])
-  })
-
-  it('only exposes lifetime authority', () => {
-    fx(function* () {
-      // @ts-expect-error The current scope cannot perform control return.
-      yield* returnFrom(currentScope, 'returned' as const)
-      // @ts-expect-error The current scope cannot abort.
-      yield* abort(currentScope)
-      // @ts-expect-error The current scope does not create a yielding protocol.
-      yield* yieldFrom(currentScope, 'event' as const)
-      // @ts-expect-error The current scope does not create a state protocol.
-      yield* getState(currentScope)
-      // @ts-expect-error The current scope does not create a state protocol.
-      yield* modifyState(currentScope, state => [state, undefined] as const)
-      return 'done' as const
-    })
-  })
-
-  it('is a logical nearest-scope token, not a snapshot', () => {
-    const events: string[] = []
-    const saved = currentScope
-
-    const result = run(scoped(fx(function* () {
-      yield* andFinallyIn(saved, fx(function* () {
-        events.push('outer cleanup')
-      }))
-      yield* scoped(fx(function* () {
-        yield* andFinallyIn(saved, fx(function* () {
-          events.push('inner cleanup')
-        }))
-      }))
-      events.push('body done')
-      return 'done' as const
-    })).pipe(assertNoFail))
-
-    assert.equal(result, 'done')
-    assert.deepEqual(events, ['inner cleanup', 'body done', 'outer cleanup'])
-  })
-
-  it('re-yields current-scope interruption as the handled concrete scope', () => {
-    const TestScope = scope('test/CurrentScope/interrupt')
-    const reason = { type: 'stop' }
-
-    const result = run(fx(function* () {
-      return yield* interruptFrom(currentScope, reason)
-    }).pipe(
-      withScope(TestScope),
-      recoverInterrupt(TestScope, r => ok(r)),
-      assertNoFail
-    ))
-
-    assert.equal(result, reason)
-  })
 })
 
 describe('scoped', () => {
-  it('runs private-scope finalizers after success', () => {
-    const exits: string[] = []
-
-    const result = run(scoped(fx(function* () {
-      yield* andFinally(exit => ok(void exits.push(exit.type)))
-      return 'done' as const
-    })).pipe(assertNoFail))
+  it('runs direct Fx programs in a private lifetime boundary', () => {
+    const result = run(scoped(ok('done' as const)))
 
     assert.equal(result, 'done')
-    assert.deepEqual(exits, ['success'])
-  })
-
-  it('runs private-scope finalizers after failure', () => {
-    const failure = new Error('boom')
-    const exits: string[] = []
-
-    const result = run(scoped(fx(function* () {
-      yield* andFinally(exit => ok(void exits.push(exit.type)))
-      return yield* fail(failure)
-    })).pipe(returnFail))
-
-    assert.equal(result instanceof Fail, true)
-    assert.equal((result as Fail<Error>).arg, failure)
-    assert.deepEqual(exits, ['failure'])
-  })
-
-  it('runs private-scope finalizers before re-yielding interruption', () => {
-    const reason = new Error('stop')
-    const exits: string[] = []
-    const program = scoped(fx(function* () {
-      yield* andFinally(exit => ok(void exits.push(exit.type)))
-      return yield* interruptFrom(currentScope, reason)
-    }))
-
-    const next = program[Symbol.iterator]().next()
-
-    assert.equal(next.done, false)
-    assert.equal(InterruptFrom.is(next.value), true)
-    assert.deepEqual(exits, ['interrupted'])
-  })
-
-  it('owns forkIn child lifetime with the private scope', async () => {
-    const events: string[] = []
-
-    const result = await scoped(fx(function* () {
-      yield* forkIn(currentScope, fx(function* () {
-        events.push('child ran')
-        yield* andFinally(ok(void events.push('child cleanup')))
-        return 'child' as const
-      }))
-      events.push('parent done')
-      return 'parent' as const
-    })).pipe(
-      withUnboundedConcurrency,
-      assertNoFail,
-      runPromise
-    )
-
-    assert.equal(result, 'parent')
-    assert.deepEqual(events, ['parent done', 'child ran', 'child cleanup'])
-  })
-
-  it('handles currentScope for direct Fx programs', () => {
-    const exits: string[] = []
-
-    const result = run(scoped(fx(function* () {
-      yield* andFinally(exit => ok(void exits.push(exit.type)))
-      return 'done' as const
-    })).pipe(assertNoFail))
-
-    assert.equal(result, 'done')
-    assert.deepEqual(exits, ['success'])
   })
 
   it('leaves caller-owned scoped effects visible', () => {
@@ -341,23 +219,23 @@ describe('scoped', () => {
     assert.equal(next.value.scope, Outer)
   })
 
-  it('only provides lifetime authority', () => {
-    scoped(fx(function* () {
-      // @ts-expect-error A lifetime-only current scope cannot perform control return.
-      yield* returnFrom(currentScope, 'returned' as const)
-      // @ts-expect-error The ReturnFrom constructor also requires control scope authority.
-      yield* new ReturnFrom(currentScope, 'constructed' as const)
-      // @ts-expect-error A lifetime-only current scope cannot abort.
-      yield* abort(currentScope)
-      // @ts-expect-error The Abort constructor also requires control scope authority.
-      yield* new Abort(currentScope, undefined)
-      // @ts-expect-error A lifetime-only current scope does not create a yielding protocol.
-      yield* yieldFrom(currentScope, 'event' as const)
-      // @ts-expect-error A lifetime-only current scope does not create a state protocol.
-      yield* getState(currentScope)
-      // @ts-expect-error A lifetime-only current scope does not create a state protocol.
-      yield* modifyState(currentScope, state => [state, undefined] as const)
-      return 'done' as const
-    }))
+  it('does not expose a private handle for scoped operations', async () => {
+    const events: string[] = []
+    const Parent = scope('test/Scoped/parent')
+
+    const result = await scoped(fx(function* () {
+      yield* forkIn(Parent, fx(function* () {
+        events.push('child')
+      }))
+      return 'parent' as const
+    })).pipe(
+      inScope(Parent),
+      withUnboundedConcurrency,
+      assertNoFail,
+      runPromise
+    )
+
+    assert.equal(result, 'parent')
+    assert.deepEqual(events, ['child'])
   })
 })

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -44,6 +44,19 @@ describe('currentScope', () => {
     )
   })
 
+  it('rejects closed lexical handles passed to explicit withScope', () => {
+    let leaked: AnyLifetimeScope | undefined
+
+    withScope(scope => fx(function* () {
+      leaked = scope
+    })).pipe(run)
+
+    assert.throws(
+      () => withScope(leaked!),
+      /used after its scope exited/
+    )
+  })
+
   it('allocates lexical lifetime handles per execution', () => {
     const handles: AnyLifetimeScope[] = []
     const program = withScope({ label: 'repeatable' }, scope => fx(function* () {
@@ -74,6 +87,24 @@ describe('currentScope', () => {
     assert.equal(handles[0]?.label, 'repeatable control')
     assert.equal(handles[1]?.label, 'repeatable control')
     assert.equal(sameScope(handles[0]!, handles[1]!), false)
+  })
+
+  it('does not type callback scopes as handling effects for outer lifetime handles', () => {
+    const OwnerScope = scope('test/CurrentScope/owner')
+    const program = withScope(_ => forkIn(OwnerScope, ok('child')))
+
+    // @ts-expect-error The fresh lexical scope does not own OwnerScope effects.
+    const runnable: Fx<never, unknown> = program
+    void runnable
+  })
+
+  it('does not type callback control scopes as handling effects for outer control handles', () => {
+    const OwnerScope = scope<Control>()('test/CurrentScope/control-owner')
+    const program = withControlScope(_ => abort(OwnerScope))
+
+    // @ts-expect-error The fresh lexical scope does not handle OwnerScope aborts.
+    const runnable: Fx<never, unknown> = program
+    void runnable
   })
 
   it('is eliminated by withScope', () => {

--- a/src/Scoped.test.ts
+++ b/src/Scoped.test.ts
@@ -57,6 +57,19 @@ describe('currentScope', () => {
     )
   })
 
+  it('rejects cached withScope pipeables for closed lexical handles', () => {
+    let cached: ((f: Fx<unknown, unknown>) => Fx<unknown, unknown>) | undefined
+
+    withScope(scope => fx(function* () {
+      cached = withScope(scope)
+    })).pipe(run)
+
+    assert.throws(
+      () => cached!(andFinally(ok(undefined))),
+      /used after its scope exited/
+    )
+  })
+
   it('allocates lexical lifetime handles per execution', () => {
     const handles: AnyLifetimeScope[] = []
     const program = withScope({ label: 'repeatable' }, scope => fx(function* () {

--- a/src/Scoped.ts
+++ b/src/Scoped.ts
@@ -1,20 +1,10 @@
 import { Fx } from './Fx.js'
-import { scope, withScope, type AnyLifetimeScope, type ScopeEffects } from './Scope.js'
-
-declare const ScopedTypeId: unique symbol
-
-type PrivateScope = AnyLifetimeScope & {
-  readonly [ScopedTypeId]: true
-}
+import { inScope } from './Scope.js'
 
 /**
- * Run an Fx in a private named scope.
- *
- * Use `currentScope` inside the Fx to target the private boundary.
+ * Run an Fx in a private scope.
  */
 export const scoped = <const E, const A>(
   f: Fx<E, A>
-): Fx<ScopeEffects<E, PrivateScope>, A> => {
-  const privateScope = scope<PrivateScope>()(Symbol('fx/Scoped/scoped'), { diagnostic: false })
-  return f.pipe(withScope(privateScope)) as Fx<ScopeEffects<E, PrivateScope>, A>
-}
+): Fx<E, A> =>
+  inScope({ diagnostic: false }, f)

--- a/src/Sink.ts
+++ b/src/Sink.ts
@@ -1,5 +1,5 @@
-import { ScopedEffect } from './Effect.js'
-import type { AnyScope } from './Scope.js'
+import { KeyedEffect } from './Effect.js'
+import type { AnyKey } from './Key.js'
 
 declare const ReceivingTypeId: unique symbol
 
@@ -13,16 +13,16 @@ export type SinkInput<Scope> =
   Scope extends Receiving<infer In> ? In : never
 
 export class Sink<
-  const Scope extends AnyScope & Receiving<unknown>
-> extends ScopedEffect('fx/Sink')<Scope, void, SinkInput<Scope>> { }
+  const Key extends AnyKey & Receiving<unknown>
+> extends KeyedEffect('fx/Sink')<Key, void, SinkInput<Key>> { }
 
-export const next = <const Scope extends AnyScope & Receiving<unknown>>(
-  scope: Scope
-): Sink<Scope> =>
-  new Sink(scope, undefined)
+export const next = <const Key extends AnyKey & Receiving<unknown>>(
+  key: Key
+): Sink<Key> =>
+  new Sink(key, undefined)
 
-export type SinkValue<E, Scope extends AnyScope & Receiving<unknown>> =
-  E extends Sink<Scope> ? SinkInput<Scope> : never
+export type SinkValue<E, Key extends AnyKey & Receiving<unknown>> =
+  E extends Sink<Key> ? SinkInput<Key> : never
 
-export type ExcludeSink<E, Scope extends AnyScope & Receiving<unknown>, E2 = never> =
-  E extends Sink<Scope> ? E2 : E
+export type ExcludeSink<E, Key extends AnyKey & Receiving<unknown>, E2 = never> =
+  E extends Sink<Key> ? E2 : E

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -3,11 +3,11 @@ import { describe, it } from 'node:test'
 
 import { fork, forkIn, withUnboundedConcurrency } from './Concurrent.js'
 import { Fail, catchAll, catchIf, fail, returnFail, runCatch } from './Fail.js'
-import { andFinally, andFinallyIn } from './Finalization.js'
+import { andFinallyIn } from './Finalization.js'
 import { finalizing, fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control } from './Scope.js'
+import { scope, inScope, type Control } from './Scope.js'
 import {
   GetState,
   getState,
@@ -136,7 +136,7 @@ describe('State', () => {
       }))
 
       return yield* getState(CounterState)
-    }).pipe(withScope(CleanupScope), withState(CounterState, 1), returnFail, run)
+    }).pipe(inScope(CleanupScope), withState(CounterState, 1), returnFail, run)
 
     assert.equal(program, 2)
     assert.equal(finalizerState, 2)
@@ -148,8 +148,8 @@ describe('State', () => {
       yield* andFinallyIn(CleanupScope, modifyState(CounterState, count => [count + 1, undefined]))
       return 'done'
     })
-    const wrongOrder = program.pipe(withState(CounterState, 1), withScope(CleanupScope))
-    const rightOrder = program.pipe(withScope(CleanupScope), withState(CounterState, 1))
+    const wrongOrder = program.pipe(withState(CounterState, 1), inScope(CleanupScope))
+    const rightOrder = program.pipe(inScope(CleanupScope), withState(CounterState, 1))
 
     type WrongEffects = typeof wrongOrder extends Fx<infer E, 'done'> ? E : never
     type RightEffects = typeof rightOrder extends Fx<infer E, 'done'> ? E : never
@@ -398,7 +398,7 @@ describe('State', () => {
 
         return [recovered, yield* getState(CounterState)] as const
       }).pipe(
-        withScope(ForkScope),
+        inScope(ForkScope),
         withState(CounterState, 0),
         withUnboundedConcurrency
       )
@@ -483,7 +483,7 @@ describe('State', () => {
         }).pipe(
           finalizing(fail(cleanupFailure)),
           transactionalState(CounterState),
-          withScope(ForkScope),
+          inScope(ForkScope),
           returnFail
         )
 
@@ -504,7 +504,7 @@ describe('State', () => {
         }).pipe(
           finalizing(returnFrom(ForkScope, 'cleanup')),
           transactionalState(CounterState),
-          withScope(ForkScope),
+          inScope(ForkScope),
           returnFail
         )
 
@@ -514,12 +514,12 @@ describe('State', () => {
       assert.deepEqual(result, ['cleanup', 1])
     })
 
-    it('does not become the nearest current scope', () => {
+    it('does not install a lifetime boundary', () => {
       const events: string[] = []
 
       const result = fx(function* () {
         yield* fx(function* () {
-          yield* andFinally(fx(function* () {
+          yield* andFinallyIn(ForkScope, fx(function* () {
             events.push('transaction finalizer')
           }))
           yield* modifyState(CounterState, count => [count + 1, undefined])
@@ -528,7 +528,7 @@ describe('State', () => {
         events.push('after transaction')
         return yield* getState(CounterState)
       }).pipe(
-        withScope(ForkScope),
+        inScope(ForkScope),
         withState(CounterState, 0),
         returnFail,
         run

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -5,6 +5,7 @@ import { fork, forkIn, withUnboundedConcurrency } from './Concurrent.js'
 import { Fail, catchAll, catchIf, fail, returnFail, runCatch } from './Fail.js'
 import { andFinally, andFinallyIn } from './Finalization.js'
 import { finalizing, fx, ok, run, runPromise, type Fx } from './Fx.js'
+import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
 import { scope, withScope, type Control } from './Scope.js'
 import {
@@ -20,9 +21,9 @@ import {
 import { wait } from './Task.js'
 
 describe('State', () => {
-  const CounterState = scope<Stateful<number>>()('test/State/Counter')
-  const OtherState = scope<Stateful<string>>()('test/State/Other')
-  const ObjectState = scope<Stateful<{ readonly count: number }>>()('test/State/Object')
+  const CounterState = key<Stateful<number>>()('test/State/Counter')
+  const OtherState = key<Stateful<string>>()('test/State/Other')
+  const ObjectState = key<Stateful<{ readonly count: number }>>()('test/State/Object')
 
   it('gets the initial state', () => {
     const program = getState(CounterState).pipe(withState(CounterState, 1), run)
@@ -70,12 +71,12 @@ describe('State', () => {
 
     assert.equal(next.done, false)
     assert.equal(GetState.is(next.value), true)
-    assert.equal((next.value as GetState<typeof OtherState>).scope, OtherState)
+    assert.equal((next.value as GetState<typeof OtherState>).key, OtherState)
   })
 
   it('handles same-id state scope tokens', () => {
-    const FirstScope = scope<Stateful<number>>()('test/State/SameName')
-    const SecondScope = scope<Stateful<number>>()('test/State/SameName')
+    const FirstScope = key<Stateful<number>>()('test/State/SameName')
+    const SecondScope = key<Stateful<number>>()('test/State/SameName')
     const result = getState(SecondScope).pipe(withState(FirstScope, 1), run)
 
     assert.equal(result, 1)
@@ -126,27 +127,29 @@ describe('State', () => {
   })
 
   it('handles state effects requested during scope cleanup', () => {
+    const CleanupScope = scope('test/State/Cleanup')
     let finalizerState = 0
     const program = fx(function* () {
       yield* modifyState(CounterState, count => [count + 1, undefined])
-      yield* andFinallyIn(CounterState, fx(function* () {
+      yield* andFinallyIn(CleanupScope, fx(function* () {
         finalizerState = yield* modifyState(CounterState, count => [count + 1, count])
       }))
 
       return yield* getState(CounterState)
-    }).pipe(withScope(CounterState), withState(CounterState, 1), returnFail, run)
+    }).pipe(withScope(CleanupScope), withState(CounterState, 1), returnFail, run)
 
     assert.equal(program, 2)
     assert.equal(finalizerState, 2)
   })
 
   it('leaves cleanup state effects typed when withState is inside the scope boundary', () => {
+    const CleanupScope = scope('test/State/Cleanup/type')
     const program = fx(function* () {
-      yield* andFinallyIn(CounterState, modifyState(CounterState, count => [count + 1, undefined]))
+      yield* andFinallyIn(CleanupScope, modifyState(CounterState, count => [count + 1, undefined]))
       return 'done'
     })
-    const wrongOrder = program.pipe(withState(CounterState, 1), withScope(CounterState))
-    const rightOrder = program.pipe(withScope(CounterState), withState(CounterState, 1))
+    const wrongOrder = program.pipe(withState(CounterState, 1), withScope(CleanupScope))
+    const rightOrder = program.pipe(withScope(CleanupScope), withState(CounterState, 1))
 
     type WrongEffects = typeof wrongOrder extends Fx<infer E, 'done'> ? E : never
     type RightEffects = typeof rightOrder extends Fx<infer E, 'done'> ? E : never
@@ -442,8 +445,8 @@ describe('State', () => {
     })
 
     it('handles same-id state scope tokens', () => {
-      const FirstScope = scope<Stateful<number>>()('test/State/Transactional/SameName')
-      const SecondScope = scope<Stateful<number>>()('test/State/Transactional/SameName')
+      const FirstScope = key<Stateful<number>>()('test/State/Transactional/SameName')
+      const SecondScope = key<Stateful<number>>()('test/State/Transactional/SameName')
       const result = fail('body').pipe(
         transactionalState(SecondScope),
         catchAll(() => getState(SecondScope)),
@@ -546,7 +549,7 @@ describe('State', () => {
     })
 
     it('requires a stateful scope', () => {
-      const PlainScope = scope('test/State/Transactional/Plain')
+      const PlainScope = key('test/State/Transactional/Plain')
 
       // @ts-expect-error transactionalState requires a Stateful scope.
       ok('plain').pipe(transactionalState(PlainScope))

--- a/src/State.ts
+++ b/src/State.ts
@@ -1,7 +1,7 @@
-import { ScopedEffect } from './Effect.js'
+import { KeyedEffect } from './Effect.js'
 import { Fx, flatMap, fx, ok } from './Fx.js'
-import { handleScoped, type HandleScoped } from './Handler.js'
-import { AnyScope } from './Scope.js'
+import { handleKeyed, type HandleKeyed } from './Handler.js'
+import { AnyKey } from './Key.js'
 import { effectiveExit, returnExit, resumeExit } from './internal/returnExit.js'
 
 declare const StatefulTypeId: unique symbol
@@ -16,64 +16,64 @@ export type StateOf<Scope> =
 /**
  * Read the current state from the named scope.
  */
-export class GetState<const Scope extends AnyScope & Stateful<unknown>>
-  extends ScopedEffect('fx/State/Get')<Scope, void, StateOf<Scope>> { }
+export class GetState<const Key extends AnyKey & Stateful<unknown>>
+  extends KeyedEffect('fx/State/Get')<Key, void, StateOf<Key>> { }
 
 /**
  * Replace the current state and return a computed result.
  */
-export class ModifyState<const Scope extends AnyScope & Stateful<unknown>, const B = unknown>
-  extends ScopedEffect('fx/State/Modify')<Scope, (state: StateOf<Scope>) => readonly [StateOf<Scope>, B], B> { }
+export class ModifyState<const Key extends AnyKey & Stateful<unknown>, const B = unknown>
+  extends KeyedEffect('fx/State/Modify')<Key, (state: StateOf<Key>) => readonly [StateOf<Key>, B], B> { }
 
-export type StateEffects<Scope extends AnyScope & Stateful<unknown>> =
-  | GetState<Scope>
-  | ModifyState<Scope>
+export type StateEffects<Key extends AnyKey & Stateful<unknown>> =
+  | GetState<Key>
+  | ModifyState<Key>
 
-export type ExcludeState<E, Scope extends AnyScope & Stateful<unknown>> =
-  HandleScoped<HandleScoped<E, GetState<Scope>, Scope>, ModifyState<Scope>, Scope>
+export type ExcludeState<E, Key extends AnyKey & Stateful<unknown>> =
+  HandleKeyed<HandleKeyed<E, GetState<Key>, Key>, ModifyState<Key>, Key>
 
-export const getState = <const Scope extends AnyScope & Stateful<unknown>>(scope: Scope): Fx<GetState<Scope>, StateOf<Scope>> =>
-  new GetState(scope, undefined)
+export const getState = <const Key extends AnyKey & Stateful<unknown>>(key: Key): Fx<GetState<Key>, StateOf<Key>> =>
+  new GetState(key, undefined)
 
-export const modifyState = <const Scope extends AnyScope & Stateful<unknown>, const B>(
-  scope: Scope,
-  f: (state: StateOf<Scope>) => readonly [StateOf<Scope>, B]
-): Fx<ModifyState<Scope, B>, B> =>
-  new ModifyState(scope, f)
+export const modifyState = <const Key extends AnyKey & Stateful<unknown>, const B>(
+  key: Key,
+  f: (state: StateOf<Key>) => readonly [StateOf<Key>, B]
+): Fx<ModifyState<Key, B>, B> =>
+  new ModifyState(key, f)
 
 /**
  * Handle state operations for the named scope with state local to one execution.
  */
-export const withState = <const Scope extends AnyScope & Stateful<unknown>>(
-  scope: Scope,
-  initial: StateOf<Scope>
+export const withState = <const Key extends AnyKey & Stateful<unknown>>(
+  key: Key,
+  initial: StateOf<Key>
 ) => <const E, const A>(
   f: Fx<E, A>
-): Fx<ExcludeState<E, Scope>, A> =>
+): Fx<ExcludeState<E, Key>, A> =>
     fx(function* () {
       let state = initial
 
       return yield* f.pipe(
-        handleScoped(GetState<Scope>, scope, () => ok(state)),
-        handleScoped(ModifyState<Scope>, scope, effect => {
+        handleKeyed(GetState<Key>, key, () => ok(state)),
+        handleKeyed(ModifyState<Key>, key, effect => {
           const [next, result] = effect.arg(state)
           state = next
           return ok(result)
         })
       )
-    }) as Fx<ExcludeState<E, Scope>, A>
+    }) as Fx<ExcludeState<E, Key>, A>
 
 /**
  * Handle state operations for the named scope, obtaining the initial state by
  * running an Fx once per execution.
  */
-export const withStateInit = <const Scope extends AnyScope & Stateful<unknown>, const IE>(
-  scope: Scope,
-  initially: Fx<IE, StateOf<Scope>>
+export const withStateInit = <const Key extends AnyKey & Stateful<unknown>, const IE>(
+  key: Key,
+  initially: Fx<IE, StateOf<Key>>
 ) => <const E, const A>(
   f: Fx<E, A>
 ) =>
-    initially.pipe(flatMap(s => f.pipe(withState(scope, s))))
+    initially.pipe(flatMap(s => f.pipe(withState(key, s))))
 
 /**
  * Run matching state operations transactionally for the named scope.
@@ -83,19 +83,19 @@ export const withStateInit = <const Scope extends AnyScope & Stateful<unknown>, 
  * it back to the durable state only if the region succeeds or returns from a
  * control scope.
  */
-export const transactionalState = <const Scope extends AnyScope & Stateful<unknown>>(
-  scope: Scope
+export const transactionalState = <const Key extends AnyKey & Stateful<unknown>>(
+  key: Key
 ) => <const E, const A>(
   body: Fx<E, A>
-): Fx<ExcludeState<E, Scope> | StateEffects<Scope>, A> =>
+): Fx<ExcludeState<E, Key> | StateEffects<Key>, A> =>
     fx(function* () {
-      let state = yield* getState(scope)
+      let state = yield* getState(key)
       let dirty = false
 
       const exit = yield* body.pipe(
         returnExit,
-        handleScoped(GetState<Scope>, scope, () => ok(state)),
-        handleScoped(ModifyState<Scope, unknown>, scope, effect => {
+        handleKeyed(GetState<Key>, key, () => ok(state)),
+        handleKeyed(ModifyState<Key, unknown>, key, effect => {
           const [next, result] = effect.arg(state)
           state = next
           dirty = true
@@ -105,8 +105,8 @@ export const transactionalState = <const Scope extends AnyScope & Stateful<unkno
 
       const effective = effectiveExit(exit)
       if (dirty && (effective.type === 'success' || effective.type === 'returnFrom')) {
-        yield* modifyState(scope, () => [state, undefined])
+        yield* modifyState(key, () => [state, undefined])
       }
 
       return yield* resumeExit(exit)
-    }) as Fx<ExcludeState<E, Scope> | StateEffects<Scope>, A>
+    }) as Fx<ExcludeState<E, Key> | StateEffects<Key>, A>

--- a/src/Timeout.test.ts
+++ b/src/Timeout.test.ts
@@ -7,7 +7,7 @@ import { andFinallyIn } from './Finalization.js'
 import type { Fx } from './Fx.js'
 import { control } from './Handler.js'
 import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
-import { scope, withScope, type AnyScope, type Exit } from './Scope.js'
+import { scope, inScope, type AnyScope, type Exit } from './Scope.js'
 import { TimeoutInterrupt, timeout, timeoutIn } from './Timeout.js'
 import { sleep, withClock } from './Time.js'
 import { getTrace } from './Trace.js'
@@ -28,7 +28,7 @@ describe('Timeout', () => {
         ms: 100,
         reason: () => void (reasons += 1)
       }),
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
       withUnboundedConcurrency,
       returnFail,
@@ -115,7 +115,7 @@ describe('Timeout', () => {
       completed = true
     }).pipe(
       timeout({ ms: 50, reason: () => reason }),
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withUnboundedConcurrency,
       returnFail,
@@ -142,7 +142,7 @@ describe('Timeout', () => {
       yield* sleep(100)
     }).pipe(
       timeout({ ms: 50 }),
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withUnboundedConcurrency,
       returnFail,
@@ -191,7 +191,7 @@ describe('Timeout', () => {
       return 'unreachable'
     }).pipe(
       timeout({ ms: 100 }),
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
       withUnboundedConcurrency,
       returnFail,
@@ -220,7 +220,7 @@ describe('Timeout', () => {
       yield* sleep(100)
     }).pipe(
       timeout({ ms: 50 }),
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
       withUnboundedConcurrency,
       returnFail,
@@ -282,7 +282,7 @@ describe('Timeout', () => {
         completed = true
       }))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withUnboundedConcurrency,
       returnFail,
@@ -308,7 +308,7 @@ describe('Timeout', () => {
       yield* sleep(60_000)
       completed = true
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withUnboundedConcurrency,
       returnFail,
@@ -335,7 +335,7 @@ describe('Timeout', () => {
       }))
       yield* timeoutIn(TestScope, { ms: 10, reason: () => reason })
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withBoundedConcurrency(1),
       returnFail,
@@ -362,7 +362,7 @@ describe('Timeout', () => {
       }))
       yield* timeoutIn(TestScope, { ms: 10, reason: () => reason })
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withCoopConcurrency({ concurrency: 1 }),
       returnFail,
@@ -388,7 +388,7 @@ describe('Timeout', () => {
       })
       return 'ok'
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, () => ok('interrupted')),
       withUnboundedConcurrency,
       returnFail,
@@ -427,7 +427,7 @@ describe('Timeout', () => {
       yield* sleep(0)
       yield* interruptFrom(TestScope, reason)
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withBoundedConcurrency(1),
       returnFail,
@@ -452,7 +452,7 @@ describe('Timeout', () => {
       yield* timeoutIn(TestScope, { ms: 50, label: 'request deadline' })
       yield* forkIn(TestScope, sleep(100))
     }).pipe(
-      withScope(TestScope),
+      inScope(TestScope),
       control(InterruptFrom, (_, interrupt) => ok(interrupt.arg)),
       withUnboundedConcurrency,
       returnFail,

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -6,7 +6,7 @@ import { Finally, andFinallyIn } from './Finalization.js'
 import { Fx, flatMap, fx, map, ok } from './Fx.js'
 import type { HandlerCapture } from './HandlerCapture.js'
 import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
-import { assertScopeOpen, scopeLabel, withScope, type AnyLifetimeScope, type Exit } from './Scope.js'
+import { assertScopeOpen, inScope, scopeLabel, withScope, type AnyLifetimeScope, type Exit } from './Scope.js'
 import { wait } from './Task.js'
 import { Sleep, sleep } from './Time.js'
 import type { TraceOrigin } from './Trace.js'
@@ -33,13 +33,13 @@ export function timeout<const Options extends AnyTimeoutOptions>(
   const trace = captureTrace(origin, undefined, { kind: 'timeout' })
 
   return <const E, const A>(f: Fx<E, A>): Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<AnyLifetimeScope, TimeoutReasonOf<Options>>, A> =>
-    (withScope(scopeOptions, timeoutScope => fx(function* () {
+    (withScope(scopeOptions, timeoutScope => inScope(timeoutScope, fx(function* () {
       const task = yield* forkIn(timeoutScope, attempt(f), { origin, trace })
 
       yield* timeoutInWithTrace(timeoutScope, options, { origin, trace })
 
       return yield* wait(task)
-    })) as Fx<E | Fork | Sleep | Async | Fail<unknown>, AttemptResult<ErrorsOf<E>, A>>).pipe(
+    })) as Fx<unknown, unknown>) as Fx<E | Fork | Sleep | Async | Fail<unknown>, AttemptResult<ErrorsOf<E>, A>>).pipe(
       flatMap(unwrapAttempt)
     ) as Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<AnyLifetimeScope, TimeoutReasonOf<Options>>, A>
 }

--- a/src/Timeout.ts
+++ b/src/Timeout.ts
@@ -6,7 +6,7 @@ import { Finally, andFinallyIn } from './Finalization.js'
 import { Fx, flatMap, fx, map, ok } from './Fx.js'
 import type { HandlerCapture } from './HandlerCapture.js'
 import { InterruptFrom, interruptFrom } from './InterruptFrom.js'
-import { scope, scopeLabel, withScope, type AnyLifetimeScope, type Exit } from './Scope.js'
+import { assertScopeOpen, scopeLabel, withScope, type AnyLifetimeScope, type Exit } from './Scope.js'
 import { wait } from './Task.js'
 import { Sleep, sleep } from './Time.js'
 import type { TraceOrigin } from './Trace.js'
@@ -25,22 +25,21 @@ export function timeout<const Options extends AnyTimeoutOptions>(
   options: Options
 ): <const E, const A>(f: Fx<E, A>) => Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<AnyLifetimeScope, TimeoutReasonOf<Options>>, A> {
   const { ms, label } = options
-  const timeoutScope = scope(Symbol('fx/Timeout'), {
+  const scopeOptions = {
     label: label ?? 'timeout',
     diagnostic: false
-  })
-  const origin = at(`Timeout interrupted ${scopeLabel(timeoutScope)} after ${ms}ms`, timeout)
+  }
+  const origin = at(`Timeout interrupted ${scopeOptions.label} after ${ms}ms`, timeout)
   const trace = captureTrace(origin, undefined, { kind: 'timeout' })
 
   return <const E, const A>(f: Fx<E, A>): Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<AnyLifetimeScope, TimeoutReasonOf<Options>>, A> =>
-    fx(function* () {
+    (withScope(scopeOptions, timeoutScope => fx(function* () {
       const task = yield* forkIn(timeoutScope, attempt(f), { origin, trace })
 
       yield* timeoutInWithTrace(timeoutScope, options, { origin, trace })
 
       return yield* wait(task)
-    }).pipe(
-      withScope(timeoutScope),
+    })) as Fx<E | Fork | Sleep | Async | Fail<unknown>, AttemptResult<ErrorsOf<E>, A>>).pipe(
       flatMap(unwrapAttempt)
     ) as Fx<E | Fork | Sleep | Async | Fail<unknown> | InterruptFrom<AnyLifetimeScope, TimeoutReasonOf<Options>>, A>
 }
@@ -59,6 +58,7 @@ export function timeoutIn<const Scope extends AnyLifetimeScope, const Options ex
   scope: Scope,
   options: Options
 ): Fx<Sleep | InterruptFrom<Scope, TimeoutReasonOf<Options>> | Fork | Finally<Scope, Async> | ScopedFork<Scope> | HandlerCapture<'fx/Concurrent/ForkIn'>, void> {
+  assertScopeOpen(scope)
   const origin = at(`Timeout interrupted ${options.label ?? scopeLabel(scope)} after ${options.ms}ms`, timeoutIn)
   const trace = captureTrace(origin, undefined, { kind: 'timeout' })
 

--- a/src/Trace.test.ts
+++ b/src/Trace.test.ts
@@ -9,7 +9,7 @@ import { fx, runPromise } from './Fx.js'
 import { control } from './Handler.js'
 import { InterruptFrom } from './InterruptFrom.js'
 import { defaultRetry, retry } from './Retry.js'
-import { scope, scopeId, withScope } from './Scope.js'
+import { scope, scopeId, inScope } from './Scope.js'
 import { ScopeTypeId } from './internal/scopeIdentity.js'
 import { wait } from './Task.js'
 import { sleep, withClock } from './Time.js'
@@ -147,8 +147,8 @@ describe('Trace', () => {
     const f = fx(function* () {
       yield* fail(new Error('scoped failure'))
     }).pipe(
-      withScope(DbTransaction),
-      withScope(HttpRequest)
+      inScope(DbTransaction),
+      inScope(HttpRequest)
     )
 
     await assert.rejects(
@@ -184,7 +184,7 @@ describe('Trace', () => {
     const RequestScope = scope('test/Trace/request', { label: 'request' })
     const f = fx(function* () {
       yield* fail(new Error('labeled scope'))
-    }).pipe(withScope(RequestScope))
+    }).pipe(inScope(RequestScope))
 
     await assert.rejects(
       runPromise(f as never),
@@ -209,8 +209,8 @@ describe('Trace', () => {
     const f = fx(function* () {
       yield* fail(new Error('same diagnostic text'))
     }).pipe(
-      withScope(InnerRequest),
-      withScope(OuterRequest)
+      inScope(InnerRequest),
+      inScope(OuterRequest)
     )
 
     await assert.rejects(
@@ -239,8 +239,8 @@ describe('Trace', () => {
     const f = fx(function* () {
       yield* fail(new Error('scoped formatting'))
     }).pipe(
-      withScope(DbTransaction),
-      withScope(HttpRequest)
+      inScope(DbTransaction),
+      inScope(HttpRequest)
     )
 
     await assert.rejects(
@@ -255,7 +255,7 @@ describe('Trace', () => {
 
   it('compacts deep active scope stacks', async () => {
     const scoped = ['a', 'b', 'c', 'd', 'e'].map(name => scope(name)).reduceRight(
-      (f, name) => f.pipe(withScope(name)),
+      (f, name) => f.pipe(inScope(name)),
       fx(function* () {
         yield* fail(new Error('deep scopes'))
       })
@@ -472,7 +472,7 @@ describe('Trace', () => {
         yield* fail(new Error('fork scoped'))
       }))
       yield* wait(task)
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
 
     await assert.rejects(
       runPromise(f.pipe(withUnboundedConcurrency) as never),
@@ -490,10 +490,10 @@ describe('Trace', () => {
     const HttpRequest = scope('http/request')
     const allProgram = fx(function* () {
       yield* all([fx(function* () { yield* fail(new Error('all scoped')) })])
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
     const raceProgram = fx(function* () {
       yield* race([fx(function* () { yield* fail(new Error('race scoped')) })])
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
 
     await assert.rejects(
       runPromise(allProgram.pipe(withUnboundedConcurrency) as never),
@@ -521,13 +521,13 @@ describe('Trace', () => {
     const HttpRequest = scope('http/request')
     const allProgram = fx(function* () {
       yield* all([fx(function* () { yield* fail(new Error('hidden all scope')) })])
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
     const raceProgram = fx(function* () {
       yield* race([fx(function* () { yield* fail(new Error('hidden race scope')) })])
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
     const firstSuccessProgram = fx(function* () {
       yield* firstSuccess([fx(function* () { yield* fail(new Error('hidden firstSuccess scope')) })])
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
 
     await assert.rejects(
       runPromise(allProgram.pipe(withUnboundedConcurrency) as never),
@@ -575,7 +575,7 @@ describe('Trace', () => {
     })
 
     const timeoutPromise = runPromise(timeoutProgram.pipe(
-      withScope(HttpRequest),
+      inScope(HttpRequest),
       control(InterruptFrom, (_, interrupt) => fx(function* () {
         return interrupt.arg
       })),
@@ -596,7 +596,7 @@ describe('Trace', () => {
     const HttpRequest = scope('http/request')
     const f = fx(function* () {
       yield* tryPromise(() => Promise.reject(new Error('async scoped')))
-    }).pipe(withScope(HttpRequest))
+    }).pipe(inScope(HttpRequest))
 
     await assert.rejects(
       runPromise(f as never),
@@ -614,7 +614,7 @@ describe('Trace', () => {
     const DbTransaction = scope('db/transaction')
     const f = fx(function* () {
       yield* andFinallyIn(DbTransaction, fail(new Error('cleanup scoped')))
-    }).pipe(withScope(DbTransaction))
+    }).pipe(inScope(DbTransaction))
 
     await assert.rejects(
       runPromise(f as never),
@@ -705,7 +705,7 @@ describe('Trace', () => {
     })
 
     const timeoutPromise = runPromise(timeoutProgram.pipe(
-      withScope(TimeoutScope),
+      inScope(TimeoutScope),
       control(InterruptFrom, (_, interrupt) => fx(function* () {
         return interrupt.arg
       })),
@@ -767,7 +767,7 @@ describe('Trace', () => {
     })
 
     const labeledPromise = runPromise(labeledProgram.pipe(
-      withScope(LabeledDeadline),
+      inScope(LabeledDeadline),
       control(InterruptFrom, (_, interrupt) => fx(function* () {
         return interrupt.arg
       })),
@@ -789,7 +789,7 @@ describe('Trace', () => {
     })
 
     const fallbackPromise = runPromise(fallbackProgram.pipe(
-      withScope(FallbackDeadline),
+      inScope(FallbackDeadline),
       control(InterruptFrom, (_, interrupt) => fx(function* () {
         return interrupt.arg
       })),

--- a/src/YieldFrom.test.ts
+++ b/src/YieldFrom.test.ts
@@ -7,7 +7,7 @@ import { fx, ok, run, runPromise, type Fx } from './Fx.js'
 import { handle, handleKeyed } from './Handler.js'
 import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
-import { scope, withScope, type Control } from './Scope.js'
+import { scope, inScope, type Control } from './Scope.js'
 import { next as nextSink, Sink } from './Sink.js'
 import type { Receiving } from './Sink.js'
 import {
@@ -159,7 +159,7 @@ describe('YieldFrom', () => {
       return 'late'
     }).pipe(
       handleKeyed(YieldFrom<typeof ItemScope>, ItemScope, () => returnFrom(ReturnScope, 'early')),
-      withScope(ReturnScope),
+      inScope(ReturnScope),
       run
     )
 
@@ -174,7 +174,7 @@ describe('YieldFrom', () => {
       return 'late'
     }).pipe(
       handleKeyed(YieldFrom<typeof ItemScope>, ItemScope, () => abort(AbortScope)),
-      withScope(AbortScope),
+      inScope(AbortScope),
       orReturn(AbortScope, 'aborted'),
       run
     )

--- a/src/YieldFrom.test.ts
+++ b/src/YieldFrom.test.ts
@@ -4,7 +4,8 @@ import { abort, orReturn } from './Abort.js'
 import { withUnboundedConcurrency } from './Concurrent.js'
 import { Effect } from './Effect.js'
 import { fx, ok, run, runPromise, type Fx } from './Fx.js'
-import { handle, handleScoped } from './Handler.js'
+import { handle, handleKeyed } from './Handler.js'
+import { key } from './Key.js'
 import { returnFrom } from './ReturnFrom.js'
 import { scope, withScope, type Control } from './Scope.js'
 import { next as nextSink, Sink } from './Sink.js'
@@ -27,13 +28,13 @@ import { dispose } from './internal/disposable.js'
 import type { Yielding } from './YieldFrom.js'
 
 describe('YieldFrom', () => {
-  const NumberScope = scope<Yielding<number>>()('test/YieldFrom/numbers')
-  const NumberSinkScope = scope<Receiving<number>>()('test/YieldFrom/number-sink')
-  const ItemScope = scope<Yielding<'item'>>()('test/YieldFrom/item')
-  const DecisionScope = scope<Yielding<string, boolean>>()('test/YieldFrom/decision')
+  const NumberScope = key<Yielding<number>>()('test/YieldFrom/numbers')
+  const NumberSinkScope = key<Receiving<number>>()('test/YieldFrom/number-sink')
+  const ItemScope = key<Yielding<'item'>>()('test/YieldFrom/item')
+  const DecisionScope = key<Yielding<string, boolean>>()('test/YieldFrom/decision')
 
   it('allows sink scopes independent of YieldFrom protocols', () => {
-    const SinkOnlyScope = scope<Receiving<number>>()('test/YieldFrom/sink-only')
+    const SinkOnlyScope = key<Receiving<number>>()('test/YieldFrom/sink-only')
     const f = fx(function* () {
       const value = yield* nextSink(SinkOnlyScope)
       return value + 1
@@ -43,7 +44,7 @@ describe('YieldFrom', () => {
     const next = f[Symbol.iterator]().next()
 
     assert.equal(Sink.is(next.value), true)
-    assert.equal((next.value as Sink<typeof SinkOnlyScope>).scope, SinkOnlyScope)
+    assert.equal((next.value as Sink<typeof SinkOnlyScope>).key, SinkOnlyScope)
     void _
   })
 
@@ -61,8 +62,8 @@ describe('YieldFrom', () => {
   })
 
   it('collects yields from a same-id scope token', () => {
-    const FirstScope = scope<Yielding<'item'>>()('test/YieldFrom/same-id')
-    const SecondScope = scope<Yielding<'item'>>()('test/YieldFrom/same-id')
+    const FirstScope = key<Yielding<'item'>>()('test/YieldFrom/same-id')
+    const SecondScope = key<Yielding<'item'>>()('test/YieldFrom/same-id')
     const result = fx(function* () {
       yield* yieldFrom(SecondScope, 'item')
       return 'done'
@@ -84,24 +85,24 @@ describe('YieldFrom', () => {
   })
 
   it('propagates yields from a different scope', () => {
-    const OtherScope = scope<Yielding<'other'>>()('test/YieldFrom/other')
+    const OtherScope = key<Yielding<'other'>>()('test/YieldFrom/other')
 
     const f = fx(function* () {
       yield* yieldFrom(OtherScope, 'other')
       return 'done'
-    }).pipe(handleScoped(YieldFrom<typeof NumberScope>, NumberScope, () => ok(undefined)))
+    }).pipe(handleKeyed(YieldFrom<typeof NumberScope>, NumberScope, () => ok(undefined)))
 
     const _: typeof f extends Fx<YieldFrom<typeof OtherScope>, string> ? true : false = true
     const next = f[Symbol.iterator]().next()
 
     assert.equal(YieldFrom.is(next.value), true)
     const effect = next.value as YieldFrom<typeof OtherScope>
-    assert.equal(effect.scope, OtherScope)
+    assert.equal(effect.key, OtherScope)
     assert.equal(effect.arg, 'other')
   })
 
   it('handles nested named yield scopes independently', () => {
-    const InnerScope = scope<Yielding<'inner'>>()('test/YieldFrom/inner')
+    const InnerScope = key<Yielding<'inner'>>()('test/YieldFrom/inner')
     const outer = [] as number[]
     const inner = [] as string[]
 
@@ -110,8 +111,8 @@ describe('YieldFrom', () => {
       yield* yieldFrom(InnerScope, 'inner')
       return 'done'
     }).pipe(
-      handleScoped(YieldFrom<typeof InnerScope>, InnerScope, effect => ok(void inner.push(effect.arg))),
-      handleScoped(YieldFrom<typeof NumberScope>, NumberScope, effect => ok(void outer.push(effect.arg))),
+      handleKeyed(YieldFrom<typeof InnerScope>, InnerScope, effect => ok(void inner.push(effect.arg))),
+      handleKeyed(YieldFrom<typeof NumberScope>, NumberScope, effect => ok(void outer.push(effect.arg))),
       run
     )
 
@@ -124,7 +125,7 @@ describe('YieldFrom', () => {
     const f = fx(function* () {
       yield* yieldFrom(ItemScope, 'item')
       return true
-    }).pipe(handleScoped(YieldFrom<typeof ItemScope>, ItemScope, () => ok(undefined)))
+    }).pipe(handleKeyed(YieldFrom<typeof ItemScope>, ItemScope, () => ok(undefined)))
 
     const _: typeof f extends Fx<never, boolean> ? true : false = true
 
@@ -136,7 +137,7 @@ describe('YieldFrom', () => {
       const accepted = yield* yieldFrom(DecisionScope, 'item')
       const _: boolean = accepted
       return accepted ? 'accepted' : 'rejected'
-    }).pipe(handleScoped(YieldFrom<typeof DecisionScope>, DecisionScope, effect => ok(effect.arg === 'item')))
+    }).pipe(handleKeyed(YieldFrom<typeof DecisionScope>, DecisionScope, effect => ok(effect.arg === 'item')))
 
     const _: typeof f extends Fx<never, 'accepted' | 'rejected'> ? true : false = true
 
@@ -157,7 +158,7 @@ describe('YieldFrom', () => {
       yield* yieldFrom(ItemScope, 'item')
       return 'late'
     }).pipe(
-      handleScoped(YieldFrom<typeof ItemScope>, ItemScope, () => returnFrom(ReturnScope, 'early')),
+      handleKeyed(YieldFrom<typeof ItemScope>, ItemScope, () => returnFrom(ReturnScope, 'early')),
       withScope(ReturnScope),
       run
     )
@@ -172,7 +173,7 @@ describe('YieldFrom', () => {
       yield* yieldFrom(ItemScope, 'item')
       return 'late'
     }).pipe(
-      handleScoped(YieldFrom<typeof ItemScope>, ItemScope, () => abort(AbortScope)),
+      handleKeyed(YieldFrom<typeof ItemScope>, ItemScope, () => abort(AbortScope)),
       withScope(AbortScope),
       orReturn(AbortScope, 'aborted'),
       run
@@ -347,8 +348,8 @@ describe('YieldFrom', () => {
     })
 
     it('leaves unrelated YieldFrom and Sink scopes visible', () => {
-      const OtherScope = scope<Yielding<'other'>>()('test/YieldFrom/other-to')
-      const OtherSinkScope = scope<Receiving<'other'>>()('test/YieldFrom/other-sink-to')
+      const OtherScope = key<Yielding<'other'>>()('test/YieldFrom/other-to')
+      const OtherSinkScope = key<Receiving<'other'>>()('test/YieldFrom/other-sink-to')
       const source = fx(function* () {
         yield* yieldFrom(OtherScope, 'other')
         return 'source'
@@ -449,7 +450,7 @@ describe('YieldFrom', () => {
     })
 
     it('rejects bidirectional YieldFrom scopes', () => {
-      const DecisionSinkScope = scope<Receiving<string>>()('test/YieldFrom/decision-sink')
+      const DecisionSinkScope = key<Receiving<string>>()('test/YieldFrom/decision-sink')
       const source = fx(function* () {
         yield* yieldFrom(DecisionScope, 'item')
       })
@@ -464,7 +465,7 @@ describe('YieldFrom', () => {
     })
 
     it('rejects sinks that cannot receive the yielded values', () => {
-      const StringSinkScope = scope<Receiving<string>>()('test/YieldFrom/string-sink')
+      const StringSinkScope = key<Receiving<string>>()('test/YieldFrom/string-sink')
       const source = fx(function* () {
         yield* yieldFrom(NumberScope, 1)
       })

--- a/src/YieldFrom.ts
+++ b/src/YieldFrom.ts
@@ -1,14 +1,15 @@
 import { Async, assertPromise } from './Async.js'
-import { ScopedEffect } from './Effect.js'
+import { KeyedEffect } from './Effect.js'
 import { Fail } from './Fail.js'
 import { Fx, assertSync, bracket, fx, map, ok } from './Fx.js'
-import { handleScoped } from './Handler.js'
+import { handleKeyed } from './Handler.js'
+import type { AnyKey } from './Key.js'
 import { Sink, ExcludeSink, type Receiving, type SinkInput } from './Sink.js'
-import { scopeLabel, type AnyScope } from './Scope.js'
+import { keyLabel } from './Key.js'
 import type { Interrupt } from './Interrupt.js'
 import * as Queue from './internal/Queue.js'
 import { dispose } from './internal/disposable.js'
-import { sameScope } from './internal/scopeIdentity.js'
+import { sameKey } from './internal/keyIdentity.js'
 import { drainIteratorReturn } from './internal/iteratorClose.js'
 import { IfAny } from './internal/type.js'
 
@@ -31,23 +32,23 @@ export type YieldInput<Scope> =
  * Yield a value to the named scope.
  */
 export class YieldFrom<
-  const Scope extends AnyScope & Yielding<unknown, unknown>
-> extends ScopedEffect('fx/YieldFrom')<Scope, YieldOutput<Scope>, YieldInput<Scope>> { }
+  const Key extends AnyKey & Yielding<unknown, unknown>
+> extends KeyedEffect('fx/YieldFrom')<Key, YieldOutput<Key>, YieldInput<Key>> { }
 
 /**
  * Yield a value to the named scope.
  */
-export const yieldFrom = <const Scope extends AnyScope & Yielding<unknown, unknown>>(
-  scope: Scope,
-  value: YieldOutput<Scope>
-): YieldFrom<Scope> =>
-  new YieldFrom(scope, value)
+export const yieldFrom = <const Key extends AnyKey & Yielding<unknown, unknown>>(
+  key: Key,
+  value: YieldOutput<Key>
+): YieldFrom<Key> =>
+  new YieldFrom(key, value)
 
-export type YieldValue<E, Scope extends AnyScope & Yielding<unknown, unknown>> =
-  E extends YieldFrom<Scope> ? YieldOutput<Scope> : never
+export type YieldValue<E, Key extends AnyKey & Yielding<unknown, unknown>> =
+  E extends YieldFrom<Key> ? YieldOutput<Key> : never
 
-export type ExcludeYieldFrom<E, Scope extends AnyScope & Yielding<unknown, unknown>, E2 = never> =
-  E extends YieldFrom<Scope> ? E2 : E
+export type ExcludeYieldFrom<E, Key extends AnyKey & Yielding<unknown, unknown>, E2 = never> =
+  E extends YieldFrom<Key> ? E2 : E
 
 export interface IterableWithReturn<Y, R> {
   [Symbol.iterator](): Iterator<Y, R>
@@ -64,102 +65,102 @@ export type PipeResult<Source, Sink> =
 /**
  * Collect all one-way yields from the named scope.
  */
-export const collectFrom = <const Scope extends AnyScope & Yielding<unknown, void>>(scope: Scope) =>
+export const collectFrom = <const Key extends AnyKey & Yielding<unknown, void>>(key: Key) =>
   <const E, const A>(
     f: Fx<E, A>
-  ): Fx<ExcludeYieldFrom<E, Scope>, readonly [A, readonly YieldValue<E, Scope>[]]> => {
-    const values = [] as YieldValue<E, Scope>[]
+  ): Fx<ExcludeYieldFrom<E, Key>, readonly [A, readonly YieldValue<E, Key>[]]> => {
+    const values = [] as YieldValue<E, Key>[]
 
     return f.pipe(
-      handleScoped(YieldFrom<Scope>, scope, effect =>
-        ok(void values.push(effect.arg as YieldValue<E, Scope>) as YieldInput<Scope>)),
+      handleKeyed(YieldFrom<Key>, key, effect =>
+        ok(void values.push(effect.arg as YieldValue<E, Key>) as YieldInput<Key>)),
       map(result => [result, values] as const)
-    ) as Fx<ExcludeYieldFrom<E, Scope>, readonly [A, readonly YieldValue<E, Scope>[]]>
+    ) as Fx<ExcludeYieldFrom<E, Key>, readonly [A, readonly YieldValue<E, Key>[]]>
   }
 
 /**
  * Apply an effectful function to each yield from the named scope.
  */
-export const forEachFrom = <const Scope extends AnyScope & Yielding<unknown, void>, E, R, E2>(
-  scope: Scope,
+export const forEachFrom = <const Key extends AnyKey & Yielding<unknown, void>, E, R, E2>(
+  key: Key,
   f: Fx<E, R>,
-  each: (a: YieldValue<E, Scope>) => Fx<E2, void>
-): Fx<ExcludeYieldFrom<E, Scope, E2>, R> =>
-  f.pipe(handleScoped(YieldFrom<Scope>, scope, effect =>
-    each(effect.arg as YieldValue<E, Scope>) as Fx<E2, YieldInput<Scope>>
-  )) as Fx<ExcludeYieldFrom<E, Scope, E2>, R>
+  each: (a: YieldValue<E, Key>) => Fx<E2, void>
+): Fx<ExcludeYieldFrom<E, Key, E2>, R> =>
+  f.pipe(handleKeyed(YieldFrom<Key>, key, effect =>
+    each(effect.arg as YieldValue<E, Key>) as Fx<E2, YieldInput<Key>>
+  )) as Fx<ExcludeYieldFrom<E, Key, E2>, R>
 
 /**
  * Create a scoped yield source from a {@link Queue.Dequeue}.
  */
-export const fromDequeue = <const Scope extends AnyScope & Yielding<unknown, void>>(
-  scope: Scope,
-  queue: Queue.Dequeue<YieldOutput<Scope>>
-): Fx<Async | YieldFrom<Scope>, void> => fx(function* () {
+export const fromDequeue = <const Key extends AnyKey & Yielding<unknown, void>>(
+  key: Key,
+  queue: Queue.Dequeue<YieldOutput<Key>>
+): Fx<Async | YieldFrom<Key>, void> => fx(function* () {
   const take = Queue.dequeue(queue)
 
   while (!queue.disposed) {
     const next = yield* take
-    if (next.tag === 'fx/Queue/Dequeued') yield* yieldFrom(scope, next.value)
+    if (next.tag === 'fx/Queue/Dequeued') yield* yieldFrom(key, next.value)
   }
 })
 
 /**
  * Create a scoped yield source from values enqueued by f.
  */
-export const withEnqueue = <const Scope extends AnyScope & Yielding<unknown, void>>(
-  scope: Scope,
-  f: (o: Queue.Enqueue<YieldOutput<Scope>>) => Disposable,
-  queue: Queue.Queue<YieldOutput<Scope>> = new Queue.UnboundedQueue()
+export const withEnqueue = <const Key extends AnyKey & Yielding<unknown, void>>(
+  key: Key,
+  f: (o: Queue.Enqueue<YieldOutput<Key>>) => Disposable,
+  queue: Queue.Queue<YieldOutput<Key>> = new Queue.UnboundedQueue()
 ) => bracket(
   assertSync(() => f(queue)),
   disposable => ok(dispose(disposable)),
-  _ => fromDequeue(scope, queue)
+  _ => fromDequeue(key, queue)
 )
 
 /**
  * Create a scoped yield source from an Iterable.
  */
-export const fromIterable = <const Scope extends AnyScope & Yielding<unknown, void>, R>(
-  scope: Scope,
-  i: IterableWithReturn<YieldOutput<Scope>, R>
-): Fx<YieldFrom<Scope> | Interrupt, IfAny<R, void>> => bracket(
+export const fromIterable = <const Key extends AnyKey & Yielding<unknown, void>, R>(
+  key: Key,
+  i: IterableWithReturn<YieldOutput<Key>, R>
+): Fx<YieldFrom<Key> | Interrupt, IfAny<R, void>> => bracket(
   assertSync(() => i[Symbol.iterator]()),
   iterator => ok(void iterator.return?.()),
   iterator => fx(function* () {
     let result = iterator.next()
     while (!result.done) {
-      yield* yieldFrom(scope, result.value)
+      yield* yieldFrom(key, result.value)
       result = iterator.next()
     }
     return result.value
   })
-) as Fx<YieldFrom<Scope> | Interrupt, IfAny<R, void>>
+) as Fx<YieldFrom<Key> | Interrupt, IfAny<R, void>>
 
 /**
  * Create a scoped yield source from an AsyncIterable.
  */
-export const fromAsyncIterable = <const Scope extends AnyScope & Yielding<unknown, void>, R>(
-  scope: Scope,
-  f: () => AsyncIterableWithReturn<YieldOutput<Scope>, R>
-): Fx<Async | YieldFrom<Scope> | Interrupt, R> => bracket(
+export const fromAsyncIterable = <const Key extends AnyKey & Yielding<unknown, void>, R>(
+  key: Key,
+  f: () => AsyncIterableWithReturn<YieldOutput<Key>, R>
+): Fx<Async | YieldFrom<Key> | Interrupt, R> => bracket(
   assertSync(() => f()[Symbol.asyncIterator]()),
   iterator => assertPromise(() => iterator.return?.().then(() => { }) ?? Promise.resolve()),
   iterator => fx(function* () {
     const next = assertPromise(() => iterator.next())
     let result = yield* next
     while (!result.done) {
-      yield* yieldFrom(scope, result.value)
+      yield* yieldFrom(key, result.value)
       result = yield* next
     }
     return result.value
   })
 )
 
-export const toAsyncIterable = <const Scope extends AnyScope & Yielding<unknown, void>, E extends Async | YieldFrom<Scope> | Fail<any>, A>(
-  scope: Scope,
+export const toAsyncIterable = <const Key extends AnyKey & Yielding<unknown, void>, E extends Async | YieldFrom<Key> | Fail<any>, A>(
+  key: Key,
   f: Fx<E, A>
-): AsyncIterableWithReturn<YieldValue<E, Scope>, A> => ({
+): AsyncIterableWithReturn<YieldValue<E, Key>, A> => ({
     async *[Symbol.asyncIterator]() {
       const controller = new AbortController()
       const iterator = f[Symbol.iterator]()
@@ -173,11 +174,11 @@ export const toAsyncIterable = <const Scope extends AnyScope & Yielding<unknown,
             result = iterator.next(value)
           } else if (next._fxEffectId === 'fx/Fail') {
             throw next.arg
-          } else if (YieldFrom.is(next) && sameScope(next.scope, scope)) {
-            yield next.arg as YieldValue<E, Scope>
+          } else if (YieldFrom.is(next) && sameKey(next.key, key)) {
+            yield next.arg as YieldValue<E, Key>
             result = iterator.next()
           } else {
-            throw new Error(`Unexpected effect while converting YieldFrom scope ${scopeLabel(scope)} to AsyncIterable`)
+            throw new Error(`Unexpected effect while converting YieldFrom key ${keyLabel(key)} to AsyncIterable`)
           }
         }
         return result.value
@@ -192,18 +193,18 @@ export const toAsyncIterable = <const Scope extends AnyScope & Yielding<unknown,
  * Pipe all one-way yields from one scope into a sink from another scope.
  */
 export const to = <
-  const SourceScope extends AnyScope & Yielding<unknown, void>,
-  const SinkScope extends AnyScope & Receiving<YieldOutput<SourceScope>>,
+  const SourceKey extends AnyKey & Yielding<unknown, void>,
+  const SinkKey extends AnyKey & Receiving<YieldOutput<SourceKey>>,
   E1,
   E2,
   R1,
   R2
 >(
-  sourceScope: SourceScope,
-  sinkScope: SinkScope,
+  sourceKey: SourceKey,
+  sinkKey: SinkKey,
   source: Fx<E1, R1>,
   sink: Fx<E2, R2>
-): Fx<ExcludeYieldFrom<E1, SourceScope> | ExcludeSink<E2, SinkScope>, PipeResult<R1, R2>> => fx(function* () {
+): Fx<ExcludeYieldFrom<E1, SourceKey> | ExcludeSink<E2, SinkKey>, PipeResult<R1, R2>> => fx(function* () {
   const sourceIterator = source[Symbol.iterator]()
   const sinkIterator = sink[Symbol.iterator]()
   let sourceOpen = true
@@ -211,24 +212,24 @@ export const to = <
 
   const drainSource = function* (
     result: IteratorResult<E1, R1>
-  ): Generator<ExcludeYieldFrom<E1, SourceScope> | ExcludeSink<E2, SinkScope>, R1, unknown> {
+  ): Generator<ExcludeYieldFrom<E1, SourceKey> | ExcludeSink<E2, SinkKey>, R1, unknown> {
     while (!result.done) {
       const effect = result.value
-      result = YieldFrom.is(effect) && sameScope(effect.scope, sourceScope)
-        ? sourceIterator.next(undefined as YieldInput<SourceScope>)
-        : sourceIterator.next(yield effect as ExcludeYieldFrom<E1, SourceScope>)
+      result = YieldFrom.is(effect) && sameKey(effect.key, sourceKey)
+        ? sourceIterator.next(undefined as YieldInput<SourceKey>)
+        : sourceIterator.next(yield effect as ExcludeYieldFrom<E1, SourceKey>)
     }
     return result.value
   }
 
   const drainSink = function* (
     result: IteratorResult<E2, R2>
-  ): Generator<ExcludeYieldFrom<E1, SourceScope> | ExcludeSink<E2, SinkScope>, R2, unknown> {
+  ): Generator<ExcludeYieldFrom<E1, SourceKey> | ExcludeSink<E2, SinkKey>, R2, unknown> {
     while (!result.done) {
       const effect = result.value
-      result = Sink.is(effect) && sameScope(effect.scope, sinkScope)
-        ? sinkIterator.next(undefined as SinkInput<SinkScope>)
-        : sinkIterator.next(yield effect as ExcludeSink<E2, SinkScope>)
+      result = Sink.is(effect) && sameKey(effect.key, sinkKey)
+        ? sinkIterator.next(undefined as SinkInput<SinkKey>)
+        : sinkIterator.next(yield effect as ExcludeSink<E2, SinkKey>)
     }
     return result.value
   }
@@ -250,12 +251,12 @@ export const to = <
     let sinkResult = sinkIterator.next()
 
     while (true) {
-      while (!sinkResult.done && !sourceResult.done && !(YieldFrom.is(sourceResult.value) && sameScope(sourceResult.value.scope, sourceScope))) {
-        sourceResult = sourceIterator.next(yield sourceResult.value as ExcludeYieldFrom<E1, SourceScope>)
+      while (!sinkResult.done && !sourceResult.done && !(YieldFrom.is(sourceResult.value) && sameKey(sourceResult.value.key, sourceKey))) {
+        sourceResult = sourceIterator.next(yield sourceResult.value as ExcludeYieldFrom<E1, SourceKey>)
       }
 
-      while (!sourceResult.done && !sinkResult.done && !(Sink.is(sinkResult.value) && sameScope(sinkResult.value.scope, sinkScope))) {
-        sinkResult = sinkIterator.next(yield sinkResult.value as ExcludeSink<E2, SinkScope>)
+      while (!sourceResult.done && !sinkResult.done && !(Sink.is(sinkResult.value) && sameKey(sinkResult.value.key, sinkKey))) {
+        sinkResult = sinkIterator.next(yield sinkResult.value as ExcludeSink<E2, SinkKey>)
       }
 
       if (sinkResult.done) {
@@ -271,11 +272,11 @@ export const to = <
         return { type: 'sourceEnded', value: sourceResult.value }
       }
 
-      sinkResult = sinkIterator.next((sourceResult.value as YieldFrom<SourceScope>).arg)
+      sinkResult = sinkIterator.next((sourceResult.value as YieldFrom<SourceKey>).arg)
       if (!sinkResult.done) sourceResult = sourceIterator.next()
     }
   } finally {
     yield* closeSource()
     yield* closeSink()
   }
-}) as Fx<ExcludeYieldFrom<E1, SourceScope> | ExcludeSink<E2, SinkScope>, PipeResult<R1, R2>>
+}) as Fx<ExcludeYieldFrom<E1, SourceKey> | ExcludeSink<E2, SinkKey>, PipeResult<R1, R2>>

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -3,6 +3,7 @@ export {
   EffectOriginTypeId,
   EffectTypeId,
   isEffect,
+  KeyedEffect,
   originOf,
   ScopedEffect,
   traceOriginOf,
@@ -10,8 +11,19 @@ export {
   withTraceOrigin,
   type AnyEffect,
   type EffectOrigin,
-  type EffectType
+  type EffectType,
+  type KeyedEffectClass,
+  type KeyedEffectInstance
 } from '../Effect.js'
+export {
+  key,
+  keyId,
+  keyLabel,
+  sameKey,
+  type AnyKey,
+  type Key,
+  type KeyMetadata
+} from '../Key.js'
 export {
   andReturn,
   andThen,
@@ -34,9 +46,11 @@ export {
 export {
   control,
   handle,
+  handleKeyed,
   handleScoped,
   type Arg,
   type Handle,
+  type HandleKeyed,
   type HandleReturn,
   type HandleScoped
 } from '../Handler.js'

--- a/src/exports/scope.ts
+++ b/src/exports/scope.ts
@@ -1,7 +1,43 @@
-export * from '../Abort.js'
-export * from '../Finalization.js'
-export * from '../InterruptFrom.js'
-export * from '../ReturnFrom.js'
-export * from '../Scope.js'
-export * from '../Scoped.js'
-export * from '../YieldFrom.js'
+export { Abort, abort, orReturn, restartOnAbort, restartOnAbortIn, type RestartOnAbortOptions } from '../Abort.js'
+export {
+  Finally,
+  andFinally,
+  andFinallyIn,
+  managed,
+  using,
+  usingIn,
+  usingManaged,
+  usingManagedIn,
+  type Finalizer,
+  type Managed
+} from '../Finalization.js'
+export { InterruptFrom, interruptFrom, recoverInterrupt } from '../InterruptFrom.js'
+export { ReturnFrom, returnFrom } from '../ReturnFrom.js'
+export {
+  currentScope,
+  sameScope,
+  scopeId,
+  scopeLabel,
+  withControlScope,
+  withScope,
+  type Aborted,
+  type AnyControlScope,
+  type AnyLifetimeScope,
+  type AnyScope,
+  type Control,
+  type ControlScope,
+  type CurrentLifetimeScope,
+  type Exit,
+  type Failure,
+  type Interrupted,
+  type Lifetime,
+  type LifetimeScope,
+  type ReturnValue,
+  type ReturnedFrom,
+  type Scope,
+  type ScopeEffects,
+  type ScopeHandle,
+  type ScopeOptions,
+  type Success
+} from '../Scope.js'
+export { scoped } from '../Scoped.js'

--- a/src/exports/scope.ts
+++ b/src/exports/scope.ts
@@ -1,12 +1,9 @@
 export { Abort, abort, orReturn, restartOnAbort, restartOnAbortIn, type RestartOnAbortOptions } from '../Abort.js'
 export {
   Finally,
-  andFinally,
   andFinallyIn,
   managed,
-  using,
   usingIn,
-  usingManaged,
   usingManagedIn,
   type Finalizer,
   type Managed
@@ -14,8 +11,9 @@ export {
 export { InterruptFrom, interruptFrom, recoverInterrupt } from '../InterruptFrom.js'
 export { ReturnFrom, returnFrom } from '../ReturnFrom.js'
 export {
-  currentScope,
+  inScope,
   sameScope,
+  scope,
   scopeId,
   scopeLabel,
   withControlScope,
@@ -26,7 +24,6 @@ export {
   type AnyScope,
   type Control,
   type ControlScope,
-  type CurrentLifetimeScope,
   type Exit,
   type Failure,
   type Interrupted,

--- a/src/exports/state.ts
+++ b/src/exports/state.ts
@@ -11,3 +11,12 @@ export {
   type StateOf,
   type Stateful
 } from '../State.js'
+export {
+  key,
+  keyId,
+  keyLabel,
+  sameKey,
+  type AnyKey,
+  type Key,
+  type KeyMetadata
+} from '../Key.js'

--- a/src/exports/yield.ts
+++ b/src/exports/yield.ts
@@ -1,4 +1,4 @@
-export * from '../Sink.js'
+export * from '../YieldFrom.js'
 export {
   key,
   keyId,

--- a/src/internal/keyIdentity.ts
+++ b/src/internal/keyIdentity.ts
@@ -1,0 +1,13 @@
+export const KeyTypeId = Symbol('fx/Key')
+
+export interface KeyIdentity<Identity extends PropertyKey = PropertyKey> {
+  readonly [KeyTypeId]: Identity
+}
+
+export type AnyKeyIdentity = KeyIdentity<PropertyKey>
+
+export const keyId = <const Key extends AnyKeyIdentity>(key: Key): Key[typeof KeyTypeId] =>
+  key[KeyTypeId]
+
+export const sameKey = (a: AnyKeyIdentity, b: AnyKeyIdentity): boolean =>
+  keyId(a) === keyId(b)

--- a/src/internal/returnExit.test.ts
+++ b/src/internal/returnExit.test.ts
@@ -8,6 +8,7 @@ import { fail, Fail } from '../Fail.js'
 import { finalizing, fx, ok, run, runTask, type Fx } from '../Fx.js'
 import { handle } from '../Handler.js'
 import { interruptFrom } from '../InterruptFrom.js'
+import { key } from '../Key.js'
 import { ReturnFrom, returnFrom } from '../ReturnFrom.js'
 import { scope, type Control } from '../Scope.js'
 import { getState, modifyState, withState, type Stateful } from '../State.js'
@@ -16,7 +17,7 @@ import { returnExit, resumeExit } from './returnExit.js'
 
 describe('returnExit', () => {
   const ControlScope = scope<Control>()('test/returnExit/control')
-  const StateScope = scope<Stateful<number>>()('test/returnExit/state')
+  const StateScope = key<Stateful<number>>()('test/returnExit/state')
 
   it('returns and resumes successful exits', () => {
     const exit = ok('value').pipe(returnExit, run)

--- a/src/internal/scopeLifetime.ts
+++ b/src/internal/scopeLifetime.ts
@@ -1,0 +1,23 @@
+type ScopeLike = object & {
+  readonly label?: string
+}
+
+const closedScopes = new WeakSet<object>()
+const closeableScopes = new WeakSet<object>()
+
+export const markScopeCloseable = (scope: object): void => {
+  closeableScopes.add(scope)
+}
+
+export const assertScopeOpen = (scope: object, label?: string): void => {
+  if (closedScopes.has(scope)) {
+    throw new Error(`Scope handle ${label ?? scopeLabel(scope)} was used after its scope exited`)
+  }
+}
+
+export const closeScope = (scope: object): void => {
+  if (closeableScopes.has(scope)) closedScopes.add(scope)
+}
+
+const scopeLabel = (scope: object): string =>
+  (scope as ScopeLike).label ?? 'unknown'


### PR DESCRIPTION
## Summary
- add typed key identity plus KeyedEffect/handleKeyed and migrate State, YieldFrom, and Sink to keyed slots/channels
- add lexical withScope/withControlScope handle APIs with closed-handle runtime checks and lifetime/control type separation
- remove the public scope constructor from the curated scope subpath and update examples/docs to use key(...) and lexical handles

## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test (658 tests)